### PR TITLE
feat: enhance player initialization with additional arguments

### DIFF
--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -282,7 +282,7 @@ export default function PlayerManager(
         return;
       }
 
-      metricsCollector.setProperty("player", sourceId);
+      metricsCollector.setProperty("player", sourceId, args);
       setSelectedSource(foundSource);
 
       // Sample sources don't need args or prompts to initialize

--- a/packages/studio-base/src/components/TopicList/TopicStatsChip.tsx
+++ b/packages/studio-base/src/components/TopicList/TopicStatsChip.tsx
@@ -6,6 +6,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { Divider, Paper } from "@mui/material";
+import { isNumber } from "mathjs";
 import { makeStyles } from "tss-react/mui";
 
 const useStyles = makeStyles<void, "selected">()((theme, _props, classes) => ({
@@ -75,7 +76,7 @@ export function TopicStatsChip({
   return (
     <Paper variant="outlined" className={cx(classes.root, { [classes.selected]: selected })}>
       <div className={classes.stat} data-topic={topicName} data-topic-stat="frequency">
-        {messageFrequency}
+        {isNumber(messageFrequency) ? messageFrequency : "-"}
       </div>
       <Divider className={classes.divider} orientation="vertical" flexItem />
       <div className={classes.stat} data-topic={topicName} data-topic-stat="count">

--- a/packages/studio-base/src/players/AnalyticsMetricsCollector.ts
+++ b/packages/studio-base/src/players/AnalyticsMetricsCollector.ts
@@ -7,6 +7,7 @@
 
 import Log from "@foxglove/log";
 import { Time } from "@foxglove/rostime";
+import { DataSourceArgs } from "@foxglove/studio-base/context/CoScenePlayerSelectionContext";
 import {
   PlayerMetricsCollectorInterface,
   SubscribePayload,
@@ -54,12 +55,12 @@ export default class AnalyticsMetricsCollector implements PlayerMetricsCollector
   }
 
   // sets sourceId in every time  opening a file or connecting to server
-  public setProperty(key: string, value: string | number | boolean): void {
+  public setProperty(key: string, value: string | number | boolean, args?: DataSourceArgs): void {
     this.#metadata[key] = value;
     console.debug(`coScene setProperty: ${key}=${value}`);
     if (key === "player") {
       this.#sourceId = value as string;
-      this.#analytics.initPlayer(this.#sourceId);
+      this.#analytics.initPlayer(this.#sourceId, args);
     }
   }
 

--- a/packages/studio-base/src/services/AmplitudeAnalytics.ts
+++ b/packages/studio-base/src/services/AmplitudeAnalytics.ts
@@ -10,6 +10,7 @@ import { posthog } from "posthog-js";
 import Logger from "@foxglove/log";
 import OsContextSingleton from "@foxglove/studio-base/OsContextSingleton";
 import { User } from "@foxglove/studio-base/context/CoSceneCurrentUserContext";
+import { DataSourceArgs } from "@foxglove/studio-base/context/CoScenePlayerSelectionContext";
 import CoSceneConsoleApi, { MetricType } from "@foxglove/studio-base/services/CoSceneConsoleApi";
 import IAnalytics, { AppEvent } from "@foxglove/studio-base/services/IAnalytics";
 import { APP_CONFIG } from "@foxglove/studio-base/util/appConfig";
@@ -41,11 +42,11 @@ export class AmplitudeAnalytics implements IAnalytics {
     });
   }
 
-  public async initPlayer(sourceId: string): Promise<void> {
+  public async initPlayer(sourceId: string, args?: DataSourceArgs): Promise<void> {
     posthog.register({
       source_id: sourceId,
     });
-    posthog.capture(AppEvent.PLAYER_INIT, { source_id: sourceId });
+    posthog.capture(AppEvent.PLAYER_INIT, { source_id: sourceId, args });
   }
 
   public setSpeed(speed: number): void {

--- a/packages/studio-base/src/services/IAnalytics.ts
+++ b/packages/studio-base/src/services/IAnalytics.ts
@@ -4,6 +4,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
+import { DataSourceArgs } from "@foxglove/studio-base/context/CoScenePlayerSelectionContext";
 
 enum AppEvent {
   APP_INIT = "app_initialized",
@@ -89,7 +90,7 @@ enum AppEvent {
 interface IAnalytics {
   logEvent(event: AppEvent, data?: { [key: string]: unknown }): void | Promise<void>;
   setSpeed(speed: number): void;
-  initPlayer(sourceId: string): void;
+  initPlayer(sourceId: string, args?: DataSourceArgs): void;
 }
 
 export { AppEvent };


### PR DESCRIPTION
- Updated PlayerManager to pass additional arguments to metricsCollector.setProperty.
- Modified AnalyticsMetricsCollector and AmplitudeAnalytics to accept and utilize DataSourceArgs during player initialization.
- Improved TopicStatsChip to handle non-numeric message frequency gracefully.

**User-Facing Changes**
<!-- will be used as a changelog entry -->

**Description**


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
