### PR TITLE
fix: OBJECT_STORAGE_BASE_URL link

### DIFF
--- a/packages/studio-base/src/dataSources/CoSceneDataPlatformDataSourceFactory.test.ts
+++ b/packages/studio-base/src/dataSources/CoSceneDataPlatformDataSourceFactory.test.ts
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { buildManifestUrl } from "./CoSceneDataPlatformDataSourceFactory";
+
+describe("buildManifestUrl", () => {
+  it("adds https protocol to object storage base URL without protocol", () => {
+    expect(buildManifestUrl("mcap.dev.coscene.cn", "project-id", "record-id")).toBe(
+      "https://mcap.dev.coscene.cn/projects/project-id/records/record-id/manifest.json",
+    );
+  });
+
+  it("keeps existing protocol on object storage base URL", () => {
+    expect(buildManifestUrl("http://mcap.dev.coscene.cn", "project-id", "record-id")).toBe(
+      "http://mcap.dev.coscene.cn/projects/project-id/records/record-id/manifest.json",
+    );
+    expect(buildManifestUrl("https://mcap.dev.coscene.cn", "project-id", "record-id")).toBe(
+      "https://mcap.dev.coscene.cn/projects/project-id/records/record-id/manifest.json",
+    );
+  });
+
+  it("trims trailing slashes before appending manifest path", () => {
+    expect(buildManifestUrl("mcap.dev.coscene.cn///", "project-id", "record-id")).toBe(
+      "https://mcap.dev.coscene.cn/projects/project-id/records/record-id/manifest.json",
+    );
+  });
+});

--- a/packages/studio-base/src/dataSources/CoSceneDataPlatformDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/CoSceneDataPlatformDataSourceFactory.ts
@@ -42,12 +42,19 @@ function definedUrlParams(params?: Record<string, string | undefined>): Record<s
   return definedParams;
 }
 
-function buildManifestUrl(
+function ensureObjectStorageBaseUrlProtocol(objectStorageBaseUrl: string): string {
+  if (/^https?:\/\//i.test(objectStorageBaseUrl)) {
+    return objectStorageBaseUrl;
+  }
+  return `https://${objectStorageBaseUrl}`;
+}
+
+export function buildManifestUrl(
   objectStorageBaseUrl: string,
   projectId: string,
   recordId: string,
 ): string {
-  return `${objectStorageBaseUrl.replace(
+  return `${ensureObjectStorageBaseUrlProtocol(objectStorageBaseUrl).replace(
     /\/+$/,
     "",
   )}/projects/${projectId}/records/${recordId}/manifest.json`;


### PR DESCRIPTION
## Summary
- Normalize `OBJECT_STORAGE_BASE_URL` before building manifest URLs so bare hosts like `mcap.dev.coscene.cn` resolve to `https://mcap.dev.coscene.cn` instead of a relative path.
- Keep existing `http://` and `https://` prefixes unchanged.
- Add unit coverage for bare hosts, pre-prefixed URLs, and trailing slashes.

## Testing
- Added unit tests for `buildManifestUrl`.
- `git diff --check` passed.
- Not run (dependency state for Jest was not available in this worktree).