### PR TITLE
fix: layout unsaved change prompt

### DIFF
--- a/packages/studio-base/src/components/AppBar/CoSceneLayoutButton/index.tsx
+++ b/packages/studio-base/src/components/AppBar/CoSceneLayoutButton/index.tsx
@@ -618,6 +618,7 @@ export function CoSceneLayoutButton(): JSX.Element {
       {promptModal}
       {confirmModal}
       {unsavedChangesPrompt}
+      {layoutActions.unsavedChangesPrompt}
       <Menu
         id="add-panel-menu"
         anchorEl={anchorEl.current}

--- a/packages/studio-base/src/context/Workspace/useWorkspaceActions.ts
+++ b/packages/studio-base/src/context/Workspace/useWorkspaceActions.ts
@@ -89,6 +89,7 @@ export type WorkspaceActions = {
     // Export the current layout to a file
     // This will perform a browser download of the current layout to a file
     exportToFile: (layout: Layout) => void;
+    unsavedChangesPrompt: JSX.Element | undefined;
   };
 };
 
@@ -108,7 +109,7 @@ const selectedLayoutIdSelector = (state: LayoutState) => state.selectedLayout?.i
 export function useWorkspaceActions(): WorkspaceActions {
   const { setState } = useGuaranteedContext(WorkspaceContext);
   const layoutManager = useLayoutManager();
-  const { openUnsavedChangesPrompt } = useUnsavedChangesPrompt();
+  const { unsavedChangesPrompt, openUnsavedChangesPrompt } = useUnsavedChangesPrompt();
   const currentLayoutId = useCurrentLayoutSelector(selectedLayoutIdSelector);
   const { enqueueSnackbar } = useSnackbar();
   const { setSelectedLayoutId } = useCurrentLayoutActions();
@@ -457,7 +458,8 @@ export function useWorkspaceActions(): WorkspaceActions {
       layoutActions: {
         importFromFile: importLayout,
         exportToFile: onExportLayout,
+        unsavedChangesPrompt,
       },
     };
-  }, [onExportLayout, importLayout, openFile, set]);
+  }, [onExportLayout, importLayout, openFile, set, unsavedChangesPrompt]);
 }


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->

**Description**


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
