### PR TITLE
Use remote config hostname when resolving desktop login domain

### DIFF
--- a/packages/studio-base/src/util/appConfig.test.ts
+++ b/packages/studio-base/src/util/appConfig.test.ts
@@ -1,0 +1,58 @@
+/** @jest-environment jsdom */
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { getDomainConfig } from "./appConfig";
+
+describe("getDomainConfig", () => {
+  const defaultDomainConfig = {
+    env: "saas",
+    logo: "coscene",
+    authStatusCookieName: "coSceneAuthStatus",
+    authStatusCookieDomain: "coscene.cn",
+    webDomain: "coscene.cn",
+    ssoDomain: "sso.coscene.cn",
+  };
+
+  const agibotDomainConfig = {
+    env: "saas",
+    logo: "agibot",
+    authStatusCookieName: "agibotAuthStatus",
+    authStatusCookieDomain: "coscene.cn",
+    webDomain: "agibot.coscene.cn",
+    ssoDomain: "agibot.sso.coscene.cn",
+  };
+
+  afterEach(() => {
+    window.cosConfig = undefined;
+    window.cosConfigRemoteHostname = undefined;
+  });
+
+  it("uses the remote config hostname when the window hostname does not match a domain config", () => {
+    window.cosConfig = {
+      DOMAIN_CONFIG: {
+        default: defaultDomainConfig,
+        "agibot.coscene.cn": agibotDomainConfig,
+      },
+    };
+    window.cosConfigRemoteHostname = "agibot.coscene.cn";
+
+    expect(getDomainConfig().webDomain).toEqual("agibot.coscene.cn");
+  });
+
+  it("falls back to the default domain config when there is no remote hostname match", () => {
+    window.cosConfig = {
+      DOMAIN_CONFIG: {
+        default: defaultDomainConfig,
+        "agibot.coscene.cn": agibotDomainConfig,
+      },
+    };
+    window.cosConfigRemoteHostname = "unknown.coscene.cn";
+
+    expect(getDomainConfig().webDomain).toEqual("coscene.cn");
+  });
+});

--- a/packages/studio-base/src/util/appConfig.ts
+++ b/packages/studio-base/src/util/appConfig.ts
@@ -60,6 +60,7 @@ declare global {
       OBJECT_STORAGE_BASE_URL?: string;
     };
     buildTime?: string;
+    cosConfigRemoteHostname?: string;
   }
 }
 
@@ -132,9 +133,13 @@ export function getAppConfig(): NonNullable<Window["cosConfig"]> {
 
 export function getDomainConfig(): DomainConfig {
   const appConfig = getAppConfig();
+  const hostname = typeof window !== "undefined" ? window.location.hostname : undefined;
+  const remoteConfigHostname =
+    typeof window !== "undefined" ? window.cosConfigRemoteHostname : undefined;
 
   return (
-    appConfig.DOMAIN_CONFIG?.[window.location.hostname] ??
+    (hostname ? appConfig.DOMAIN_CONFIG?.[hostname] : undefined) ??
+    (remoteConfigHostname ? appConfig.DOMAIN_CONFIG?.[remoteConfigHostname] : undefined) ??
     appConfig.DOMAIN_CONFIG?.default ??
     DEFAULT_DOMAN_CONFIG.default!
   );

--- a/packages/studio-desktop/src/renderer/services/RemoteConfigLoader.ts
+++ b/packages/studio-desktop/src/renderer/services/RemoteConfigLoader.ts
@@ -20,7 +20,7 @@ export interface RemoteConfigOptions {
 const DEFAULT_TIMEOUT = 5000;
 
 export async function initializeCosConfig(options: RemoteConfigOptions): Promise<void> {
-  (window as { cosConfigRemoteHostname?: string }).cosConfigRemoteHostname = undefined;
+  window.cosConfigRemoteHostname = undefined;
 
   // local config
   await loadLocalConfig();
@@ -71,8 +71,7 @@ async function loadRemoteConfig(options: RemoteConfigOptions): Promise<boolean> 
     if (success && window.cosConfig && typeof window.cosConfig === "object") {
       // 合并配置：远程配置优先
       window.cosConfig = { ...localConfig, ...window.cosConfig };
-      (window as { cosConfigRemoteHostname?: string }).cosConfigRemoteHostname =
-        remoteConfigHostname;
+      window.cosConfigRemoteHostname = remoteConfigHostname;
       log.info("Remote config loaded and merged successfully");
       return true;
     } else {

--- a/packages/studio-desktop/src/renderer/services/RemoteConfigLoader.ts
+++ b/packages/studio-desktop/src/renderer/services/RemoteConfigLoader.ts
@@ -20,6 +20,8 @@ export interface RemoteConfigOptions {
 const DEFAULT_TIMEOUT = 5000;
 
 export async function initializeCosConfig(options: RemoteConfigOptions): Promise<void> {
+  (window as { cosConfigRemoteHostname?: string }).cosConfigRemoteHostname = undefined;
+
   // local config
   await loadLocalConfig();
 
@@ -60,6 +62,7 @@ async function loadRemoteConfig(options: RemoteConfigOptions): Promise<boolean> 
 
     // 保存当前配置（此时已经加载了本地配置）
     const localConfig = { ...window.cosConfig };
+    const remoteConfigHostname = new URL(remoteUrl).hostname;
 
     // 加载远程配置
     const scriptUrl = new URL("cos-config.js", remoteUrl).toString();
@@ -68,6 +71,8 @@ async function loadRemoteConfig(options: RemoteConfigOptions): Promise<boolean> 
     if (success && window.cosConfig && typeof window.cosConfig === "object") {
       // 合并配置：远程配置优先
       window.cosConfig = { ...localConfig, ...window.cosConfig };
+      (window as { cosConfigRemoteHostname?: string }).cosConfigRemoteHostname =
+        remoteConfigHostname;
       log.info("Remote config loaded and merged successfully");
       return true;
     } else {


### PR DESCRIPTION
## Summary
- Record the remote config hostname when desktop loads `REMOTE_CONFIG_URL`
- Use that hostname as a fallback when resolving `DOMAIN_CONFIG` so desktop login links can target the correct site even when `window.location.hostname` is `localhost` or empty
- Add unit coverage for the remote-hostname fallback and default-domain fallback

## Testing
- Added `appConfig` unit tests for hostname resolution behavior
- Ran the targeted Jest suite for `packages/studio-base/src/util/appConfig.test.ts`
- Ran ESLint on the touched files