### PR TITLE
fix: snapshort req

### DIFF
--- a/packages/studio-base/src/hooks/useCoSceneInitialDeepLinkState.ts
+++ b/packages/studio-base/src/hooks/useCoSceneInitialDeepLinkState.ts
@@ -20,7 +20,6 @@ import { AppURLState, parseAppURLState } from "@foxglove/studio-base/util/appURL
 
 const selectPlayerPresence = (ctx: MessagePipelineContext) => ctx.playerState.presence;
 const selectSeek = (ctx: MessagePipelineContext) => ctx.seekPlayback;
-const selectStartTime = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.startTime;
 const selectLoginStatus = (store: UserStore) => store.loginStatus;
 
 const log = Log.getLogger(__filename);
@@ -58,10 +57,9 @@ function useSyncLayoutFromUrl(targetUrlState: AppURLState | undefined) {
 function useSyncTimeFromUrl(targetUrlState: AppURLState | undefined) {
   const seekPlayback = useMessagePipeline(selectSeek);
   const playerPresence = useMessagePipeline(selectPlayerPresence);
-  const startTime = useMessagePipeline(selectStartTime);
   const [isAppliedTime, setIsAppliedTime] = useState(false);
 
-  const time = targetUrlState?.time ?? startTime;
+  const time = targetUrlState?.time;
 
   // Wait until player is ready before we try to seek.
   // Seek to time in URL.

--- a/packages/studio-base/src/services/CoSceneConsoleApi.ts
+++ b/packages/studio-base/src/services/CoSceneConsoleApi.ts
@@ -695,12 +695,6 @@ class CoSceneConsoleApi {
     signal: AbortSignal;
     projectName: string;
   }): Promise<Response> {
-    // if (topics.length === 1) {
-    //   const topic = topics[0];
-    //   if (topic === "/tf") {
-    //     debugger;
-    //   }
-    // }
     const { fullUrl, fullConfig } = this.getRequectConfig("/v1/data/getStreams", {
       method: "POST",
       signal,

--- a/packages/studio-base/src/services/CoSceneConsoleApi.ts
+++ b/packages/studio-base/src/services/CoSceneConsoleApi.ts
@@ -695,6 +695,12 @@ class CoSceneConsoleApi {
     signal: AbortSignal;
     projectName: string;
   }): Promise<Response> {
+    // if (topics.length === 1) {
+    //   const topic = topics[0];
+    //   if (topic === "/tf") {
+    //     debugger;
+    //   }
+    // }
     const { fullUrl, fullConfig } = this.getRequectConfig("/v1/data/getStreams", {
       method: "POST",
       signal,


### PR DESCRIPTION
Ensure that a snapshot request is sent every time a data source is initialized. The snapshot request is controlled by the iterable player, which resolves the issue in the hike code that requires seeking to the start time when the time in the URL is empty.

**User-Facing Changes**
<!-- will be used as a changelog entry -->

**Description**


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
