### PR TITLE
Fix image renderable resource cleanup

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts
@@ -16,6 +16,7 @@ import {
   IMAGE_RENDERABLE_DEFAULT_SETTINGS,
   ImageUserData,
 } from "./ImageRenderable";
+import type { AnyImage, CompressedVideo } from "./ImageTypes";
 
 const mockAdd = jest.fn();
 const mockAddToTopic = jest.fn();
@@ -23,7 +24,14 @@ const mockRemove = jest.fn();
 const mockRemoveFromTopic = jest.fn();
 
 class MockVideoFrame {
-  public close(): void {}
+  public readonly displayWidth: number;
+  public readonly displayHeight: number;
+  public readonly close = jest.fn();
+
+  public constructor(displayWidth = 640, displayHeight = 480) {
+    this.displayWidth = displayWidth;
+    this.displayHeight = displayHeight;
+  }
 }
 
 // Mocked dependencies
@@ -65,13 +73,75 @@ const sampleImage = {
   header: { frame_id: "camera", stamp: { sec: 0, nsec: 1 } },
 };
 
+const sampleVideo: CompressedVideo = {
+  format: "h264",
+  data: new Uint8Array([0x65]),
+  timestamp: { sec: 0, nsec: 1 },
+  frame_id: "camera",
+};
+
+function makeUserData(): ImageUserData {
+  return {
+    ...mockUserData,
+    settings: { ...IMAGE_RENDERABLE_DEFAULT_SETTINGS },
+    texture: undefined,
+    material: undefined,
+    geometry: undefined,
+    mesh: undefined,
+    image: undefined,
+  };
+}
+
+class TestImageRenderable extends ImageRenderable {
+  readonly #decodedImages: (ImageBitmap | ImageData | VideoFrame)[];
+
+  public constructor(decodedImages: (ImageBitmap | ImageData | VideoFrame)[]) {
+    super(mockUserData.topic, mockRenderer, makeUserData());
+    this.#decodedImages = decodedImages;
+  }
+
+  protected override async decodeImage(
+    _image: AnyImage,
+    _resizeWidth?: number,
+  ): Promise<ImageBitmap | ImageData | VideoFrame> {
+    const decodedImage = this.#decodedImages.shift();
+    if (!decodedImage) {
+      throw new Error("No decoded image queued");
+    }
+    return decodedImage;
+  }
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function mockDateNow(start = 1_000): { advance: (ms: number) => void; restore: () => void } {
+  let now = start;
+  const spy = jest.spyOn(Date, "now").mockImplementation(() => now);
+  return {
+    advance: (ms: number) => {
+      now += ms;
+    },
+    restore: () => {
+      spy.mockRestore();
+    },
+  };
+}
+
 describe("ImageRenderable", () => {
+  let originalVideoFrame: unknown;
+
   beforeAll(() => {
-    (globalThis as unknown as { VideoFrame?: unknown }).VideoFrame = MockVideoFrame;
+    const globals = globalThis as unknown as { VideoFrame?: unknown };
+    originalVideoFrame = globals.VideoFrame;
+    globals.VideoFrame = MockVideoFrame;
   });
 
   afterAll(() => {
-    delete (globalThis as unknown as { VideoFrame?: unknown }).VideoFrame;
+    const globals = globalThis as unknown as { VideoFrame?: unknown };
+    globals.VideoFrame = originalVideoFrame;
   });
 
   beforeEach(() => {
@@ -160,15 +230,129 @@ describe("ImageRenderable", () => {
     renderable.setCameraModel(model);
     expect(renderable.userData.cameraModel).toBe(model);
   });
+
+  it("should update texture and queue render for a new video frame", async () => {
+    const time = mockDateNow();
+    try {
+      const frame = new MockVideoFrame() as unknown as VideoFrame;
+      const onDecoded = jest.fn();
+      const renderable = new TestImageRenderable([frame]);
+
+      renderable.setImage(sampleVideo, undefined, onDecoded);
+      await flushPromises();
+
+      expect(renderable.getDecodedImage()).toBe(frame);
+      expect(renderable.userData.texture?.image).toBe(frame);
+      expect(mockRenderer.queueAnimationFrame).toHaveBeenCalledTimes(1);
+      expect(onDecoded).toHaveBeenCalledTimes(1);
+    } finally {
+      time.restore();
+    }
+  });
+
+  it("should skip texture update and render when video decode reuses the current frame", async () => {
+    const time = mockDateNow();
+    try {
+      const frame = new MockVideoFrame() as unknown as VideoFrame;
+      const onDecoded = jest.fn();
+      const renderable = new TestImageRenderable([frame, frame]);
+
+      renderable.setImage(sampleVideo, undefined, onDecoded);
+      await flushPromises();
+
+      time.advance(20);
+      jest.clearAllMocks();
+      renderable.setImage({ ...sampleVideo, timestamp: { sec: 0, nsec: 2 } }, undefined, onDecoded);
+      await flushPromises();
+
+      expect(renderable.getDecodedImage()).toBe(frame);
+      expect(renderable.userData.texture?.image).toBe(frame);
+      expect(mockRenderer.queueAnimationFrame).not.toHaveBeenCalled();
+      expect(onDecoded).not.toHaveBeenCalled();
+      expect((frame as unknown as MockVideoFrame).close).not.toHaveBeenCalled();
+    } finally {
+      time.restore();
+    }
+  });
+
+  it("should close the previous video frame once when replacing it", async () => {
+    const time = mockDateNow();
+    try {
+      const frame1 = new MockVideoFrame() as unknown as VideoFrame;
+      const frame2 = new MockVideoFrame() as unknown as VideoFrame;
+      const renderable = new TestImageRenderable([frame1, frame2]);
+
+      renderable.setImage(sampleVideo);
+      await flushPromises();
+
+      time.advance(20);
+      renderable.setImage({ ...sampleVideo, timestamp: { sec: 0, nsec: 2 } });
+      await flushPromises();
+
+      expect(renderable.userData.texture?.image).toBe(frame2);
+      expect((frame1 as unknown as MockVideoFrame).close).toHaveBeenCalledTimes(1);
+      expect((frame2 as unknown as MockVideoFrame).close).not.toHaveBeenCalled();
+    } finally {
+      time.restore();
+    }
+  });
+
+  it("should not close the same video frame twice on dispose", async () => {
+    const time = mockDateNow();
+    try {
+      const frame = new MockVideoFrame() as unknown as VideoFrame;
+      const renderable = new TestImageRenderable([frame]);
+
+      renderable.setImage(sampleVideo);
+      await flushPromises();
+      renderable.dispose();
+
+      expect((frame as unknown as MockVideoFrame).close).toHaveBeenCalledTimes(1);
+    } finally {
+      time.restore();
+    }
+  });
+
+  it("should close the previous ImageBitmap when replacing it with the same dimensions", async () => {
+    const time = mockDateNow();
+    try {
+      const bitmap1 = await createImageBitmap(new ImageData(640, 480));
+      const bitmap2 = await createImageBitmap(new ImageData(640, 480));
+      const closeBitmap1 = jest.spyOn(bitmap1, "close");
+      const closeBitmap2 = jest.spyOn(bitmap2, "close");
+      const renderable = new TestImageRenderable([bitmap1, bitmap2]);
+
+      renderable.setImage(sampleImage);
+      await flushPromises();
+
+      time.advance(20);
+      renderable.setImage({
+        ...sampleImage,
+        header: { frame_id: "camera", stamp: { sec: 0, nsec: 2 } },
+      });
+      await flushPromises();
+
+      expect(renderable.userData.texture?.image).toBe(bitmap2);
+      expect(closeBitmap1).toHaveBeenCalledTimes(1);
+      expect(closeBitmap2).not.toHaveBeenCalled();
+    } finally {
+      time.restore();
+    }
+  });
 });
 
 describe("ImageRenderable error handling", () => {
+  let originalVideoFrame: unknown;
+
   beforeAll(() => {
-    (globalThis as unknown as { VideoFrame?: unknown }).VideoFrame = MockVideoFrame;
+    const globals = globalThis as unknown as { VideoFrame?: unknown };
+    originalVideoFrame = globals.VideoFrame;
+    globals.VideoFrame = MockVideoFrame;
   });
 
   afterAll(() => {
-    delete (globalThis as unknown as { VideoFrame?: unknown }).VideoFrame;
+    const globals = globalThis as unknown as { VideoFrame?: unknown };
+    globals.VideoFrame = originalVideoFrame;
   });
 
   beforeEach(() => {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts
@@ -80,6 +80,8 @@ const sampleVideo: CompressedVideo = {
   frame_id: "camera",
 };
 
+type TestDecodedImage = ImageBitmap | ImageData | VideoFrame;
+
 function makeUserData(): ImageUserData {
   return {
     ...mockUserData,
@@ -93,9 +95,9 @@ function makeUserData(): ImageUserData {
 }
 
 class TestImageRenderable extends ImageRenderable {
-  readonly #decodedImages: (ImageBitmap | ImageData | VideoFrame)[];
+  readonly #decodedImages: (TestDecodedImage | Promise<TestDecodedImage>)[];
 
-  public constructor(decodedImages: (ImageBitmap | ImageData | VideoFrame)[]) {
+  public constructor(decodedImages: (TestDecodedImage | Promise<TestDecodedImage>)[]) {
     super(mockUserData.topic, mockRenderer, makeUserData());
     this.#decodedImages = decodedImages;
   }
@@ -103,12 +105,12 @@ class TestImageRenderable extends ImageRenderable {
   protected override async decodeImage(
     _image: AnyImage,
     _resizeWidth?: number,
-  ): Promise<ImageBitmap | ImageData | VideoFrame> {
+  ): Promise<TestDecodedImage> {
     const decodedImage = this.#decodedImages.shift();
     if (!decodedImage) {
       throw new Error("No decoded image queued");
     }
-    return decodedImage;
+    return await decodedImage;
   }
 }
 
@@ -270,6 +272,44 @@ describe("ImageRenderable", () => {
       expect(mockRenderer.queueAnimationFrame).not.toHaveBeenCalled();
       expect(onDecoded).not.toHaveBeenCalled();
       expect((frame as unknown as MockVideoFrame).close).not.toHaveBeenCalled();
+    } finally {
+      time.restore();
+    }
+  });
+
+  it("should reject an older decoded frame after a newer decode reuses the current frame", async () => {
+    const time = mockDateNow();
+    try {
+      const frame = new MockVideoFrame() as unknown as VideoFrame;
+      const staleFrame = new MockVideoFrame() as unknown as VideoFrame;
+      let resolveStaleFrame!: (value: TestDecodedImage) => void;
+      const staleFramePromise = new Promise<TestDecodedImage>((resolve) => {
+        resolveStaleFrame = resolve;
+      });
+      const renderable = new TestImageRenderable([frame, staleFramePromise, frame]);
+
+      renderable.setImage(sampleVideo);
+      await flushPromises();
+
+      time.advance(20);
+      jest.clearAllMocks();
+      renderable.setImage({ ...sampleVideo, timestamp: { sec: 0, nsec: 2 } });
+
+      time.advance(20);
+      renderable.setImage({ ...sampleVideo, timestamp: { sec: 0, nsec: 3 } });
+      await flushPromises();
+
+      expect(renderable.getDecodedImage()).toBe(frame);
+      expect(renderable.userData.texture?.image).toBe(frame);
+      expect(renderable.userData.messageTime).toBe(3n);
+
+      resolveStaleFrame(staleFrame);
+      await flushPromises();
+
+      expect(renderable.getDecodedImage()).toBe(frame);
+      expect(renderable.userData.texture?.image).toBe(frame);
+      expect((staleFrame as unknown as MockVideoFrame).close).toHaveBeenCalledTimes(1);
+      expect(mockRenderer.queueAnimationFrame).not.toHaveBeenCalled();
     } finally {
       time.restore();
     }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -115,11 +115,10 @@ export class ImageRenderable extends Renderable<ImageUserData> {
 
   public override dispose(): void {
     this.#disposed = true;
-    if (this.userData.texture?.image instanceof VideoFrame) {
-      this.userData.texture.image.close();
-    }
-    if (isVideoFrame(this.#decodedImage)) {
-      this.#decodedImage.close();
+    const textureImage = this.userData.texture?.image;
+    closeDecodedImageResource(textureImage);
+    if (this.#decodedImage !== textureImage) {
+      closeDecodedImageResource(this.#decodedImage);
     }
     this.userData.texture?.dispose();
     this.userData.material?.dispose();
@@ -231,18 +230,17 @@ export class ImageRenderable extends Renderable<ImageUserData> {
           }
           return;
         }
+        if (isReusedFrame) {
+          return;
+        }
         // prevent displaying an image older than the one currently displayed
         if (this.#displayedImageSequenceNumber > seq) {
-          if (!isReusedFrame) {
-            closeDecodedImageResource(result);
-          }
+          closeDecodedImageResource(result);
           return;
         }
         // cap at 60 fps
         if (this.#lastRenderImage > Date.now() - 16) {
-          if (!isReusedFrame) {
-            closeDecodedImageResource(result);
-          }
+          closeDecodedImageResource(result);
           return;
         }
         this.#lastRenderImage = Date.now();
@@ -396,15 +394,14 @@ export class ImageRenderable extends Renderable<ImageUserData> {
         !(texture.image instanceof VideoFrame) ||
         !videoFrameDimensionsEqual(decodedImage, texture.image)
       ) {
-        if (texture?.image instanceof VideoFrame) {
-          texture.image.close();
-        }
+        closeDecodedImageResource(texture?.image);
         texture?.dispose();
         this.userData.texture = createVideoFrameTexture(decodedImage);
       } else {
-        if (texture.image !== decodedImage) {
-          texture.image.close();
+        if (texture.image === decodedImage) {
+          return;
         }
+        texture.image.close();
         texture.image = decodedImage;
         texture.needsUpdate = true;
       }
@@ -416,16 +413,14 @@ export class ImageRenderable extends Renderable<ImageUserData> {
         !(canvasTexture instanceof THREE.CanvasTexture) ||
         !bitmapDimensionsEqual(decodedImage, canvasTexture.image as ImageBitmap | undefined)
       ) {
-        if (canvasTexture?.image instanceof VideoFrame) {
-          canvasTexture.image.close();
-        }
-        if (canvasTexture?.image instanceof ImageBitmap) {
-          // don't close the image if it is the error image
-          canvasTexture.image.close();
-        }
+        closeDecodedImageResource(canvasTexture?.image);
         canvasTexture?.dispose();
         this.userData.texture = createCanvasTexture(decodedImage);
       } else {
+        if (canvasTexture.image === decodedImage) {
+          return;
+        }
+        closeDecodedImageResource(canvasTexture.image);
         canvasTexture.image = decodedImage;
         canvasTexture.needsUpdate = true;
       }
@@ -438,9 +433,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
         dataTexture.image.width !== decodedImage.width ||
         dataTexture.image.height !== decodedImage.height
       ) {
-        if (dataTexture?.image instanceof VideoFrame) {
-          dataTexture.image.close();
-        }
+        closeDecodedImageResource(dataTexture?.image);
         dataTexture?.dispose();
         dataTexture = createDataTexture(decodedImage);
         this.userData.texture = dataTexture;
@@ -678,9 +671,7 @@ function createEmptyVideoFrame(): VideoFrame {
   return new VideoFrame(canvas, { timestamp: 0 });
 }
 
-function closeDecodedImageResource(
-  resource: ImageBitmap | ImageData | VideoFrame | undefined,
-): void {
+function closeDecodedImageResource(resource: unknown): void {
   if (!resource) {
     return;
   }
@@ -688,7 +679,7 @@ function closeDecodedImageResource(
     resource.close();
     return;
   }
-  if (resource instanceof ImageBitmap) {
+  if (typeof ImageBitmap !== "undefined" && resource instanceof ImageBitmap) {
     resource.close();
   }
 }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -230,12 +230,18 @@ export class ImageRenderable extends Renderable<ImageUserData> {
           }
           return;
         }
-        if (isReusedFrame) {
-          return;
-        }
         // prevent displaying an image older than the one currently displayed
         if (this.#displayedImageSequenceNumber > seq) {
-          closeDecodedImageResource(result);
+          if (!isReusedFrame) {
+            closeDecodedImageResource(result);
+          }
+          return;
+        }
+        if (isReusedFrame) {
+          this.#displayedImageSequenceNumber = seq;
+          this.update();
+          this.#showingErrorImage = false;
+          this.removeError(DECODE_IMAGE_ERR_KEY);
           return;
         }
         // cap at 60 fps
@@ -672,7 +678,7 @@ function createEmptyVideoFrame(): VideoFrame {
 }
 
 function closeDecodedImageResource(resource: unknown): void {
-  if (!resource) {
+  if (resource == undefined) {
     return;
   }
   if (typeof VideoFrame !== "undefined" && resource instanceof VideoFrame) {


### PR DESCRIPTION
## Summary
- Avoid double-closing reused `VideoFrame` and `ImageBitmap` instances during image updates and disposal
- Centralize decoded image cleanup so texture replacement paths handle both frame and bitmap resources consistently
- Expand unit coverage for frame reuse, replacement, and disposal behavior

## Testing
- Not run (not requested)
- Added unit tests covering video frame reuse, video frame replacement, disposal cleanup, and bitmap replacement