### PR TITLE
[codex] Memoize PanelSettings tree rendering

### DIFF
--- a/packages/studio-base/src/components/PanelSettings/index.tsx
+++ b/packages/studio-base/src/components/PanelSettings/index.tsx
@@ -123,9 +123,12 @@ export default function PanelSettings({
 
   const [config] = useConfigById(selectedPanelId);
 
-  const settingsTree = usePanelStateStore((state) =>
-    selectedPanelId ? state.settingsTrees[selectedPanelId] : undefined,
+  const settingsTreeSelector = useCallback(
+    (state: PanelStateStore) =>
+      selectedPanelId ? state.settingsTrees[selectedPanelId] : undefined,
+    [selectedPanelId],
   );
+  const settingsTree = usePanelStateStore(settingsTreeSelector);
 
   const resetToDefaults = useCallback(() => {
     if (selectedPanelId) {

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -334,9 +334,7 @@ function NodeEditorComponent(props: NodeEditorProps): React.JSX.Element {
             actionHandler={actionHandler}
             defaultOpen={child.defaultExpansionState !== "collapsed"}
             open={
-              child.expansionState == undefined
-                ? undefined
-                : child.expansionState !== "collapsed"
+              child.expansionState == undefined ? undefined : child.expansionState !== "collapsed"
             }
             filter={filter}
             focusedPath={focusedPath}

--- a/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
@@ -251,24 +251,33 @@ function NodeEditorComponent(props: NodeEditorProps): React.JSX.Element {
     [actionHandler, open, props.path, setState],
   );
 
-  const selectVisibilityFilter = (action: SettingsTreeAction) => {
-    if (action.action === "update" && action.payload.input === "select") {
-      setState((draft) => {
-        draft.visibilityFilter = action.payload.value as SelectVisibilityFilterValue;
-      });
-    }
-  };
+  const selectVisibilityFilter = useCallback(
+    (action: SettingsTreeAction) => {
+      if (action.action === "update" && action.payload.input === "select") {
+        setState((draft) => {
+          draft.visibilityFilter = action.payload.value as SelectVisibilityFilterValue;
+        });
+      }
+    },
+    [setState],
+  );
 
-  const toggleVisibility = () => {
+  const toggleVisibility = useCallback(() => {
     actionHandler({
       action: "update",
       payload: { input: "boolean", path: [...props.path, "visible"], value: !visible },
     });
-  };
+  }, [actionHandler, props.path, visible]);
 
-  const handleNodeAction = (actionId: string) => {
-    actionHandler({ action: "perform-node-action", payload: { id: actionId, path: props.path } });
-  };
+  const handleNodeAction = useCallback(
+    (actionId: string) => {
+      actionHandler({
+        action: "perform-node-action",
+        payload: { id: actionId, path: props.path },
+      });
+    },
+    [actionHandler, props.path],
+  );
 
   const isFocused = _.isEqual(focusedPath, props.path);
 
@@ -291,43 +300,54 @@ function NodeEditorComponent(props: NodeEditorProps): React.JSX.Element {
 
   const rootRef = useRef<HTMLDivElement>(ReactNull);
 
-  const fieldEditors = filterMap(Object.entries(fields ?? {}), ([key, field]) => {
-    return field ? (
-      <FieldEditor
-        key={key}
-        field={field}
-        path={makeStablePath(props.path, key)}
-        actionHandler={actionHandler}
-      />
-    ) : undefined;
-  });
+  const fieldEditors = useMemo(
+    () =>
+      filterMap(Object.entries(fields ?? {}), ([key, field]) => {
+        return field ? (
+          <FieldEditor
+            key={key}
+            field={field}
+            path={makeStablePath(props.path, key)}
+            actionHandler={actionHandler}
+          />
+        ) : undefined;
+      }),
+    [actionHandler, fields, props.path],
+  );
 
-  const filterFn =
-    state.visibilityFilter === "visible"
-      ? showVisibleFilter
-      : state.visibilityFilter === "invisible"
-      ? showInvisibleFilter
-      : undefined;
-  const childNodes = filterMap(prepareSettingsNodes(children ?? {}), ([key, child]) => {
-    return !filterFn || filterFn(child) ? (
-      <NodeEditor
-        actionHandler={actionHandler}
-        defaultOpen={child.defaultExpansionState === "collapsed" ? false : true}
-        open={
-          child.expansionState == undefined
-            ? undefined
-            : child.expansionState === "collapsed"
-            ? false
-            : true
-        }
-        filter={filter}
-        focusedPath={focusedPath}
-        key={key}
-        settings={child}
-        path={makeStablePath(props.path, key)}
-      />
-    ) : undefined;
-  });
+  const filterFn = useMemo(() => {
+    if (state.visibilityFilter === "visible") {
+      return showVisibleFilter;
+    }
+    if (state.visibilityFilter === "invisible") {
+      return showInvisibleFilter;
+    }
+    return undefined;
+  }, [state.visibilityFilter]);
+
+  const preparedChildNodes = useMemo(() => prepareSettingsNodes(children ?? {}), [children]);
+  const childNodes = useMemo(
+    () =>
+      filterMap(preparedChildNodes, ([key, child]) => {
+        return !filterFn || filterFn(child) ? (
+          <NodeEditor
+            actionHandler={actionHandler}
+            defaultOpen={child.defaultExpansionState !== "collapsed"}
+            open={
+              child.expansionState == undefined
+                ? undefined
+                : child.expansionState !== "collapsed"
+            }
+            filter={filter}
+            focusedPath={focusedPath}
+            key={key}
+            settings={child}
+            path={makeStablePath(props.path, key)}
+          />
+        ) : undefined;
+      }),
+    [actionHandler, filter, filterFn, focusedPath, preparedChildNodes, props.path],
+  );
 
   const IconComponent = settings.icon ? icons[settings.icon] : undefined;
 

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
@@ -9,7 +9,7 @@ import CancelIcon from "@mui/icons-material/Cancel";
 import SearchIcon from "@mui/icons-material/Search";
 import { IconButton, TextField } from "@mui/material";
 import memoizeWeak from "memoize-weak";
-import { useCallback, useMemo, useState } from "react";
+import { ChangeEvent, useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { makeStyles } from "tss-react/mui";
 
@@ -19,7 +19,10 @@ import { FieldEditor } from "@foxglove/studio-base/components/SettingsTreeEditor
 import Stack from "@foxglove/studio-base/components/Stack";
 import { useSelectedPanels } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { usePanelCatalog } from "@foxglove/studio-base/context/PanelCatalogContext";
-import { usePanelStateStore } from "@foxglove/studio-base/context/PanelStateContext";
+import {
+  PanelStateStore,
+  usePanelStateStore,
+} from "@foxglove/studio-base/context/PanelStateContext";
 import { PANEL_TITLE_CONFIG_KEY, getPanelTypeFromId } from "@foxglove/studio-base/util/layout";
 
 import { NodeEditor } from "./NodeEditor";
@@ -71,7 +74,25 @@ export default function SettingsTreeEditor({
     }
   }, [settings.nodes, filterText]);
 
-  const definedNodes = useMemo(() => prepareSettingsNodes(filteredNodes), [filteredNodes]);
+  const memoizedNodes = useMemo(
+    () =>
+      prepareSettingsNodes(filteredNodes).map(([key, root]) => ({
+        key,
+        props: {
+          actionHandler,
+          defaultOpen: root.defaultExpansionState !== "collapsed",
+          open:
+            root.expansionState == undefined
+              ? undefined
+              : root.expansionState !== "collapsed",
+          filter: filterText,
+          focusedPath,
+          path: makeStablePath(key),
+          settings: root,
+        },
+      })),
+    [actionHandler, filterText, filteredNodes, focusedPath],
+  );
 
   const { selectedPanelIds } = useSelectedPanels();
   const selectedPanelId = useMemo(
@@ -88,9 +109,12 @@ export default function SettingsTreeEditor({
     [panelCatalog, panelType],
   );
   const [config, saveConfig] = useConfigById(selectedPanelId);
-  const defaultPanelTitle = usePanelStateStore((state) =>
-    selectedPanelId ? state.defaultTitles[selectedPanelId] : undefined,
+  const defaultTitleSelector = useCallback(
+    (state: PanelStateStore) =>
+      selectedPanelId ? state.defaultTitles[selectedPanelId] : undefined,
+    [selectedPanelId],
   );
+  const defaultPanelTitle = usePanelStateStore(defaultTitleSelector);
   const customPanelTitle =
     typeof config?.[PANEL_TITLE_CONFIG_KEY] === "string"
       ? config[PANEL_TITLE_CONFIG_KEY]
@@ -116,6 +140,10 @@ export default function SettingsTreeEditor({
   const showTitleField =
     filterText.length === 0 && panelInfo?.hasCustomToolbar !== true && variant !== "log";
 
+  const handleFilterChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setFilterText(event.target.value);
+  }, []);
+
   return (
     <Stack fullHeight>
       {settings.enableFilter === true && (
@@ -123,9 +151,7 @@ export default function SettingsTreeEditor({
           <TextField
             id={`${variant}-settings-filter`}
             variant="filled"
-            onChange={(event) => {
-              setFilterText(event.target.value);
-            }}
+            onChange={handleFilterChange}
             value={filterText}
             className={classes.textField}
             fullWidth
@@ -170,23 +196,8 @@ export default function SettingsTreeEditor({
             />
           </>
         )}
-        {definedNodes.map(([key, root]) => (
-          <NodeEditor
-            key={key}
-            actionHandler={actionHandler}
-            defaultOpen={root.defaultExpansionState === "collapsed" ? false : true}
-            open={
-              root.expansionState == undefined
-                ? undefined
-                : root.expansionState === "collapsed"
-                ? false
-                : true
-            }
-            filter={filterText}
-            focusedPath={focusedPath}
-            path={makeStablePath(key)}
-            settings={root}
-          />
+        {memoizedNodes.map(({ key, props }) => (
+          <NodeEditor key={key} {...props} />
         ))}
       </div>
     </Stack>

--- a/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
+++ b/packages/studio-base/src/components/SettingsTreeEditor/index.tsx
@@ -81,10 +81,7 @@ export default function SettingsTreeEditor({
         props: {
           actionHandler,
           defaultOpen: root.defaultExpansionState !== "collapsed",
-          open:
-            root.expansionState == undefined
-              ? undefined
-              : root.expansionState !== "collapsed",
+          open: root.expansionState == undefined ? undefined : root.expansionState !== "collapsed",
           filter: filterText,
           focusedPath,
           path: makeStablePath(key),


### PR DESCRIPTION
## Summary
- stabilize the PanelSettings selector used to read the active settings tree
- memoize SettingsTreeEditor node props and filter handlers to reduce repeated work during rerenders
- memoize recursive NodeEditor field and child-node construction so divider drags and sidebar updates rebuild less JSX

## Validation
- yarn eslint packages/studio-base/src/components/PanelSettings/index.tsx packages/studio-base/src/components/SettingsTreeEditor/index.tsx packages/studio-base/src/components/SettingsTreeEditor/NodeEditor.tsx
- yarn tsc -b packages/studio-base/tsconfig.json --pretty false 2>&1 | rg "packages/studio-base/src/components/(PanelSettings/index|SettingsTreeEditor/index|SettingsTreeEditor/NodeEditor)\.tsx"

## Notes
- `SettingsTreeEditor` and `PanelSettings` do not currently have direct unit tests in this repo, so validation is limited to linting plus a filtered type-check pass for the touched files.