### PR TITLE
fix: stuido connext remote layout and default user icon

### DIFF
--- a/packages/studio-base/src/components/AppBar/index.tsx
+++ b/packages/studio-base/src/components/AppBar/index.tsx
@@ -11,6 +11,7 @@ import {
   QuestionCircle24Regular,
   ChevronDown12Regular,
 } from "@fluentui/react-icons";
+import PersonIcon from "@mui/icons-material/Person";
 import { Avatar, IconButton, Tooltip } from "@mui/material";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -129,7 +130,6 @@ const useStyles = makeStyles<{ debugDragRegion?: boolean }, "avatar">()((
     },
     avatar: {
       color: theme.palette.common.white,
-      backgroundColor: tc(theme.palette.appBar.main).lighten().toString(),
       height: theme.spacing(3.5),
       width: theme.spacing(3.5),
     },
@@ -337,7 +337,9 @@ export function AppBar(props: AppBarProps): JSX.Element {
                     src={userInfo?.avatarUrl ?? undefined}
                     className={classes.avatar}
                     variant="rounded"
-                  />
+                  >
+                    {userInfo?.avatarUrl == undefined && <PersonIcon color="secondary" />}
+                  </Avatar>
                 </IconButton>
               </Tooltip>
               {showCustomWindowControls && (

--- a/packages/studio-desktop/src/renderer/Root.tsx
+++ b/packages/studio-desktop/src/renderer/Root.tsx
@@ -30,6 +30,7 @@ import {
 import NativeAppMenuContext from "@foxglove/studio-base/context/NativeAppMenuContext";
 import NativeWindowContext from "@foxglove/studio-base/context/NativeWindowContext";
 import { useConfirm } from "@foxglove/studio-base/hooks/useConfirm";
+import { APP_CONFIG } from "@foxglove/studio-base/util/appConfig";
 
 import { DesktopExtensionLoader } from "./services/DesktopExtensionLoader";
 import { NativeAppMenu } from "./services/NativeAppMenu";
@@ -61,13 +62,14 @@ export default function Root(props: {
   // notify user login status change
   const [loginStatusKey, setLoginStatusKey] = useState(0);
 
-  // current not support connect to coscene
   const consoleApi = useMemo(
     () =>
       new ConsoleApi(
-        "baseUrl",
-        "bffUrl",
-        "addTopicPrefix",
+        APP_CONFIG.CS_HONEYBEE_BASE_URL,
+        APP_CONFIG.VITE_APP_BFF_URL,
+        localStorage.getItem("CoScene_addTopicPrefix") ??
+          APP_CONFIG.DEFAULT_TOPIC_PREFIX_OPEN[window.location.hostname] ??
+          "false",
         localStorage.getItem("CoScene_timeMode") === "relativeTime"
           ? "relativeTime"
           : "absoluteTime",


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->

**Description**


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
