### PR TITLE
fix: normalize file extension case in URDF cache check

### DIFF
--- a/packages/studio-base/src/services/IdbUrdfStorage.ts
+++ b/packages/studio-base/src/services/IdbUrdfStorage.ts
@@ -14,7 +14,7 @@ export class IdbUrdfStorage implements IUrdfStorage {
   #cacheFileExtensions = ["dae", "stl", "urdf", "xacro", "xml"];
 
   public checkUriNeedsCache(uri: string): boolean {
-    const extension = uri.split(".").pop();
+    const extension = uri.split(".").pop()?.toLocaleLowerCase();
     return extension != undefined && this.#cacheFileExtensions.includes(extension);
   }
 


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->

**Description**
- Convert file extension to lowercase when checking if URI needs caching
- Ensures consistent cache behavior regardless of file extension case (e.g. .STL vs .stl)


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
