### PR TITLE
[codex] Cache MessagePath parsing and structure lookups

### DIFF
--- a/packages/message-path/src/parseMessagePath.ts
+++ b/packages/message-path/src/parseMessagePath.ts
@@ -20,11 +20,20 @@ import grammar from "./grammar.ne";
 import { MessagePath } from "./types";
 
 const grammarObj = Grammar.fromCompiled(grammar);
+const MAX_CACHE_ENTRIES = 1000;
+const cacheMessagePath = new Map<string, MessagePath | undefined>();
+
+function evictOldestCachedPath(): void {
+  const firstEntry = cacheMessagePath.keys().next();
+  if (firstEntry.done === false) {
+    cacheMessagePath.delete(firstEntry.value);
+  }
+}
 
 /** Wrap topic name in double quotes if it contains special characters */
 export function quoteTopicNameIfNeeded(name: string): string {
   // Pattern should match `slashID` in grammar.ne
-  if (name.match(/^[a-zA-Z0-9_/-]+$/)) {
+  if (/^[a-zA-Z0-9_/-]+$/.test(name)) {
     return name;
   }
   return `"${name.replace(/[\\"]/g, (char) => `\\${char}`)}"`;
@@ -33,18 +42,31 @@ export function quoteTopicNameIfNeeded(name: string): string {
 /** Wrap field name in double quotes if it contains special characters */
 export function quoteFieldNameIfNeeded(name: string): string {
   // Pattern should match `id` in grammar.ne
-  if (name.match(/^[a-zA-Z0-9_-]+$/)) {
+  if (/^[a-zA-Z0-9_-]+$/.test(name)) {
     return name;
   }
   return `"${name.replace(/[\\"]/g, (char) => `\\${char}`)}"`;
 }
 
 const parseMessagePath = (path: string): MessagePath | undefined => {
-  // Need to create a new Parser object for every new string to parse (should be cheap).
+  if (cacheMessagePath.has(path)) {
+    return cacheMessagePath.get(path);
+  }
+
   const parser = new Parser(grammarObj);
   try {
-    return parser.feed(path).results[0];
+    const results = parser.feed(path).results as MessagePath[];
+    const result = results[0];
+    if (cacheMessagePath.size >= MAX_CACHE_ENTRIES) {
+      evictOldestCachedPath();
+    }
+    cacheMessagePath.set(path, result);
+    return result;
   } catch {
+    if (cacheMessagePath.size >= MAX_CACHE_ENTRIES) {
+      evictOldestCachedPath();
+    }
+    cacheMessagePath.set(path, undefined);
     return undefined;
   }
 };

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -33,6 +33,7 @@ import ExtensionsSettings, {
   ExtensionsSettingsMore,
 } from "@foxglove/studio-base/components/ExtensionsSettings";
 import KeyListener from "@foxglove/studio-base/components/KeyListener";
+import { useStructureItemsStoreManager } from "@foxglove/studio-base/components/MessagePathSyntax/useStructureItemsStoreManager";
 import {
   MessagePipelineContext,
   useMessagePipeline,
@@ -185,6 +186,7 @@ function WorkspaceContent(props: WorkspaceProps): React.JSX.Element {
   const playerId = useMessagePipeline(selectPlayerId);
 
   useDefaultWebLaunchPreference();
+  useStructureItemsStoreManager();
 
   const [enableDebugMode = false] = useAppConfigurationValue<boolean>(AppSetting.SHOW_DEBUG_PANELS);
 

--- a/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx
@@ -19,7 +19,6 @@ import * as _ from "lodash-es";
 import { CSSProperties, useCallback, useMemo } from "react";
 import { makeStyles } from "tss-react/mui";
 
-import { filterMap } from "@foxglove/den/collection";
 import {
   quoteTopicNameIfNeeded,
   parseMessagePath,
@@ -34,11 +33,12 @@ import useGlobalVariables, {
 
 import {
   traverseStructure,
-  messagePathStructures,
   messagePathsForStructure,
+  messagePathStructures,
   validTerminatingStructureItem,
   StructureTraversalResult,
 } from "./messagePathsForDatatype";
+import { useStructuredItemsByPath } from "./useStructureItemsByPath";
 
 export function tryToSetDefaultGlobalVar(
   variableName: string,
@@ -162,37 +162,14 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
   const trimmedPath = path.trim();
   const leadingWhitespaceLength = path.length - path.trimStart().length;
 
-  const messagePathStructuresForDataype = useMemo(
+  const messagePathStructuresForDatatype = useMemo(
     () => messagePathStructures(datatypes),
     [datatypes],
   );
-  /** A map from each possible message path to the corresponding MessagePathStructureItem */
-  const allStructureItemsByPath = useMemo(
-    () =>
-      new Map(
-        topics.flatMap((topic) => {
-          if (topic.schemaName == undefined) {
-            return [];
-          }
-          const structureItem = messagePathStructuresForDataype[topic.schemaName];
-          if (structureItem == undefined) {
-            return [];
-          }
-          const allPaths = messagePathsForStructure(structureItem, {
-            validTypes,
-            noMultiSlices,
-          });
-          return filterMap(allPaths, (item) => {
-            if (item.path === "") {
-              // Plain topic items will be added via `topicNamesAutocompleteItems`
-              return undefined;
-            }
-            return [quoteTopicNameIfNeeded(topic.name) + item.path, item.terminatingStructureItem];
-          });
-        }),
-      ),
-    [messagePathStructuresForDataype, noMultiSlices, topics, validTypes],
-  );
+  const structureItemsByPath = useStructuredItemsByPath({
+    noMultiSlices,
+    validTypes,
+  });
 
   const onChangeProp = props.onChange;
   const onChange = useCallback(
@@ -225,7 +202,7 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
 
       // Check if accepting this completion would result in a path to a non-complex field.
       const completedPath = completeStart + rawValue + completeEnd;
-      const completedField = allStructureItemsByPath.get(completedPath);
+      const completedField = structureItemsByPath.get(completedPath);
       const isSimpleField =
         completedField != undefined && completedField.structureType === "primitive";
 
@@ -251,7 +228,7 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
         autocomplete.blur();
       }
     },
-    [onChangeProp, path, props.index, allStructureItemsByPath, validTypes],
+    [onChangeProp, path, props.index, structureItemsByPath, validTypes],
   );
 
   const rosPath = useMemo(() => parseMessagePath(trimmedPath), [trimmedPath]);
@@ -282,10 +259,10 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
     }
 
     return traverseStructure(
-      messagePathStructuresForDataype[topic.schemaName],
+      messagePathStructuresForDatatype[topic.schemaName],
       rosPath.messagePath,
     );
-  }, [messagePathStructuresForDataype, rosPath?.messagePath, topic]);
+  }, [messagePathStructuresForDatatype, rosPath?.messagePath, topic]);
 
   const invalidGlobalVariablesVariable = useMemo(() => {
     if (!rosPath) {
@@ -300,8 +277,8 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
   );
 
   const topicNamesAndFieldsAutocompleteItems = useMemo(
-    () => topicNamesAutocompleteItems.concat(Array.from(allStructureItemsByPath.keys())),
-    [allStructureItemsByPath, topicNamesAutocompleteItems],
+    () => topicNamesAutocompleteItems.concat(Array.from(structureItemsByPath.keys())),
+    [structureItemsByPath, topicNamesAutocompleteItems],
   );
 
   const autocompleteType = useMemo(() => {
@@ -323,8 +300,6 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
 
     return undefined;
   }, [invalidGlobalVariablesVariable, structureTraversalResult, validTypes, rosPath, topic]);
-
-  const structures = useMemo(() => messagePathStructures(datatypes), [datatypes]);
 
   const { autocompleteItems, autocompleteFilterText, autocompleteRange } = useMemo(() => {
     const withLeadingOffset = (range: { start: number; end: number }) => ({
@@ -384,20 +359,18 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
         const initialFilterLength =
           rosPath.messagePath[0]?.type === "filter" ? rosPath.messagePath[0].repr.length + 2 : 0;
 
-        const structure = topic.schemaName != undefined ? structures[topic.schemaName] : undefined;
+        const structure =
+          topic.schemaName != undefined ? messagePathStructuresForDatatype[topic.schemaName] : undefined;
 
         return {
           autocompleteItems:
             structure == undefined
               ? []
-              : filterMap(
-                  messagePathsForStructure(structure, {
-                    validTypes,
-                    noMultiSlices,
-                    messagePath: rosPath.messagePath,
-                  }),
-                  (item) => item.path,
-                ),
+              : messagePathsForStructure(structure, {
+                  validTypes,
+                  noMultiSlices,
+                  messagePath: rosPath.messagePath,
+                }).map((item) => item.path),
 
           autocompleteRange: withLeadingOffset({
             start: rosPath.topicNameRepr.length + initialFilterLength,
@@ -442,7 +415,7 @@ export default React.memo<MessagePathInputBaseProps>(function MessagePathInput(
     topicNamesAndFieldsAutocompleteItems,
     topicNamesAutocompleteItems,
     structureTraversalResult,
-    structures,
+    messagePathStructuresForDatatype,
     validTypes,
     noMultiSlices,
     globalVariables,

--- a/packages/studio-base/src/components/MessagePathSyntax/structureAllItemsByPath.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/structureAllItemsByPath.ts
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { filterMap } from "@foxglove/den/collection";
+import {
+  MessagePathStructureItem,
+  MessagePathStructureItemMessage,
+  quoteTopicNameIfNeeded,
+} from "@foxglove/message-path";
+import { Topic } from "@foxglove/studio-base/players/types";
+
+import { messagePathsForStructure } from "./messagePathsForDatatype";
+
+type StructureAllItemsByPathProps = {
+  noMultiSlices?: boolean;
+  validTypes?: readonly string[];
+  messagePathStructuresForDatatype: Record<string, MessagePathStructureItemMessage>;
+  topics: readonly Topic[];
+};
+
+export function structureAllItemsByPath({
+  noMultiSlices,
+  validTypes,
+  messagePathStructuresForDatatype,
+  topics,
+}: StructureAllItemsByPathProps): Map<string, MessagePathStructureItem> {
+  return new Map(
+    topics.flatMap((topic) => {
+      if (topic.schemaName == undefined) {
+        return [];
+      }
+
+      const structureItem = messagePathStructuresForDatatype[topic.schemaName];
+      if (structureItem == undefined) {
+        return [];
+      }
+
+      const allPaths = messagePathsForStructure(structureItem, {
+        validTypes,
+        noMultiSlices,
+      });
+      return filterMap(allPaths, (item) => {
+        if (item.path === "") {
+          return undefined;
+        }
+        return [quoteTopicNameIfNeeded(topic.name) + item.path, item.terminatingStructureItem];
+      });
+    }),
+  );
+}

--- a/packages/studio-base/src/components/MessagePathSyntax/useStructureItemsByPath.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/useStructureItemsByPath.ts
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { useMemo } from "react";
+
+import { MessagePathStructureItem } from "@foxglove/message-path";
+import * as PanelAPI from "@foxglove/studio-base/PanelAPI";
+
+import { messagePathStructures } from "./messagePathsForDatatype";
+import { structureAllItemsByPath } from "./structureAllItemsByPath";
+import { useStructureItemsByPathStore } from "./useStructureItemsByPathStore";
+
+type UseStructuredItemsByPathProps = {
+  noMultiSlices?: boolean;
+  validTypes?: readonly string[];
+};
+
+export function useStructuredItemsByPath({
+  noMultiSlices,
+  validTypes,
+}: UseStructuredItemsByPathProps): Map<string, MessagePathStructureItem> {
+  const structureItemsByPath = useStructureItemsByPathStore((state) => state.structureItemsByPath);
+  const { datatypes, topics } = PanelAPI.useDataSourceInfo();
+
+  const messagePathStructuresForDatatype = useMemo(
+    () => messagePathStructures(datatypes),
+    [datatypes],
+  );
+
+  const computedStructureItemsByPath = useMemo(
+    () =>
+      structureAllItemsByPath({
+        noMultiSlices,
+        validTypes,
+        messagePathStructuresForDatatype,
+        topics,
+      }),
+    [messagePathStructuresForDatatype, noMultiSlices, topics, validTypes],
+  );
+
+  if (validTypes == undefined && noMultiSlices == undefined) {
+    return structureItemsByPath.size > 0 ? structureItemsByPath : computedStructureItemsByPath;
+  }
+  return computedStructureItemsByPath;
+}

--- a/packages/studio-base/src/components/MessagePathSyntax/useStructureItemsByPathStore.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/useStructureItemsByPathStore.ts
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { create } from "zustand";
+
+import { MessagePathStructureItem } from "@foxglove/message-path";
+
+type StructuredItemsState = {
+  structureItemsByPath: Map<string, MessagePathStructureItem>;
+  setStructureItemsByPath: (items: Map<string, MessagePathStructureItem>) => void;
+};
+
+export const useStructureItemsByPathStore = create<StructuredItemsState>((set) => ({
+  structureItemsByPath: new Map(),
+  setStructureItemsByPath: (items) => {
+    set({ structureItemsByPath: items });
+  },
+}));

--- a/packages/studio-base/src/components/MessagePathSyntax/useStructureItemsStoreManager.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/useStructureItemsStoreManager.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+//
+// This file incorporates work covered by the following copyright and
+// permission notice:
+//
+//   Copyright 2018-2021 Cruise LLC
+//
+//   This source code is licensed under the Apache License, Version 2.0,
+//   found at http://www.apache.org/licenses/LICENSE-2.0
+//   You may not use this file except in compliance with the License.
+
+import { useEffect, useMemo } from "react";
+
+import * as PanelAPI from "@foxglove/studio-base/PanelAPI";
+
+import { messagePathStructures } from "./messagePathsForDatatype";
+import { structureAllItemsByPath } from "./structureAllItemsByPath";
+import { useStructureItemsByPathStore } from "./useStructureItemsByPathStore";
+
+export function useStructureItemsStoreManager(): void {
+  const setStructureItemsByPath = useStructureItemsByPathStore(
+    (state) => state.setStructureItemsByPath,
+  );
+  const { datatypes, topics } = PanelAPI.useDataSourceInfo();
+
+  const messagePathStructuresForDatatype = useMemo(
+    () => messagePathStructures(datatypes),
+    [datatypes],
+  );
+
+  useEffect(() => {
+    setStructureItemsByPath(
+      structureAllItemsByPath({
+        messagePathStructuresForDatatype,
+        topics,
+      }),
+    );
+  }, [messagePathStructuresForDatatype, setStructureItemsByPath, topics]);
+}


### PR DESCRIPTION
## Summary
- cache parsed message paths with a bounded map to avoid reparsing repeated inputs
- precompute default MessagePath structure lookups once at the workspace level
- reuse the cached structure map inside MessagePathInput autocomplete and selection flows

## Validation
- yarn eslint packages/studio-base/src/Workspace.tsx packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.tsx packages/studio-base/src/components/MessagePathSyntax/structureAllItemsByPath.ts packages/studio-base/src/components/MessagePathSyntax/useStructureItemsByPath.ts packages/studio-base/src/components/MessagePathSyntax/useStructureItemsByPathStore.ts packages/studio-base/src/components/MessagePathSyntax/useStructureItemsStoreManager.ts packages/message-path/src/parseMessagePath.ts packages/message-path/src/parseMessagePath.test.ts
- yarn test packages/studio-base/src/components/MessagePathSyntax/MessagePathInput.test.ts --runInBand

## Notes
- package-wide `yarn tsc -b packages/message-path/tsconfig.json packages/studio-base/tsconfig.json --pretty false` still reports unrelated pre-existing errors in `studio-base`, so it is not used as a gate for this PR.