### PR TITLE
feat: support fetchCompleteTopicState

### DIFF
--- a/packages/studio-base/src/components/MessagePipeline/index.tsx
+++ b/packages/studio-base/src/components/MessagePipeline/index.tsx
@@ -134,10 +134,10 @@ export function MessagePipelineProvider({ children, player }: ProviderProps): Re
     };
   }, [debouncedPlayerSetSubscriptions]);
 
-  useEffect(
-    () => debouncedPlayerSetSubscriptions(subscriptions),
-    [debouncedPlayerSetSubscriptions, subscriptions],
-  );
+  useEffect(() => {
+    console.debug("woodiiTest useEffect subscriptions", subscriptions);
+    debouncedPlayerSetSubscriptions(subscriptions);
+  }, [debouncedPlayerSetSubscriptions, subscriptions]);
 
   // Slow down the message pipeline framerate to the given FPS if it is set to less than 60
   const [messageRate] = useAppConfigurationValue<number>(AppSetting.MESSAGE_RATE);

--- a/packages/studio-base/src/components/MessagePipeline/index.tsx
+++ b/packages/studio-base/src/components/MessagePipeline/index.tsx
@@ -135,7 +135,6 @@ export function MessagePipelineProvider({ children, player }: ProviderProps): Re
   }, [debouncedPlayerSetSubscriptions]);
 
   useEffect(() => {
-    console.debug("woodiiTest useEffect subscriptions", subscriptions);
     debouncedPlayerSetSubscriptions(subscriptions);
   }, [debouncedPlayerSetSubscriptions, subscriptions]);
 

--- a/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
@@ -126,6 +126,7 @@ class BufferedIterableSource<MessageType = unknown>
         topics: args.topics,
         start: this.#readHead,
         consumptionType: "partial",
+        fetchCompleteTopicState: args.fetchCompleteTopicState,
       });
 
       // Messages are read from the source until reaching the readUntil time. Then we wait for the read head

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
@@ -253,6 +253,7 @@ class CachingIterableSource<MessageType = unknown>
         start: sourceReadStart,
         end: sourceReadEnd,
         consumptionType: args.consumptionType,
+        fetchCompleteTopicState: args.fetchCompleteTopicState,
       });
 
       // The cache is indexed on time, but iterator results that are problems might not have a time.

--- a/packages/studio-base/src/players/IterablePlayer/IIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IIterableSource.ts
@@ -67,6 +67,17 @@ export type MessageIteratorArgs = {
    * `partial` indicates that the caller plans to read the iterator but may not read all the messages
    */
   consumptionType?: "full" | "partial";
+
+  /**
+   * Indicate whether to fetch the complete topic state.
+   *
+   * Some topic in some time range may not have any messages, so we need to fetch the complete topic state
+   * to know the last message in this topic.
+   *
+   * like map topic, this topic only in first frame, and this message is so big, network req will not
+   * return map message in every time, we need this param to notify the backend help us find last message in target time`s topic
+   */
+  fetchCompleteTopicState?: "complete" | "incremental";
 };
 
 /**

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -636,7 +636,9 @@ export class IterablePlayer implements Player {
     }
   }
 
-  async #resetPlaybackIterator() {
+  // in general, getStreams req will not return not in target time`s topic, (like map, map only in first frame)
+  // so we need need full param to notify the backend help us find last message in target time`s topic
+  async #resetPlaybackIterator(fetchCompleteTopicState?: "complete" | "incremental") {
     if (!this.#currentTime) {
       throw new Error("Invariant: Tried to reset playback iterator with no current time.");
     }
@@ -663,6 +665,7 @@ export class IterablePlayer implements Player {
       topics: this.#allTopics,
       start: next,
       consumptionType: "partial",
+      fetchCompleteTopicState,
     });
   }
 
@@ -671,7 +674,11 @@ export class IterablePlayer implements Player {
       throw new Error("Invariant: Tried to reset playback iterator with no current time.");
     }
 
-    await this.#resetPlaybackIterator();
+    if (!this.#start) {
+      throw new Error("Invariant: Tried to reset playback iterator with no start time.");
+    }
+
+    await this.#resetPlaybackIterator("complete");
     this.#setState(this.#isPlaying ? "play" : "idle");
   }
 

--- a/packages/studio-base/src/players/IterablePlayer/coScene-data-platform/streamMessages.ts
+++ b/packages/studio-base/src/players/IterablePlayer/coScene-data-platform/streamMessages.ts
@@ -39,6 +39,7 @@ export type StreamParams = {
   replayPolicy?: "lastPerChannel" | "";
   replayLookbackSeconds?: number;
   topics: string[];
+  fetchCompleteTopicState?: "complete" | "incremental";
 };
 
 /**
@@ -203,6 +204,7 @@ export async function* streamMessages({
       id: params.id,
       signal: controller.signal,
       projectName: params.projectName ?? "",
+      fetchCompleteTopicState: params.fetchCompleteTopicState,
     });
 
     fetchEndTime = performance.now();

--- a/packages/studio-base/src/services/CoSceneConsoleApi.ts
+++ b/packages/studio-base/src/services/CoSceneConsoleApi.ts
@@ -697,6 +697,7 @@ class CoSceneConsoleApi {
     id,
     signal,
     projectName,
+    fetchCompleteTopicState,
   }: {
     start: number;
     end: number;
@@ -704,6 +705,7 @@ class CoSceneConsoleApi {
     id: string;
     signal: AbortSignal;
     projectName: string;
+    fetchCompleteTopicState?: "complete" | "incremental";
   }): Promise<Response> {
     const { fullUrl, fullConfig } = this.getRequectConfig("/v1/data/getStreams", {
       method: "POST",
@@ -723,6 +725,7 @@ class CoSceneConsoleApi {
         end,
         topics,
         id,
+        fetchCompleteTopicState: fetchCompleteTopicState ?? "incremental",
       }),
     });
 


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->

**Description**
First, some topics do not have data in every frame, such as maps. Map data only exists in the first frame, and sending this unchanging data with every frame makes the data packet unnecessarily large. The current logic is to look backward for the previous data in the buffer when a topic is missing in a frame. However, in many cases, the previous data for some topics is not in the buffer, such as when seeking back and forth or opening the topic from the middle of the data. Previously, a snapshot request was sent to the backend with start time equal to end time to get the complete data, and the backend would help find and return the previous data. The issue now is that toggling topics does not send a snapshot request, leading to incomplete data, which can be fixed by inserting a snapshot request. However, during playback, a getStreams request is made to request upcoming data, so an additional snapshot request is redundant. We decided to add a parameter in the getStreams request to indicate whether a complete frame of data is needed from the backend.

-----------------------------------------------

首先有些 topic 并不是每帧数据都有的， 例如地图，地图数据仅仅在第一帧中存在， 而且这种不会变化的数据每一帧都发送，数据包会过于大，切不必要,所以现有的逻辑是在后续的播放中，topic 的逻辑是如果某一帧数据没有，就会向前查找，直到找到为止，复用前面的数据的缓存。但是很多情况下，某些 topic 的前一帧数据不会在缓存中，例如比如来回seek，或者从数据中间打开 topic，
之前的做法是向后端发送一个开始时间等于结束时间的 getStream 请求(snapshot 请求)，这个请求中会返回完整的数据，由后端帮我查找前一帧的数据并返回，现在呈现的现象是开关 topic 没有发送 snapshot 请求，导致数据不完整，通过插入一个 snapshot 请求来修复这个问题，但是播放中的情况下本来就要发送 getStreams 来请求后面一段的数据，这时候多插入 snapshot 请求是多余的，
我们决定直接在 getStreams 中添加一个参数来告诉后端是否需要一帧完整的数据



<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
