### PR TITLE
Prevent double-submit when creating moments

### DIFF
--- a/packages/studio-base/src/components/Events/CreateEventContainer/index.tsx
+++ b/packages/studio-base/src/components/Events/CreateEventContainer/index.tsx
@@ -164,6 +164,7 @@ export function CreateEventContainer({ onClose }: { onClose: () => void }): Reac
 
     isSubmittingRef.current = true;
     setIsLoading(true);
+    let shouldResetSubmitting = true;
 
     try {
       const isEventFormValid = await eventForm.trigger();
@@ -260,13 +261,16 @@ export function CreateEventContainer({ onClose }: { onClose: () => void }): Reac
       }
 
       refreshEvents();
+      shouldResetSubmitting = false;
       onClose();
     } catch (error) {
       console.error(error);
       toast.error(t("createMomentFailed"));
     } finally {
-      isSubmittingRef.current = false;
-      setIsLoading(false);
+      if (shouldResetSubmitting) {
+        isSubmittingRef.current = false;
+        setIsLoading(false);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- Prevent double-submit on moment creation by keeping the submit lock active after a successful create/update until the dialog closes
- Only release the lock and loading state when submission fails or validation aborts the flow

## Testing
- Lint passed for `packages/studio-base/src/components/Events/CreateEventContainer/index.tsx`
- Verified the diff is whitespace-clean with `git diff --check`