### PR TITLE
[codex] Cache pending 3D model loads

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableModels.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableModels.ts
@@ -51,10 +51,28 @@ export class RenderableModels extends RenderablePrimitive {
   #renderablesByDataCrc = new Map<number, RenderableModel[]>();
   /** Renderables loaded from URLs */
   #renderablesByUrl = new Map<string, RenderableModel[]>();
+  #pendingModelLoads = new Map<string, Promise<LoadedModel | undefined>>();
   #updateCount = 0;
 
   public constructor(renderer: IRenderer) {
     super("", renderer);
+  }
+
+  async #loadOrGetPending(
+    key: string,
+    loadFn: () => Promise<LoadedModel | undefined>,
+  ): Promise<LoadedModel | undefined> {
+    const existing = this.#pendingModelLoads.get(key);
+    if (existing) {
+      return await existing;
+    }
+
+    const pending = loadFn().finally(() => {
+      this.#pendingModelLoads.delete(key);
+    });
+
+    this.#pendingModelLoads.set(key, pending);
+    return await pending;
   }
 
   /**
@@ -69,12 +87,14 @@ export class RenderableModels extends RenderablePrimitive {
     revokeURL: (_: string) => void,
   ): Promise<RenderableModel | undefined> {
     const url = getURL(primitive);
+    const key = primitive.url.length === 0 ? crc32(primitive.data).toString() : primitive.url;
     let renderable: RenderableModel | undefined;
     try {
-      // Load the model if necessary
-      const cachedModel = await this.#loadCachedModel(url, {
-        overrideMediaType: primitive.media_type.length > 0 ? primitive.media_type : undefined,
-      });
+      const cachedModel = await this.#loadOrGetPending(key, async () =>
+        await this.#loadCachedModel(url, {
+          overrideMediaType: primitive.media_type.length > 0 ? primitive.media_type : undefined,
+        }),
+      );
       if (cachedModel) {
         renderable = { model: cloneAndPrepareModel(cachedModel), cachedModel, primitive };
       }


### PR DESCRIPTION
## What changed
- added a pending in-flight model-load cache to `RenderableModels`
- reused the same async load promise for identical model payloads/URLs while a previous frame is still loading

## Why
When the same model primitive appears across consecutive frames, the renderer can repeatedly start async model loads that get discarded before they can update the renderable list. Under load this creates a livelock where the same static model keeps reloading and may never render.

## Impact
- reduces redundant async model loads in 3D render
- improves stability under high frame rates or heavy scenes
- helps static/repeated models appear sooner instead of thrashing the loader

## Validation
- `yarn eslint packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableModels.ts`