### PR TITLE
[codex] 修复 Windows 下播放器右方向键无法前进 seek

### DIFF
--- a/packages/studio-base/src/components/PlaybackControls/index.test.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.test.tsx
@@ -1,0 +1,129 @@
+/** @jest-environment jsdom */
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { render } from "@testing-library/react";
+
+import { fromSec } from "@foxglove/rostime";
+import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
+import AppConfigurationContext from "@foxglove/studio-base/context/AppConfigurationContext";
+import CoSceneConsoleApiContext from "@foxglove/studio-base/context/CoSceneConsoleApiContext";
+import CoreDataProvider from "@foxglove/studio-base/providers/CoreDataProvider";
+import WorkspaceContextProvider from "@foxglove/studio-base/providers/WorkspaceContextProvider";
+import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
+import { makeMockAppConfiguration } from "@foxglove/studio-base/util/makeMockAppConfiguration";
+
+import PlaybackControls from "./index";
+
+jest.mock("./PlaybackTimeDisplay", () => function MockPlaybackTimeDisplay() {
+  return <></>;
+});
+jest.mock("./Scrubber", () => function MockScrubber() {
+  return <></>;
+});
+jest.mock(
+  "@foxglove/studio-base/components/PlaybackSpeedControls",
+  () => function MockPlaybackSpeedControls() {
+    return <></>;
+  },
+);
+jest.mock("./SeekStepControls", () => ({
+  __esModule: true,
+  MIN_SEEK_STEP_MS: 1e-6 * 1000,
+  MAX_SEEK_STEP_MS: 3600 * 1000,
+  default: function MockSeekStepControls() {
+    return <></>;
+  },
+}));
+
+function Wrapper({ children }: React.PropsWithChildren): React.JSX.Element {
+  const mockConsoleApi = {
+    createEvent: {
+      permission: () => false,
+    },
+  };
+
+  return (
+    <CoSceneConsoleApiContext.Provider value={mockConsoleApi as never}>
+      <AppConfigurationContext.Provider value={makeMockAppConfiguration()}>
+        <CoreDataProvider>
+          <WorkspaceContextProvider>
+            <MockMessagePipelineProvider>
+              <ThemeProvider isDark>{children}</ThemeProvider>
+            </MockMessagePipelineProvider>
+          </WorkspaceContextProvider>
+        </CoreDataProvider>
+      </AppConfigurationContext.Provider>
+    </CoSceneConsoleApiContext.Provider>
+  );
+}
+
+describe("<PlaybackControls />", () => {
+  it("supports legacy Windows right key names for seek forward", () => {
+    const seek = jest.fn();
+
+    render(
+      <Wrapper>
+        <PlaybackControls
+          isPlaying={false}
+          repeatEnabled={false}
+          play={jest.fn()}
+          pause={jest.fn()}
+          seek={seek}
+          enableRepeatPlayback={jest.fn()}
+          getTimeInfo={() => ({
+            startTime: fromSec(0),
+            currentTime: fromSec(1),
+            endTime: fromSec(2),
+          })}
+        />
+      </Wrapper>,
+    );
+
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        bubbles: true,
+        code: "",
+        key: "Right",
+      }),
+    );
+
+    expect(seek).toHaveBeenCalledWith(fromSec(1.1));
+  });
+
+  it("supports legacy Windows left key names for seek backward", () => {
+    const seek = jest.fn();
+
+    render(
+      <Wrapper>
+        <PlaybackControls
+          isPlaying={false}
+          repeatEnabled={false}
+          play={jest.fn()}
+          pause={jest.fn()}
+          seek={seek}
+          enableRepeatPlayback={jest.fn()}
+          getTimeInfo={() => ({
+            startTime: fromSec(0),
+            currentTime: fromSec(1),
+            endTime: fromSec(2),
+          })}
+        />
+      </Wrapper>,
+    );
+
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        bubbles: true,
+        code: "",
+        key: "Left",
+      }),
+    );
+
+    expect(seek).toHaveBeenCalledWith(fromSec(0.9));
+  });
+});

--- a/packages/studio-base/src/components/PlaybackControls/index.test.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.test.tsx
@@ -19,17 +19,26 @@ import { makeMockAppConfiguration } from "@foxglove/studio-base/util/makeMockApp
 
 import PlaybackControls from "./index";
 
-jest.mock("./PlaybackTimeDisplay", () => function MockPlaybackTimeDisplay() {
-  return <></>;
-});
-jest.mock("./Scrubber", () => function MockScrubber() {
-  return <></>;
-});
+jest.mock(
+  "./PlaybackTimeDisplay",
+  () =>
+    function MockPlaybackTimeDisplay() {
+      return <></>;
+    },
+);
+jest.mock(
+  "./Scrubber",
+  () =>
+    function MockScrubber() {
+      return <></>;
+    },
+);
 jest.mock(
   "@foxglove/studio-base/components/PlaybackSpeedControls",
-  () => function MockPlaybackSpeedControls() {
-    return <></>;
-  },
+  () =>
+    function MockPlaybackSpeedControls() {
+      return <></>;
+    },
 );
 jest.mock("./SeekStepControls", () => ({
   __esModule: true,

--- a/packages/studio-base/src/components/PlaybackControls/index.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.tsx
@@ -248,17 +248,29 @@ export default function PlaybackControls(props: {
     [getTimeInfo, seek, effectiveSeekMs],
   );
 
+  const handleSeekBackwardKeyDown = useCallback(
+    (ev: KeyboardEvent) => {
+      seekBackwardAction(ev);
+    },
+    [seekBackwardAction],
+  );
+
+  const handleSeekForwardKeyDown = useCallback(
+    (ev: KeyboardEvent) => {
+      seekForwardAction(ev);
+    },
+    [seekForwardAction],
+  );
+
   const keyDownHandlers = useMemo(
     () => ({
       " ": togglePlayPause,
-      ArrowLeft: (ev: KeyboardEvent) => {
-        seekBackwardAction(ev);
-      },
-      ArrowRight: (ev: KeyboardEvent) => {
-        seekForwardAction(ev);
-      },
+      ArrowLeft: handleSeekBackwardKeyDown,
+      Left: handleSeekBackwardKeyDown,
+      ArrowRight: handleSeekForwardKeyDown,
+      Right: handleSeekForwardKeyDown,
     }),
-    [seekBackwardAction, seekForwardAction, togglePlayPause],
+    [handleSeekBackwardKeyDown, handleSeekForwardKeyDown, togglePlayPause],
   );
 
   const disableControls = presence === PlayerPresence.ERROR;


### PR DESCRIPTION
## 变更说明
修复 Windows 下播放器右方向键无法向前 seek 的问题，并补充对应回归测试。

## 问题原因
播放器快捷键当前只监听 `ArrowLeft` / `ArrowRight`。在部分 Windows/Electron 环境里，键盘事件会使用旧键名 `Left` / `Right`，导致右方向键事件无法命中前进 seek 逻辑，表现为只能后退、不能前进。

## 修复内容
- 为播放器方向键 seek 增加 `Left` / `Right` 兼容键名
- 保持现有 `ArrowLeft` / `ArrowRight` 行为不变
- 新增回归测试，覆盖 `Right` 前进和 `Left` 后退两个场景

## 影响范围
- Windows 桌面端播放器方向键 seek
- 其他平台原有行为保持不变

## 验证
- `yarn test --runInBand packages/studio-base/src/components/PlaybackControls/index.test.tsx`
- `yarn eslint packages/studio-base/src/components/PlaybackControls/index.tsx packages/studio-base/src/components/PlaybackControls/index.test.tsx`
