### PR TITLE
Add manifest storage source selection for data-platform playback

### DIFF
--- a/packages/studio-base/src/AppSetting.ts
+++ b/packages/studio-base/src/AppSetting.ts
@@ -48,6 +48,7 @@ export enum AppSetting {
 
   REQUEST_WINDOW = "requestWindow",
   READ_AHEAD_DURATION = "readAheadDuration",
+  MANIFEST_STORAGE_SOURCE = "manifestStorageSource",
 
   // Remote Config
   REMOTE_CONFIG_URL = "remoteConfigUrl",

--- a/packages/studio-base/src/components/AppSettingsDialog/AppSettingsDialog.tsx
+++ b/packages/studio-base/src/components/AppSettingsDialog/AppSettingsDialog.tsx
@@ -48,6 +48,7 @@ import {
   InactivityTimeout,
   RetentionWindowMs,
   RequestWindow,
+  ManifestStorageSourceSettings,
   ReadAheadDuration,
   StudioRemoteConfigUrl,
   AutoConnectToLan,
@@ -257,6 +258,7 @@ export function AppSettingsDialog(
               <RetentionWindowMs />
               <InactivityTimeout />
               <RequestWindow />
+              <ManifestStorageSourceSettings />
               <ReadAheadDuration />
               {showLanguageOptions && <LanguageSettings />}
               <IsRenderAllTabs />

--- a/packages/studio-base/src/components/AppSettingsDialog/ManifestStorageSourceSettings.test.tsx
+++ b/packages/studio-base/src/components/AppSettingsDialog/ManifestStorageSourceSettings.test.tsx
@@ -1,0 +1,186 @@
+/** @jest-environment jsdom */
+
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { PropsWithChildren, useLayoutEffect } from "react";
+
+import { AppSetting } from "@foxglove/studio-base/AppSetting";
+import { ManifestStorageSourceSettings } from "@foxglove/studio-base/components/AppSettingsDialog/settings";
+import AppConfigurationContext, {
+  AppConfigurationValue,
+  ChangeHandler,
+  IAppConfiguration,
+} from "@foxglove/studio-base/context/AppConfigurationContext";
+import CoSceneConsoleApiContext from "@foxglove/studio-base/context/CoSceneConsoleApiContext";
+import { useCoreData } from "@foxglove/studio-base/context/CoreDataContext";
+import PlayerSelectionContext from "@foxglove/studio-base/context/PlayerSelectionContext";
+import {
+  COSCENE_VIZ_DATA_BASE_URL,
+  ManifestStorageSource,
+} from "@foxglove/studio-base/dataSources/manifestStorage";
+import CoreDataProvider from "@foxglove/studio-base/providers/CoreDataProvider";
+
+class TestAppConfiguration implements IAppConfiguration {
+  public set = jest.fn(async (key: string, value: AppConfigurationValue) => {
+    this.#values.set(key, value);
+    for (const listener of this.#listeners.get(key) ?? []) {
+      listener(value);
+    }
+  });
+
+  #values = new Map<string, AppConfigurationValue>();
+  #listeners = new Map<string, Set<ChangeHandler>>();
+
+  public get(key: string): AppConfigurationValue {
+    return this.#values.get(key);
+  }
+
+  public addChangeListener(key: string, cb: ChangeHandler): void {
+    let listeners = this.#listeners.get(key);
+    if (!listeners) {
+      listeners = new Set();
+      this.#listeners.set(key, listeners);
+    }
+    listeners.add(cb);
+  }
+
+  public removeChangeListener(key: string, cb: ChangeHandler): void {
+    this.#listeners.get(key)?.delete(cb);
+  }
+}
+
+function CoreDataSeeder(props: { sourceId?: string }): ReactNull {
+  const setDataSource = useCoreData((state) => state.setDataSource);
+
+  useLayoutEffect(() => {
+    setDataSource(
+      props.sourceId == undefined ? undefined : { id: props.sourceId, type: "connection" },
+    );
+  }, [props.sourceId, setDataSource]);
+
+  return ReactNull;
+}
+
+function renderSetting(options: { sourceId?: string; fixedManifestOk?: boolean } = {}): {
+  appConfiguration: TestAppConfiguration;
+  reloadCurrentSource: jest.Mock<Promise<void>>;
+} {
+  const appConfiguration = new TestAppConfiguration();
+  const reloadCurrentSource = jest.fn(async () => {});
+  global.fetch = jest.fn().mockResolvedValue({ ok: options.fixedManifestOk ?? true } as Response);
+
+  function Wrapper(props: PropsWithChildren): React.JSX.Element {
+    return (
+      <AppConfigurationContext.Provider value={appConfiguration}>
+        <CoSceneConsoleApiContext.Provider
+          value={
+            {
+              getApiBaseInfo: () => ({ projectId: "project-id", recordId: "record-id" }),
+            } as never
+          }
+        >
+          <PlayerSelectionContext.Provider
+            value={{
+              selectSource: jest.fn(),
+              selectRecent: jest.fn(),
+              reloadCurrentSource,
+              availableSources: [],
+              recentSources: [],
+            }}
+          >
+            <CoreDataProvider>
+              <CoreDataSeeder sourceId={options.sourceId} />
+              {props.children}
+            </CoreDataProvider>
+          </PlayerSelectionContext.Provider>
+        </CoSceneConsoleApiContext.Provider>
+      </AppConfigurationContext.Provider>
+    );
+  }
+
+  render(<ManifestStorageSourceSettings />, { wrapper: Wrapper });
+
+  return { appConfiguration, reloadCurrentSource };
+}
+
+describe("ManifestStorageSourceSettings", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("does not render outside coscene-data-platform playback", () => {
+    renderSetting({ sourceId: "coscene-websocket" });
+
+    expect(screen.queryByText(/Manifest and MCAP request host/)).toBeNull();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("renders both choices and enables the fixed host when the current manifest exists", async () => {
+    renderSetting({ sourceId: "coscene-data-platform", fixedManifestOk: true });
+
+    expect(await screen.findByText(/Manifest and MCAP request host/)).toBeTruthy();
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://coscene-viz-data.coscene.io/projects/project-id/records/record-id/manifest.json",
+        { method: "HEAD" },
+      );
+    });
+
+    fireEvent.mouseDown(screen.getByRole("combobox"));
+
+    expect(screen.getByRole("option", { name: /OBJECT_STORAGE_BASE_URL/ })).toBeTruthy();
+    expect(
+      screen.getByRole("option", { name: COSCENE_VIZ_DATA_BASE_URL }).getAttribute("aria-disabled"),
+    ).not.toBe("true");
+  });
+
+  it("disables the fixed host and explains when the current manifest is unavailable", async () => {
+    renderSetting({ sourceId: "coscene-data-platform", fixedManifestOk: false });
+
+    expect(await screen.findByText(/Manifest and MCAP request host/)).toBeTruthy();
+    expect(await screen.findByText("This address cannot play the current file.")).toBeTruthy();
+
+    fireEvent.mouseDown(screen.getByRole("combobox"));
+
+    expect(
+      screen.getByRole("option", { name: COSCENE_VIZ_DATA_BASE_URL }).getAttribute("aria-disabled"),
+    ).toBe("true");
+  });
+
+  it("persists selection and offers to refresh the current source", async () => {
+    const { appConfiguration, reloadCurrentSource } = renderSetting({
+      sourceId: "coscene-data-platform",
+      fixedManifestOk: true,
+    });
+
+    expect(await screen.findByText(/Manifest and MCAP request host/)).toBeTruthy();
+    fireEvent.mouseDown(screen.getByRole("combobox"));
+    fireEvent.click(await screen.findByRole("option", { name: COSCENE_VIZ_DATA_BASE_URL }));
+
+    await waitFor(() => {
+      expect(appConfiguration.set).toHaveBeenCalledWith(
+        AppSetting.MANIFEST_STORAGE_SOURCE,
+        ManifestStorageSource.CoSceneVizData,
+      );
+    });
+    expect(
+      await screen.findByText(
+        /Setting updated, will take effect the next time visualization starts/,
+      ),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Refresh now"));
+
+    await waitFor(() => {
+      expect(reloadCurrentSource).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/studio-base/src/components/AppSettingsDialog/ManifestStorageSourceSettings.test.tsx
+++ b/packages/studio-base/src/components/AppSettingsDialog/ManifestStorageSourceSettings.test.tsx
@@ -26,6 +26,9 @@ import {
 } from "@foxglove/studio-base/dataSources/manifestStorage";
 import CoreDataProvider from "@foxglove/studio-base/providers/CoreDataProvider";
 
+const DEFAULT_OBJECT_STORAGE_BASE_URL = "default-storage.example.com";
+const DISPLAYED_DEFAULT_OBJECT_STORAGE_BASE_URL = `https://${DEFAULT_OBJECT_STORAGE_BASE_URL}`;
+
 class TestAppConfiguration implements IAppConfiguration {
   public set = jest.fn(async (key: string, value: AppConfigurationValue) => {
     this.#values.set(key, value);
@@ -74,6 +77,7 @@ function renderSetting(options: { sourceId?: string; fixedManifestOk?: boolean }
   const appConfiguration = new TestAppConfiguration();
   const reloadCurrentSource = jest.fn(async () => {});
   global.fetch = jest.fn().mockResolvedValue({ ok: options.fixedManifestOk ?? true } as Response);
+  window.cosConfig = { OBJECT_STORAGE_BASE_URL: DEFAULT_OBJECT_STORAGE_BASE_URL };
 
   function Wrapper(props: PropsWithChildren): React.JSX.Element {
     return (
@@ -136,7 +140,10 @@ describe("ManifestStorageSourceSettings", () => {
 
     fireEvent.mouseDown(screen.getByRole("combobox"));
 
-    expect(screen.getByRole("option", { name: /OBJECT_STORAGE_BASE_URL/ })).toBeTruthy();
+    expect(
+      screen.getByRole("option", { name: `${DISPLAYED_DEFAULT_OBJECT_STORAGE_BASE_URL} default` }),
+    ).toBeTruthy();
+    expect(screen.queryByRole("option", { name: /OBJECT_STORAGE_BASE_URL/ })).toBeNull();
     expect(
       screen.getByRole("option", { name: COSCENE_VIZ_DATA_BASE_URL }).getAttribute("aria-disabled"),
     ).not.toBe("true");

--- a/packages/studio-base/src/components/AppSettingsDialog/settings.tsx
+++ b/packages/studio-base/src/components/AppSettingsDialog/settings.tsx
@@ -20,6 +20,7 @@ import {
   Divider,
   FormControl,
   FormControlLabel,
+  FormHelperText,
   FormLabel,
   Link,
   MenuItem,
@@ -32,7 +33,7 @@ import {
   Typography,
 } from "@mui/material";
 import moment from "moment-timezone";
-import { ChangeEvent, MouseEvent, useCallback, useMemo, useRef, useState } from "react";
+import { ChangeEvent, MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation, Trans } from "react-i18next";
 import { makeStyles } from "tss-react/mui";
 
@@ -50,6 +51,12 @@ import { useConsoleApi } from "@foxglove/studio-base/context/CoSceneConsoleApiCo
 import { useCurrentUser, UserStore } from "@foxglove/studio-base/context/CoSceneCurrentUserContext";
 import { CoreDataStore, useCoreData } from "@foxglove/studio-base/context/CoreDataContext";
 import { usePlayerSelection } from "@foxglove/studio-base/context/PlayerSelectionContext";
+import {
+  COSCENE_VIZ_DATA_BASE_URL,
+  ManifestStorageSource,
+  buildManifestUrl,
+  manifestExists,
+} from "@foxglove/studio-base/dataSources/manifestStorage";
 import { useAppTimeFormat } from "@foxglove/studio-base/hooks";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConfigurationValue";
 import { Language } from "@foxglove/studio-base/i18n";
@@ -760,6 +767,139 @@ export function RequestWindow(): React.ReactElement {
             <Trans
               t={t}
               i18nKey="requestWindowNextEffectiveNotice"
+              components={{
+                Link: (
+                  <Link
+                    href="#"
+                    target="_self"
+                    onClick={async () => {
+                      await reloadCurrentSource();
+                      setShowTips(false);
+                    }}
+                  />
+                ),
+              }}
+            />
+          </Typography>
+        </Stack>
+      )}
+    </Stack>
+  );
+}
+
+type FixedManifestAvailability = "idle" | "checking" | "available" | "unavailable";
+
+export function ManifestStorageSourceSettings(): React.ReactElement | ReactNull {
+  const { t } = useTranslation("appSettings");
+  const [manifestStorageSource, setManifestStorageSource] = useAppConfigurationValue<string>(
+    AppSetting.MANIFEST_STORAGE_SOURCE,
+  );
+  const dataSource = useCoreData(selectDataSource);
+  const { reloadCurrentSource } = usePlayerSelection();
+  const consoleApi = useConsoleApi();
+  const { theme } = useStyles();
+  const [showTips, setShowTips] = useState(false);
+  const fixedAvailabilityRequest = useRef(0);
+  const [fixedAvailability, setFixedAvailability] = useState<FixedManifestAvailability>("idle");
+
+  const isCoSceneDataPlatform = dataSource?.id === "coscene-data-platform";
+  const apiBaseInfo = isCoSceneDataPlatform ? consoleApi.getApiBaseInfo() : undefined;
+  const projectId = apiBaseInfo?.projectId;
+  const recordId = apiBaseInfo?.recordId;
+  const objectStorageBaseUrl = getAppConfig().OBJECT_STORAGE_BASE_URL;
+
+  const fixedManifestUrl = useMemo(() => {
+    if (projectId == undefined || recordId == undefined) {
+      return undefined;
+    }
+    return buildManifestUrl(COSCENE_VIZ_DATA_BASE_URL, projectId, recordId);
+  }, [projectId, recordId]);
+
+  useEffect(() => {
+    if (!isCoSceneDataPlatform) {
+      setFixedAvailability("idle");
+      return;
+    }
+    if (fixedManifestUrl == undefined) {
+      setFixedAvailability("unavailable");
+      return;
+    }
+
+    const requestId = fixedAvailabilityRequest.current + 1;
+    fixedAvailabilityRequest.current = requestId;
+    setFixedAvailability("checking");
+    void (async () => {
+      const exists = await manifestExists(fixedManifestUrl);
+      if (fixedAvailabilityRequest.current === requestId) {
+        setFixedAvailability(exists ? "available" : "unavailable");
+      }
+    })();
+
+    return () => {
+      fixedAvailabilityRequest.current += 1;
+    };
+  }, [fixedManifestUrl, isCoSceneDataPlatform]);
+
+  const selectedValue =
+    manifestStorageSource === ManifestStorageSource.CoSceneVizData
+      ? ManifestStorageSource.CoSceneVizData
+      : ManifestStorageSource.Default;
+  const fixedOptionDisabled = fixedAvailability !== "available";
+  const defaultStorageLabel =
+    objectStorageBaseUrl != undefined && objectStorageBaseUrl.length > 0
+      ? t("manifestStorageSourceDefault", { url: objectStorageBaseUrl })
+      : "OBJECT_STORAGE_BASE_URL";
+
+  const onChangeManifestStorageSource = useCallback(
+    (event: SelectChangeEvent<ManifestStorageSource>) => {
+      const nextValue = event.target.value as ManifestStorageSource;
+      if (nextValue === ManifestStorageSource.CoSceneVizData && fixedOptionDisabled) {
+        return;
+      }
+      void setManifestStorageSource(nextValue);
+      setShowTips(true);
+    },
+    [fixedOptionDisabled, setManifestStorageSource],
+  );
+
+  if (!isCoSceneDataPlatform) {
+    return ReactNull;
+  }
+
+  return (
+    <Stack>
+      <FormControl fullWidth>
+        <FormLabel>
+          <Stack direction="row" alignItems="center" gap={0.5}>
+            {t("manifestStorageSource")}:
+            <Tooltip title={t("manifestStorageSourceDescription")}>
+              <HelpIcon fontSize="small" />
+            </Tooltip>
+          </Stack>
+        </FormLabel>
+        <SmartSelect<ManifestStorageSource>
+          value={selectedValue}
+          fullWidth
+          onChange={onChangeManifestStorageSource}
+        >
+          <MenuItem value={ManifestStorageSource.Default}>{defaultStorageLabel}</MenuItem>
+          <MenuItem value={ManifestStorageSource.CoSceneVizData} disabled={fixedOptionDisabled}>
+            {COSCENE_VIZ_DATA_BASE_URL}
+          </MenuItem>
+        </SmartSelect>
+        {fixedAvailability === "checking" && (
+          <FormHelperText>{t("manifestStorageSourceChecking")}</FormHelperText>
+        )}
+        {fixedAvailability === "unavailable" && (
+          <FormHelperText>{t("manifestStorageSourceUnavailable")}</FormHelperText>
+        )}
+      </FormControl>
+      {showTips && (
+        <Stack>
+          <Typography color={theme.palette.warning.main}>
+            <Trans
+              t={t}
+              i18nKey="manifestStorageSourceNextEffectiveNotice"
               components={{
                 Link: (
                   <Link

--- a/packages/studio-base/src/components/AppSettingsDialog/settings.tsx
+++ b/packages/studio-base/src/components/AppSettingsDialog/settings.tsx
@@ -17,6 +17,7 @@ import WebIcon from "@mui/icons-material/Web";
 import {
   Autocomplete,
   Checkbox,
+  Chip,
   Divider,
   FormControl,
   FormControlLabel,
@@ -55,6 +56,7 @@ import {
   COSCENE_VIZ_DATA_BASE_URL,
   ManifestStorageSource,
   buildManifestUrl,
+  ensureObjectStorageBaseUrlProtocol,
   manifestExists,
 } from "@foxglove/studio-base/dataSources/manifestStorage";
 import { useAppTimeFormat } from "@foxglove/studio-base/hooks";
@@ -847,7 +849,7 @@ export function ManifestStorageSourceSettings(): React.ReactElement | ReactNull 
   const fixedOptionDisabled = fixedAvailability !== "available";
   const defaultStorageLabel =
     objectStorageBaseUrl != undefined && objectStorageBaseUrl.length > 0
-      ? t("manifestStorageSourceDefault", { url: objectStorageBaseUrl })
+      ? ensureObjectStorageBaseUrlProtocol(objectStorageBaseUrl)
       : "OBJECT_STORAGE_BASE_URL";
 
   const onChangeManifestStorageSource = useCallback(
@@ -882,7 +884,14 @@ export function ManifestStorageSourceSettings(): React.ReactElement | ReactNull 
           fullWidth
           onChange={onChangeManifestStorageSource}
         >
-          <MenuItem value={ManifestStorageSource.Default}>{defaultStorageLabel}</MenuItem>
+          <MenuItem value={ManifestStorageSource.Default}>
+            <Stack direction="row" alignItems="center" gap={1} fullWidth zeroMinWidth>
+              <Typography variant="body2" noWrap>
+                {defaultStorageLabel}
+              </Typography>
+              <Chip size="small" label={t("manifestStorageSourceDefaultTag")} />
+            </Stack>
+          </MenuItem>
           <MenuItem value={ManifestStorageSource.CoSceneVizData} disabled={fixedOptionDisabled}>
             {COSCENE_VIZ_DATA_BASE_URL}
           </MenuItem>

--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -302,6 +302,9 @@ export default function PlayerManager(
   const [retentionWindowMs] = useAppConfigurationValue<number>(AppSetting.RETENTION_WINDOW_MS);
   const [requestWindow] = useAppConfigurationValue<number>(AppSetting.REQUEST_WINDOW);
   const [readAheadDuration] = useAppConfigurationValue<number>(AppSetting.READ_AHEAD_DURATION);
+  const [manifestStorageSource] = useAppConfigurationValue<string>(
+    AppSetting.MANIFEST_STORAGE_SOURCE,
+  );
   const [autoConnectToLan] = useAppConfigurationValue<boolean>(AppSetting.AUTO_CONNECT_LAN);
 
   const positiveRequestWindow =
@@ -409,6 +412,7 @@ export default function PlayerManager(
                 positiveReadAheadDuration != undefined
                   ? { sec: positiveReadAheadDuration, nsec: 0 }
                   : undefined,
+              manifestStorageSource,
               autoConnectToLan,
               checkOutboundTrafficEntitlement,
             });
@@ -558,6 +562,7 @@ export default function PlayerManager(
       entitlement,
       entitlementDialog,
       retentionWindowMs,
+      manifestStorageSource,
       autoConnectToLan,
       addRecent,
       t,

--- a/packages/studio-base/src/context/PlayerSelectionContext.ts
+++ b/packages/studio-base/src/context/PlayerSelectionContext.ts
@@ -25,6 +25,7 @@ export type DataSourceFactoryInitializeArgs = {
   confirm?: confirmTypes;
   requestWindow?: Time;
   readAheadDuration?: Time;
+  manifestStorageSource?: string;
   autoConnectToLan?: boolean;
   checkOutboundTrafficEntitlement?: () => boolean;
 } & PersistentCacheSourceInitializeArgs;

--- a/packages/studio-base/src/dataSources/CoSceneDataPlatformDataSourceFactory.test.ts
+++ b/packages/studio-base/src/dataSources/CoSceneDataPlatformDataSourceFactory.test.ts
@@ -5,9 +5,50 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { buildManifestUrl } from "./CoSceneDataPlatformDataSourceFactory";
+import {
+  IterablePlayer,
+  WorkerIterableSource,
+  WorkerSerializedIterableSource,
+} from "@foxglove/studio-base/players/IterablePlayer";
+
+import CoSceneDataPlatformDataSourceFactory, {
+  buildManifestUrl,
+} from "./CoSceneDataPlatformDataSourceFactory";
+import {
+  COSCENE_VIZ_DATA_BASE_URL,
+  ManifestStorageSource,
+  getManifestStorageBaseUrl,
+} from "./manifestStorage";
+
+const mockGetAppConfig = jest.fn();
+
+jest.mock("@foxglove/studio-base/util/appConfig", () => ({
+  getAppConfig: () => mockGetAppConfig(),
+  getDomainConfig: () => ({ webDomain: "dev.coscene.cn" }),
+}));
+
+jest.mock("@foxglove/studio-base/players/IterablePlayer", () => ({
+  IterablePlayer: jest.fn().mockImplementation((options: unknown) => ({ options })),
+  WorkerIterableSource: jest.fn().mockImplementation((options: unknown) => ({ options })),
+  WorkerSerializedIterableSource: jest.fn().mockImplementation((options: unknown) => ({
+    options,
+  })),
+}));
+
+const mockIterablePlayer = IterablePlayer as unknown as jest.Mock;
+const mockWorkerIterableSource = WorkerIterableSource as unknown as jest.Mock;
+const mockWorkerSerializedIterableSource = WorkerSerializedIterableSource as unknown as jest.Mock;
 
 describe("buildManifestUrl", () => {
+  beforeEach(() => {
+    mockGetAppConfig.mockReturnValue({
+      OBJECT_STORAGE_BASE_URL: "mcap.dev.coscene.cn",
+    });
+    mockIterablePlayer.mockClear();
+    mockWorkerIterableSource.mockClear();
+    mockWorkerSerializedIterableSource.mockClear();
+  });
+
   it("adds https protocol to object storage base URL without protocol", () => {
     expect(buildManifestUrl("mcap.dev.coscene.cn", "project-id", "record-id")).toBe(
       "https://mcap.dev.coscene.cn/projects/project-id/records/record-id/manifest.json",
@@ -27,5 +68,89 @@ describe("buildManifestUrl", () => {
     expect(buildManifestUrl("mcap.dev.coscene.cn///", "project-id", "record-id")).toBe(
       "https://mcap.dev.coscene.cn/projects/project-id/records/record-id/manifest.json",
     );
+  });
+
+  it("builds the fixed coscene viz data manifest URL", () => {
+    expect(buildManifestUrl(COSCENE_VIZ_DATA_BASE_URL, "project-id", "record-id")).toBe(
+      "https://coscene-viz-data.coscene.io/projects/project-id/records/record-id/manifest.json",
+    );
+  });
+
+  it("resolves manifest storage selection to the configured base URL", () => {
+    expect(getManifestStorageBaseUrl(ManifestStorageSource.Default, "configured.example.com")).toBe(
+      "configured.example.com",
+    );
+    expect(
+      getManifestStorageBaseUrl(ManifestStorageSource.CoSceneVizData, "configured.example.com"),
+    ).toBe(COSCENE_VIZ_DATA_BASE_URL);
+    expect(getManifestStorageBaseUrl(undefined, "configured.example.com")).toBe(
+      "configured.example.com",
+    );
+  });
+});
+
+describe("CoSceneDataPlatformDataSourceFactory manifest storage selection", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    mockGetAppConfig.mockReturnValue({
+      OBJECT_STORAGE_BASE_URL: "default-storage.example.com",
+    });
+    global.fetch = jest.fn().mockResolvedValue({ ok: true } as Response);
+    mockIterablePlayer.mockClear();
+    mockWorkerIterableSource.mockClear();
+    mockWorkerSerializedIterableSource.mockClear();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  async function initializeFactory(manifestStorageSource?: string) {
+    const factory = new CoSceneDataPlatformDataSourceFactory();
+    return await factory.initialize({
+      metricsCollector: undefined as never,
+      consoleApi: {
+        getApiBaseInfo: () => ({ projectId: "project-id", recordId: "record-id" }),
+        getAuthHeader: () => "Bearer token",
+        getBaseUrl: () => "https://api.example.com",
+        getBffUrl: () => "https://bff.example.com",
+      } as never,
+      manifestStorageSource,
+    });
+  }
+
+  it("uses OBJECT_STORAGE_BASE_URL by default when checking for a manifest", async () => {
+    await initializeFactory();
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://default-storage.example.com/projects/project-id/records/record-id/manifest.json",
+      { method: "HEAD" },
+    );
+    expect(mockWorkerSerializedIterableSource).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the fixed coscene viz data URL when selected", async () => {
+    await initializeFactory(ManifestStorageSource.CoSceneVizData);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://coscene-viz-data.coscene.io/projects/project-id/records/record-id/manifest.json",
+      { method: "HEAD" },
+    );
+    expect(mockWorkerSerializedIterableSource).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the legacy data-platform player when the selected fixed manifest is unavailable", async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false } as Response);
+
+    await initializeFactory(ManifestStorageSource.CoSceneVizData);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).not.toHaveBeenCalledWith(
+      "https://default-storage.example.com/projects/project-id/records/record-id/manifest.json",
+      { method: "HEAD" },
+    );
+    expect(mockWorkerSerializedIterableSource).not.toHaveBeenCalled();
+    expect(mockWorkerIterableSource).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/studio-base/src/dataSources/CoSceneDataPlatformDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/CoSceneDataPlatformDataSourceFactory.ts
@@ -24,6 +24,10 @@ import { Player } from "@foxglove/studio-base/players/types";
 import { getAppConfig, getDomainConfig } from "@foxglove/studio-base/util/appConfig";
 import { parseAppURLState } from "@foxglove/studio-base/util/appURLState";
 
+import { buildManifestUrl, getManifestStorageBaseUrl, manifestExists } from "./manifestStorage";
+
+export { buildManifestUrl } from "./manifestStorage";
+
 const RAW_PROFILE = "raw";
 const SHARD_MODE_PARAM = "shardMode";
 const SHARD_MODE_MANIFEST = "manifest";
@@ -59,33 +63,6 @@ function sortJsonValue(value: unknown): unknown {
 
 function stableJsonStringify(value: unknown): string {
   return JSON.stringify(sortJsonValue(value)) ?? "";
-}
-
-function ensureObjectStorageBaseUrlProtocol(objectStorageBaseUrl: string): string {
-  if (/^https?:\/\//i.test(objectStorageBaseUrl)) {
-    return objectStorageBaseUrl;
-  }
-  return `https://${objectStorageBaseUrl}`;
-}
-
-export function buildManifestUrl(
-  objectStorageBaseUrl: string,
-  projectId: string,
-  recordId: string,
-): string {
-  return `${ensureObjectStorageBaseUrlProtocol(objectStorageBaseUrl).replace(
-    /\/+$/,
-    "",
-  )}/projects/${projectId}/records/${recordId}/manifest.json`;
-}
-
-async function manifestExists(manifestUrl: string): Promise<boolean> {
-  try {
-    const response = await fetch(manifestUrl, { method: "HEAD" });
-    return response.ok;
-  } catch {
-    return false;
-  }
 }
 
 class CoSceneDataPlatformDataSourceFactory implements IDataSourceFactory {
@@ -147,7 +124,10 @@ class CoSceneDataPlatformDataSourceFactory implements IDataSourceFactory {
       return;
     }
 
-    const objectStorageBaseUrl = getAppConfig().OBJECT_STORAGE_BASE_URL;
+    const objectStorageBaseUrl = getManifestStorageBaseUrl(
+      args.manifestStorageSource,
+      getAppConfig().OBJECT_STORAGE_BASE_URL,
+    );
     const { projectId, recordId } = consoleApi.getApiBaseInfo();
     if (!objectStorageBaseUrl || !projectId || !recordId) {
       return this.#createDataPlatformPlayer(args);

--- a/packages/studio-base/src/dataSources/manifestStorage.ts
+++ b/packages/studio-base/src/dataSources/manifestStorage.ts
@@ -12,7 +12,7 @@ export enum ManifestStorageSource {
 
 export const COSCENE_VIZ_DATA_BASE_URL = "https://coscene-viz-data.coscene.io";
 
-function ensureObjectStorageBaseUrlProtocol(objectStorageBaseUrl: string): string {
+export function ensureObjectStorageBaseUrlProtocol(objectStorageBaseUrl: string): string {
   if (/^https?:\/\//i.test(objectStorageBaseUrl)) {
     return objectStorageBaseUrl;
   }

--- a/packages/studio-base/src/dataSources/manifestStorage.ts
+++ b/packages/studio-base/src/dataSources/manifestStorage.ts
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export enum ManifestStorageSource {
+  Default = "default",
+  CoSceneVizData = "cosceneVizData",
+}
+
+export const COSCENE_VIZ_DATA_BASE_URL = "https://coscene-viz-data.coscene.io";
+
+function ensureObjectStorageBaseUrlProtocol(objectStorageBaseUrl: string): string {
+  if (/^https?:\/\//i.test(objectStorageBaseUrl)) {
+    return objectStorageBaseUrl;
+  }
+  return `https://${objectStorageBaseUrl}`;
+}
+
+export function buildManifestUrl(
+  objectStorageBaseUrl: string,
+  projectId: string,
+  recordId: string,
+): string {
+  return `${ensureObjectStorageBaseUrlProtocol(objectStorageBaseUrl).replace(
+    /\/+$/,
+    "",
+  )}/projects/${projectId}/records/${recordId}/manifest.json`;
+}
+
+export function getManifestStorageBaseUrl(
+  manifestStorageSource: string | undefined,
+  defaultObjectStorageBaseUrl: string | undefined,
+): string | undefined {
+  if (manifestStorageSource === ManifestStorageSource.CoSceneVizData) {
+    return COSCENE_VIZ_DATA_BASE_URL;
+  }
+  return defaultObjectStorageBaseUrl;
+}
+
+export async function manifestExists(manifestUrl: string): Promise<boolean> {
+  try {
+    const response = await fetch(manifestUrl, { method: "HEAD" });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}

--- a/packages/studio-base/src/i18n/en/appSettings.ts
+++ b/packages/studio-base/src/i18n/en/appSettings.ts
@@ -69,6 +69,14 @@ export const appSettings = {
     "Sets how many seconds of data the player preloads ahead of playback. Higher values smooth playback but use more memory.",
   readAheadDurationNextEffectiveNotice:
     "Setting updated, will take effect the next time visualization starts. <Link>Refresh now</Link>",
+  manifestStorageSource: "Manifest and MCAP request host",
+  manifestStorageSourceDescription:
+    "Selects the host used to fetch manifest files and relative MCAP shard files for data-platform playback.",
+  manifestStorageSourceDefault: "OBJECT_STORAGE_BASE_URL ({{url}})",
+  manifestStorageSourceChecking: "Checking whether this address can play the current file.",
+  manifestStorageSourceUnavailable: "This address cannot play the current file.",
+  manifestStorageSourceNextEffectiveNotice:
+    "Setting updated, will take effect the next time visualization starts. <Link>Refresh now</Link>",
   autoConnectToLan: "Real-time visualization auto connect to LAN",
   autoConnectToLanDescription:
     "When detected to be on the same LAN as the device, automatically connect to the LAN address, no need to manually confirm",

--- a/packages/studio-base/src/i18n/en/appSettings.ts
+++ b/packages/studio-base/src/i18n/en/appSettings.ts
@@ -72,7 +72,7 @@ export const appSettings = {
   manifestStorageSource: "Manifest and MCAP request host",
   manifestStorageSourceDescription:
     "Selects the host used to fetch manifest files and relative MCAP shard files for data-platform playback.",
-  manifestStorageSourceDefault: "OBJECT_STORAGE_BASE_URL ({{url}})",
+  manifestStorageSourceDefaultTag: "default",
   manifestStorageSourceChecking: "Checking whether this address can play the current file.",
   manifestStorageSourceUnavailable: "This address cannot play the current file.",
   manifestStorageSourceNextEffectiveNotice:

--- a/packages/studio-base/src/i18n/zh/appSettings.ts
+++ b/packages/studio-base/src/i18n/zh/appSettings.ts
@@ -64,7 +64,7 @@ export const appSettings: Partial<TypeOptions["resources"]["appSettings"]> = {
   manifestStorageSource: "Manifest 和 MCAP 请求地址",
   manifestStorageSourceDescription:
     "选择数据平台回放时拉取 manifest 文件以及相对路径 MCAP 分片文件的地址。",
-  manifestStorageSourceDefault: "OBJECT_STORAGE_BASE_URL（{{url}}）",
+  manifestStorageSourceDefaultTag: "默认",
   manifestStorageSourceChecking: "正在检查该地址是否可播放当前文件。",
   manifestStorageSourceUnavailable: "该地址不可播放当前文件。",
   manifestStorageSourceNextEffectiveNotice:

--- a/packages/studio-base/src/i18n/zh/appSettings.ts
+++ b/packages/studio-base/src/i18n/zh/appSettings.ts
@@ -61,6 +61,14 @@ export const appSettings: Partial<TypeOptions["resources"]["appSettings"]> = {
   readAheadDurationDescription:
     "设置播放器在当前播放位置前预加载的时长。值越大播放更平滑但占用更多内存，值越小则更省内存。",
   readAheadDurationNextEffectiveNotice: "设置已更新，将在下一次可视化时生效 <Link>立即刷新</Link>",
+  manifestStorageSource: "Manifest 和 MCAP 请求地址",
+  manifestStorageSourceDescription:
+    "选择数据平台回放时拉取 manifest 文件以及相对路径 MCAP 分片文件的地址。",
+  manifestStorageSourceDefault: "OBJECT_STORAGE_BASE_URL（{{url}}）",
+  manifestStorageSourceChecking: "正在检查该地址是否可播放当前文件。",
+  manifestStorageSourceUnavailable: "该地址不可播放当前文件。",
+  manifestStorageSourceNextEffectiveNotice:
+    "设置已更新，将在下一次可视化时生效 <Link>立即刷新</Link>",
   autoConnectToLan: "实时可视化自动连接局域网",
   autoConnectToLanDescription: "检测到与设备处于同一局域网时，自动连接局域网地址，无需手动确认",
   isRenderAllTabs: "渲染所有选项卡",


### PR DESCRIPTION
## Summary
- Added a new app setting to choose the manifest and MCAP base host for `coscene-data-platform` playback.
- The settings UI now shows `OBJECT_STORAGE_BASE_URL` and `https://coscene-viz-data.coscene.io`, with the fixed host only shown for data-platform playback and disabled when the current record has no manifest there.
- Wired the selected value through player initialization so the choice is persisted and used on future playback.
- Added shared manifest URL helpers plus English and Chinese copy for the new setting.

## Testing
- Added unit coverage for manifest URL/base selection and factory fallback behavior.
- Added UI coverage for visibility, availability checks, persistence, and refresh prompts.
- Ran focused Jest tests, targeted ESLint, Prettier check, and `git diff --check` successfully.
- `tsc --noEmit` was attempted for `packages/studio-base`, but it is blocked by unrelated existing type errors outside this change.