### PR TITLE
fix: Update transform validation to respect compatibility mode

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -1338,7 +1338,10 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
     for (const tf of tfMessage.transforms) {
       // tf2 message cannot have frame_id or child_frame_id starting with "/"
       // details: http://wiki.ros.org/tf2/Migration#tf_prefix_backwards_compatibility
-      if (tf.child_frame_id.startsWith("/") || tf.header.frame_id.startsWith("/")) {
+      if (
+        (tf.child_frame_id.startsWith("/") || tf.header.frame_id.startsWith("/")) &&
+        !this.compatibilityMode
+      ) {
         this.settings.errors.add(["transforms"], TF_NAME_ERROR, i18next.t("threeDee:tfNameError"));
       }
       this.#addTransformMessage(tf);


### PR DESCRIPTION
- Modified transform validation logic in Renderer to check compatibility mode before enforcing frame_id restrictions.
- Ensures that transforms with frame_id or child_frame_id starting with "/" are only flagged as errors when compatibility mode is disabled.

**User-Facing Changes**
<!-- will be used as a changelog entry -->

**Description**


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
