### PR TITLE
[codex] Optimize triangle primitive updates

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/color.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/color.ts
@@ -20,6 +20,25 @@ export function SRGBToLinear(c: number): number {
   return c < 0.04045 ? c * 0.0773993808 : Math.pow(c * 0.9478672986 + 0.0521327014, 2.4);
 }
 
+const LUT_SIZE = 256;
+const MAX_INDEX = LUT_SIZE - 1;
+const SRGBToLinearLUTArray = new Float32Array(LUT_SIZE);
+for (let i = 0; i < LUT_SIZE; i++) {
+  const c = i / MAX_INDEX;
+  SRGBToLinearLUTArray[i] = SRGBToLinear(c);
+}
+
+export function SRGBToLinearRGBLUT(output: ColorRGB, r: number, g: number, b: number): ColorRGB {
+  const ri = Math.min(MAX_INDEX, Math.max(0, (r * MAX_INDEX) | 0));
+  const gi = Math.min(MAX_INDEX, Math.max(0, (g * MAX_INDEX) | 0));
+  const bi = Math.min(MAX_INDEX, Math.max(0, (b * MAX_INDEX) | 0));
+
+  output.r = SRGBToLinearLUTArray[ri]!;
+  output.g = SRGBToLinearLUTArray[gi]!;
+  output.b = SRGBToLinearLUTArray[bi]!;
+  return output;
+}
+
 export function stringToRgba(output: ColorRGBA, colorStr: string): ColorRGBA {
   const color = tinycolor(colorStr);
   if (!color.isValid()) {
@@ -36,6 +55,10 @@ export function stringToRgba(output: ColorRGBA, colorStr: string): ColorRGBA {
 
 export function makeRgba(): ColorRGBA {
   return { r: 0, g: 0, b: 0, a: 0 };
+}
+
+export function makeRgb(): ColorRGB {
+  return { r: 0, g: 0, b: 0 };
 }
 
 export function stringToRgb<T extends ColorRGB | THREE.Color>(output: T, colorStr: string): T {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTriangles.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTriangles.ts
@@ -13,9 +13,10 @@ import { DynamicBufferGeometry } from "@foxglove/studio-base/panels/ThreeDeeRend
 
 import { RenderablePrimitive } from "./RenderablePrimitive";
 import type { IRenderer } from "../../IRenderer";
-import { makeRgba, rgbToThreeColor, SRGBToLinear, stringToRgba } from "../../color";
+import { makeRgb, makeRgba, rgbToThreeColor, SRGBToLinearRGBLUT, stringToRgba } from "../../color";
 import { LayerSettingsEntity } from "../../settings";
 
+const tempRgb = makeRgb();
 const tempRgba = makeRgba();
 const tempColor = new THREE.Color();
 const missingColor = { r: 0, g: 1.0, b: 0, a: 1.0 };
@@ -75,6 +76,7 @@ export class RenderableTriangles extends RenderablePrimitive {
         geometry.createAttribute("color", Uint8Array, 4, true);
       }
       const colors = geometry.attributes.color;
+      const verticesStride = vertices.itemSize;
 
       for (let i = 0; i < primitive.points.length; i++) {
         const point = primitive.points[i]!;
@@ -85,12 +87,15 @@ export class RenderableTriangles extends RenderablePrimitive {
           );
           continue;
         }
-        vertChanged =
-          vertChanged ||
-          vertices.getX(i) !== point.x ||
-          vertices.getY(i) !== point.y ||
-          vertices.getZ(i) !== point.z;
-        vertices.setXYZ(i, point.x, point.y, point.z);
+        const offset = i * verticesStride;
+        const thisVertChanged =
+          Math.fround(vertices.array[offset]!) !== Math.fround(point.x) ||
+          Math.fround(vertices.array[offset + 1]!) !== Math.fround(point.y) ||
+          Math.fround(vertices.array[offset + 2]!) !== Math.fround(point.z);
+        if (thisVertChanged) {
+          vertices.setXYZ(i, point.x, point.y, point.z);
+        }
+        vertChanged = vertChanged || thisVertChanged;
 
         if (!singleColor && colors && primitive.colors.length > 0) {
           const color = primitive.colors[i] ?? missingColor;
@@ -102,18 +107,22 @@ export class RenderableTriangles extends RenderablePrimitive {
               `Entity: ${this.userData.entity?.id}.triangles[${triMeshIdx}](1st index) - Colors array should be same size as points array, showing #00ff00 instead`,
             );
           }
-          const r = SRGBToLinear(color.r);
-          const g = SRGBToLinear(color.g);
-          const b = SRGBToLinear(color.b);
-          const a = color.a;
-          colorChanged =
-            colorChanged ||
-            colors.getX(i) !== r ||
-            colors.getY(i) !== g ||
-            colors.getZ(i) !== b ||
-            colors.getW(i) !== a;
-          colors.setXYZW(i, r, g, b, a);
-          if (!transparent && a < 1.0) {
+          const rgbLinear = SRGBToLinearRGBLUT(tempRgb, color.r, color.g, color.b);
+          const colorStride = colors.itemSize;
+          const colorOffset = i * colorStride;
+
+          const EPS = 2 / 255;
+          const diff =
+            Math.abs(colors.array[colorOffset]! / 255 - rgbLinear.r) > EPS ||
+            Math.abs(colors.array[colorOffset + 1]! / 255 - rgbLinear.g) > EPS ||
+            Math.abs(colors.array[colorOffset + 2]! / 255 - rgbLinear.b) > EPS ||
+            Math.abs(colors.array[colorOffset + 3]! / 255 - color.a) > EPS;
+
+          if (diff) {
+            colors.setXYZW(i, rgbLinear.r, rgbLinear.g, rgbLinear.b, color.a);
+            colorChanged = true;
+          }
+          if (!transparent && color.a < 1.0) {
             transparent = true;
           }
         }


### PR DESCRIPTION
## What changed
- fixed the triangle primitive vertex update comparison so unchanged `Float32Array`-backed geometry does not get rewritten every frame
- switched repeated per-vertex sRGB-to-linear color conversion to a 256-entry lookup table
- avoided unnecessary color buffer writes when the effective values are unchanged

## Why
The previous comparison path was effectively defeated by `number` vs `Float32Array` precision differences, so the renderer kept rewriting geometry and recomputing normals for unchanged triangle data. Vertex color conversion also did expensive math in a tight loop for large triangle lists.

## Impact
- reduces per-frame geometry churn for triangle primitives
- lowers CPU work for large triangle lists with vertex colors
- improves 3D render performance in scenes with stable or slowly changing meshes

## Validation
- `yarn eslint packages/studio-base/src/panels/ThreeDeeRender/color.ts packages/studio-base/src/panels/ThreeDeeRender/renderables/primitives/RenderableTriangles.ts`