### PR TITLE
fix: empty frame seekback

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -348,6 +348,7 @@ export class IterablePlayer implements Player {
     this.#untilTime = undefined;
     this.#lastTickMillis = undefined;
     this.#lastRangeMillis = undefined;
+    this.#lastStamp = undefined;
 
     this.#setState("seek-backfill");
   }
@@ -870,6 +871,13 @@ export class IterablePlayer implements Player {
     //
     // If we have a lastStamp but it isn't after the tick end, then we clear it and proceed with the
     // tick logic.
+
+    // ps:
+    // The optimization here is to avoid parsing new data when
+    // the data returned by the two getStreams requests overlap.
+    // Instead, it reads already parsed data from the cache.
+    // 这里的优化是为了两次的 getStreams 的请求返回的数据有重叠的情况下，
+    // 不需要去解析新的数据，而是从已经解析好的缓存中读取已经解析的数据
     if (this.#lastStamp) {
       if (compare(this.#lastStamp, end) >= 0) {
         // Wait for the previous render frame to finish


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->

**Description**
[COS-7382](https://coscene.atlassian.net/browse/COS-7382)
If the data type of the previous frame is stamp (indicating that the getStreams request return has been fully produced, or this frame's data is empty), seeking forward will cause the iterator to become disordered and playback errors will occur.

<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->


[COS-7382]: https://coscene.atlassian.net/browse/COS-7382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ