### PR TITLE
fix: update default retention window to 30 seconds in FoxgloveWebSocketDataSourceFactory and IndexedDbMessageStore

### DIFF
--- a/packages/studio-base/src/dataSources/FoxgloveWebSocketDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/FoxgloveWebSocketDataSourceFactory.ts
@@ -86,7 +86,7 @@ export default class FoxgloveWebSocketDataSourceFactory implements IDataSourceFa
       username: this.#username,
       deviceName: this.#deviceName,
       authHeader: args.consoleApi?.getAuthHeader() ?? "",
-      retentionWindowMs: args.retentionWindowMs,
+      retentionWindowMs: args.retentionWindowMs ?? 30 * 1000, // 30 seconds default
       sessionId,
     });
   }

--- a/packages/studio-base/src/persistence/IndexedDbMessageStore.ts
+++ b/packages/studio-base/src/persistence/IndexedDbMessageStore.ts
@@ -107,7 +107,7 @@ export class IndexedDbMessageStore implements PersistentMessageCache {
 
   public constructor(options: IndexedDbMessageStoreOptions = {}) {
     const {
-      retentionWindowMs = 5 * 60 * 1000, // 5 minutes default
+      retentionWindowMs = 30 * 1000, // 30 seconds default
       sessionId = `session-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
       maxCacheSize = 25 * 1024 * 1024 * 1024, // 25GB default
     } = options;


### PR DESCRIPTION
**User-Facing Changes**
<!-- will be used as a changelog entry -->

**Description**


<!-- link relevant GitHub issues -->
<!-- add `docs` label if this PR requires documentation updates -->
<!-- add relevant metric tracking for experimental / new features -->
