### PR TITLE
feat: only display annotated plot and tab panel for Supor

### DIFF
--- a/packages/studio-base/src/panels/suporPanels.ts
+++ b/packages/studio-base/src/panels/suporPanels.ts
@@ -1,0 +1,30 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+import { TFunction } from "i18next";
+
+import { PanelInfo } from "@foxglove/studio-base/context/PanelCatalogContext";
+import { TAB_PANEL_TYPE } from "@foxglove/studio-base/util/globalConstants";
+
+import plotThumbnail from "./Plot/thumbnail.png";
+import tabThumbnail from "./Tab/thumbnail.png";
+
+export const getBuiltin: (t: TFunction<"panels">) => PanelInfo[] = (t) => [
+  {
+    title: t("annotatedPlot", {
+      ns: "cosAnnotatedPlot",
+    }),
+    type: "AnnotatedPlot",
+    description: t("plotDescription"),
+    thumbnail: plotThumbnail,
+    module: async () => await import("./AnnotatedPlot"),
+  },
+  {
+    title: t("tab"),
+    type: TAB_PANEL_TYPE,
+    description: t("tabDescription"),
+    thumbnail: tabThumbnail,
+    module: async () => await import("./Tab"),
+    hasCustomToolbar: true,
+  },
+];

--- a/packages/studio-base/src/providers/PanelCatalogProvider.tsx
+++ b/packages/studio-base/src/providers/PanelCatalogProvider.tsx
@@ -13,8 +13,13 @@ import PanelCatalogContext, {
   PanelCatalog,
   PanelInfo,
 } from "@foxglove/studio-base/context/PanelCatalogContext";
-import * as panels from "@foxglove/studio-base/panels";
+import * as generalPanels from "@foxglove/studio-base/panels";
+import * as suporPanels from "@foxglove/studio-base/panels/suporPanels";
 import { SaveConfig } from "@foxglove/studio-base/types/panels";
+import { APP_CONFIG } from "@foxglove/studio-base/util/appConfig";
+
+const panels =
+  APP_CONFIG.LOGO_CONFIG[window.location.hostname]?.logo !== "supor" ? suporPanels : generalPanels;
 
 type PanelProps = {
   config: unknown;


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->

**Description**


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
