### PR TITLE
Propagate iterator abort signals through iterable sources

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
@@ -265,7 +265,10 @@ export class BlockLoader {
       const cursor =
         this.#source.getMessageCursor?.({ ...iteratorArgs, abort: this.#abortController.signal }) ??
         new IteratorCursor(
-          this.#source.messageIterator(iteratorArgs),
+          this.#source.messageIterator({
+            ...iteratorArgs,
+            abortSignal: this.#abortController.signal,
+          }),
           this.#abortController.signal,
         );
 

--- a/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.test.ts
@@ -42,6 +42,10 @@ function waiter(count: number) {
   };
 }
 
+function delay(ms: number): Promise<"timeout"> {
+  return new Promise((resolve) => setTimeout(() => resolve("timeout"), ms));
+}
+
 class TestSource implements IIterableSource {
   public async initialize(): Promise<Initalization> {
     return {
@@ -126,6 +130,69 @@ describe("BufferedIterableSource", () => {
     });
 
     expect(bufferedSource.loadedRanges()).toEqual([{ start: 0, end: 1 }]);
+  });
+
+  it("aborts the pending source iterator when the buffered iterator is returned", async () => {
+    const source = new TestSource();
+    const bufferedSource = new BufferedIterableSource(source);
+
+    await bufferedSource.initialize();
+
+    const sourceStarted = waiter(1);
+
+    source.messageIterator = async function* messageIterator(
+      args: MessageIteratorArgs & { abortSignal?: AbortSignal },
+    ): AsyncIterableIterator<Readonly<IteratorResult>> {
+      sourceStarted.notify();
+      await new Promise<void>((resolve) => {
+        args.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+      });
+    };
+
+    const messageIterator = bufferedSource.messageIterator({
+      topics: mockTopicSelection("a"),
+      start: { sec: 0, nsec: 0 },
+    });
+    await sourceStarted.wait();
+
+    const result = await Promise.race([
+      messageIterator.return?.().then(() => "returned" as const),
+      delay(50),
+    ]);
+
+    expect(result).toBe("returned");
+  });
+
+  it("aborts the pending source iterator when the producer is stopped", async () => {
+    const source = new TestSource();
+    const bufferedSource = new BufferedIterableSource(source);
+
+    await bufferedSource.initialize();
+
+    const sourceStarted = waiter(1);
+
+    source.messageIterator = async function* messageIterator(
+      args: MessageIteratorArgs & { abortSignal?: AbortSignal },
+    ): AsyncIterableIterator<Readonly<IteratorResult>> {
+      sourceStarted.notify();
+      await new Promise<void>((resolve) => {
+        args.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+      });
+    };
+
+    const messageIterator = bufferedSource.messageIterator({
+      topics: mockTopicSelection("a"),
+      start: { sec: 0, nsec: 0 },
+    });
+    await sourceStarted.wait();
+
+    const result = await Promise.race([
+      bufferedSource.stopProducer().then(() => "stopped" as const),
+      delay(50),
+    ]);
+
+    expect(result).toBe("stopped");
+    await messageIterator.return?.();
   });
 
   it("should produce messages after buffering is complete", async () => {
@@ -419,12 +486,11 @@ describe("BufferedIterableSource", () => {
     source.messageIterator = async function* messageIterator(
       args: MessageIteratorArgs,
     ): AsyncIterableIterator<Readonly<IteratorResult>> {
-      expect(args).toEqual({
-        topics: mockTopicSelection("a"),
-        start: { sec: 0, nsec: 0 },
-        end: { sec: 10, nsec: 0 },
-        consumptionType: "partial",
-      });
+      expect(args.topics).toEqual(mockTopicSelection("a"));
+      expect(args.start).toEqual({ sec: 0, nsec: 0 });
+      expect(args.end).toEqual({ sec: 10, nsec: 0 });
+      expect(args.consumptionType).toEqual("partial");
+      expect(args.abortSignal).toBeInstanceOf(AbortSignal);
       messageIteratorCount += 1;
 
       for (let i = 0; i < 8; ++i) {
@@ -483,12 +549,11 @@ describe("BufferedIterableSource", () => {
     source.messageIterator = async function* messageIterator(
       args: MessageIteratorArgs,
     ): AsyncIterableIterator<Readonly<IteratorResult>> {
-      expect(args).toEqual({
-        topics: mockTopicSelection("a"),
-        start: { sec: 0, nsec: 0 },
-        end: { sec: 10, nsec: 0 },
-        consumptionType: "partial",
-      });
+      expect(args.topics).toEqual(mockTopicSelection("a"));
+      expect(args.start).toEqual({ sec: 0, nsec: 0 });
+      expect(args.end).toEqual({ sec: 10, nsec: 0 });
+      expect(args.consumptionType).toEqual("partial");
+      expect(args.abortSignal).toBeInstanceOf(AbortSignal);
       messageIteratorCount += 1;
 
       for (let i = 0; i < 8; ++i) {
@@ -598,12 +663,11 @@ describe("BufferedIterableSource", () => {
     source.messageIterator = async function* messageIterator(
       args: MessageIteratorArgs,
     ): AsyncIterableIterator<Readonly<IteratorResult>> {
-      expect(args).toEqual({
-        topics: mockTopicSelection("a"),
-        start: { sec: 0, nsec: 0 },
-        end: { sec: 10, nsec: 0 },
-        consumptionType: "partial",
-      });
+      expect(args.topics).toEqual(mockTopicSelection("a"));
+      expect(args.start).toEqual({ sec: 0, nsec: 0 });
+      expect(args.end).toEqual({ sec: 10, nsec: 0 });
+      expect(args.consumptionType).toEqual("partial");
+      expect(args.abortSignal).toBeInstanceOf(AbortSignal);
       messageIteratorCount += 1;
 
       for (let i = 0; i < 8; ++i) {
@@ -655,12 +719,11 @@ describe("BufferedIterableSource", () => {
     source.messageIterator = async function* messageIterator(
       args: MessageIteratorArgs,
     ): AsyncIterableIterator<Readonly<IteratorResult>> {
-      expect(args).toEqual({
-        topics: mockTopicSelection("a"),
-        start: { sec: 0, nsec: 0 },
-        end: { sec: 10, nsec: 0 },
-        consumptionType: "partial",
-      });
+      expect(args.topics).toEqual(mockTopicSelection("a"));
+      expect(args.start).toEqual({ sec: 0, nsec: 0 });
+      expect(args.end).toEqual({ sec: 10, nsec: 0 });
+      expect(args.consumptionType).toEqual("partial");
+      expect(args.abortSignal).toBeInstanceOf(AbortSignal);
       messageIteratorCount += 1;
 
       for (let i = 0; i < 8; ++i) {

--- a/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.test.ts
@@ -6,6 +6,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import * as _ from "lodash-es";
+import race from "race-as-promised";
 
 import { MessageEvent } from "@foxglove/studio";
 import { mockTopicSelection } from "@foxglove/studio-base/test/mocks/mockTopicSelection";
@@ -42,8 +43,11 @@ function waiter(count: number) {
   };
 }
 
-function delay(ms: number): Promise<"timeout"> {
-  return new Promise((resolve) => setTimeout(() => resolve("timeout"), ms));
+async function delay(ms: number): Promise<"timeout"> {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+  return "timeout";
 }
 
 class TestSource implements IIterableSource {
@@ -62,7 +66,9 @@ class TestSource implements IIterableSource {
 
   public async *messageIterator(
     _args: MessageIteratorArgs,
-  ): AsyncIterableIterator<Readonly<IteratorResult>> {}
+  ): AsyncIterableIterator<Readonly<IteratorResult>> {
+    yield* [];
+  }
 
   public async getBackfillMessages(_args: GetBackfillMessagesArgs): Promise<MessageEvent[]> {
     return [];
@@ -145,8 +151,15 @@ describe("BufferedIterableSource", () => {
     ): AsyncIterableIterator<Readonly<IteratorResult>> {
       sourceStarted.notify();
       await new Promise<void>((resolve) => {
-        args.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+        args.abortSignal?.addEventListener(
+          "abort",
+          () => {
+            resolve();
+          },
+          { once: true },
+        );
       });
+      yield* [];
     };
 
     const messageIterator = bufferedSource.messageIterator({
@@ -155,7 +168,7 @@ describe("BufferedIterableSource", () => {
     });
     await sourceStarted.wait();
 
-    const result = await Promise.race([
+    const result = await race([
       messageIterator.return?.().then(() => "returned" as const),
       delay(50),
     ]);
@@ -176,8 +189,15 @@ describe("BufferedIterableSource", () => {
     ): AsyncIterableIterator<Readonly<IteratorResult>> {
       sourceStarted.notify();
       await new Promise<void>((resolve) => {
-        args.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+        args.abortSignal?.addEventListener(
+          "abort",
+          () => {
+            resolve();
+          },
+          { once: true },
+        );
       });
+      yield* [];
     };
 
     const messageIterator = bufferedSource.messageIterator({
@@ -186,7 +206,7 @@ describe("BufferedIterableSource", () => {
     });
     await sourceStarted.wait();
 
-    const result = await Promise.race([
+    const result = await race([
       bufferedSource.stopProducer().then(() => "stopped" as const),
       delay(50),
     ]);

--- a/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
@@ -85,6 +85,7 @@ class BufferedIterableSource<MessageType = unknown>
   // The promise for the current producer. The message generator starts a producer and awaits the
   // producer before exiting.
   #producer?: Promise<void>;
+  #producerAbortController?: AbortController;
 
   #initResult?: Initalization;
 
@@ -137,12 +138,28 @@ class BufferedIterableSource<MessageType = unknown>
     // the start of the array.
     this.#cache.clear();
 
+    const producerAbortController = new AbortController();
+    this.#producerAbortController = producerAbortController;
+    const abortProducer = () => {
+      this.#aborted = true;
+      producerAbortController.abort();
+      this.#readSignal.notifyAll();
+      this.#writeSignal.notifyAll();
+    };
+
+    if (args.abortSignal?.aborted === true) {
+      abortProducer();
+    } else {
+      args.abortSignal?.addEventListener("abort", abortProducer, { once: true });
+    }
+
     try {
       const sourceIterator = this.#source.messageIterator({
         topics: args.topics,
         start: this.#readHead,
         consumptionType: "partial",
         fetchCompleteTopicState: args.fetchCompleteTopicState,
+        abortSignal: producerAbortController.signal,
       });
 
       // Messages are read from the source until reaching the readUntil time. Then we wait for the read head
@@ -230,6 +247,10 @@ class BufferedIterableSource<MessageType = unknown>
         await this.#writeSignal.wait();
       }
     } finally {
+      args.abortSignal?.removeEventListener("abort", abortProducer);
+      if (this.#producerAbortController === producerAbortController) {
+        this.#producerAbortController = undefined;
+      }
       // Indicate to the consumer that it can try reading again
       this.#readSignal.notifyAll();
       this.#readDone = true;
@@ -249,6 +270,8 @@ class BufferedIterableSource<MessageType = unknown>
   public async stopProducer(): Promise<void> {
     log.debug("Stopping producer");
     this.#aborted = true;
+    this.#producerAbortController?.abort();
+    this.#readSignal.notifyAll();
     this.#writeSignal.notifyAll();
     await this.#producer;
     this.#producer = undefined;

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
@@ -639,6 +639,7 @@ class CachingIterableSource<MessageType = unknown>
     topics: TopicSelection;
     consumptionType: MessageIteratorArgs["consumptionType"];
     fetchCompleteTopicState: MessageIteratorArgs["fetchCompleteTopicState"];
+    abortSignal: MessageIteratorArgs["abortSignal"];
     writeSpill: boolean;
   }): AsyncIterableIterator<Readonly<IteratorResult<MessageType>>> {
     const sourceMessageIterator = this.#source.messageIterator({
@@ -647,6 +648,7 @@ class CachingIterableSource<MessageType = unknown>
       end: args.end,
       consumptionType: args.consumptionType,
       fetchCompleteTopicState: args.fetchCompleteTopicState,
+      abortSignal: args.abortSignal,
     });
 
     // The cache is indexed on time, but iterator results that are problems might not have a time.
@@ -832,6 +834,7 @@ class CachingIterableSource<MessageType = unknown>
         end: maxEnd,
         consumptionType: args.consumptionType,
         fetchCompleteTopicState: args.fetchCompleteTopicState,
+        abortSignal: args.abortSignal,
       });
       return;
     }
@@ -934,6 +937,7 @@ class CachingIterableSource<MessageType = unknown>
           topics: this.#cachedTopics,
           consumptionType: args.consumptionType,
           fetchCompleteTopicState: args.fetchCompleteTopicState,
+          abortSignal: args.abortSignal,
           writeSpill: false,
         });
         readHead = add(sourceReadEnd, { sec: 0, nsec: 1 });
@@ -977,6 +981,7 @@ class CachingIterableSource<MessageType = unknown>
               topics: this.#cachedTopics,
               consumptionType: args.consumptionType,
               fetchCompleteTopicState: args.fetchCompleteTopicState,
+              abortSignal: args.abortSignal,
               writeSpill: true,
             });
           }
@@ -1001,6 +1006,7 @@ class CachingIterableSource<MessageType = unknown>
           topics: this.#cachedTopics,
           consumptionType: args.consumptionType,
           fetchCompleteTopicState: args.fetchCompleteTopicState,
+          abortSignal: args.abortSignal,
           writeSpill: true,
         });
         segmentStart = add(segmentEnd, { sec: 0, nsec: 1 });

--- a/packages/studio-base/src/players/IterablePlayer/IIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IIterableSource.ts
@@ -78,6 +78,12 @@ export type MessageIteratorArgs = {
    * return map message in every time, we need this param to notify the backend help us find last message in target time`s topic
    */
   fetchCompleteTopicState?: "complete" | "incremental";
+
+  /**
+   * Allows a caller to cancel an in-flight iterator read. This is especially important for
+   * streaming sources whose next result may be blocked on network I/O.
+   */
+  abortSignal?: AbortSignal;
 };
 
 /**

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
@@ -878,22 +878,24 @@ describe("IterablePlayer", () => {
 
     expect(messageIteratorSpy.mock.calls).toEqual([
       [
-        {
+        expect.objectContaining({
           start: { sec: 0, nsec: 99000001 },
           end: { sec: 1, nsec: 0 },
           topics: mockTopicSelection("foo"),
           consumptionType: "partial",
           fetchCompleteTopicState: undefined,
-        },
+          abortSignal: expect.any(AbortSignal),
+        }),
       ],
       [
-        {
+        expect.objectContaining({
           start: { sec: 0, nsec: 99000001 },
           end: { sec: 1, nsec: 0 },
           topics: mockTopicSelection("foo", "bar"),
           consumptionType: "partial",
           fetchCompleteTopicState: undefined,
-        },
+          abortSignal: expect.any(AbortSignal),
+        }),
       ],
     ]);
 
@@ -925,13 +927,14 @@ describe("IterablePlayer", () => {
 
     expect(messageIteratorSpy.mock.calls).toEqual([
       [
-        {
+        expect.objectContaining({
           start: { sec: 0, nsec: 99000001 },
           end: { sec: 1, nsec: 0 },
           topics: mockTopicSelection("foo"),
           consumptionType: "partial",
           fetchCompleteTopicState: undefined,
-        },
+          abortSignal: expect.any(AbortSignal),
+        }),
       ],
     ]);
 

--- a/packages/studio-base/src/players/IterablePlayer/WorkerIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/WorkerIterableSource.ts
@@ -106,8 +106,11 @@ export class WorkerIterableSource implements IDeserializedIterableSource {
     // An AbortSignal is not clonable, so we remove it from the args and send it as a separate argumet
     // to our worker getBackfillMessages call. Our installed Comlink handler for AbortSignal handles
     // making the abort signal available within the worker.
-    const { abort, ...rest } = args;
-    const messageCursorPromise = this.#sourceWorkerRemote.getMessageCursor(rest, abort);
+    const { abort, abortSignal, ...rest } = args;
+    const messageCursorPromise = this.#sourceWorkerRemote.getMessageCursor(
+      rest,
+      abort ?? abortSignal,
+    );
 
     const cursor: IMessageCursor = {
       async next() {

--- a/packages/studio-base/src/players/IterablePlayer/WorkerIterableSourceWorker.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/WorkerIterableSourceWorker.test.ts
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { MessageEvent } from "@foxglove/studio";
+import { mockTopicSelection } from "@foxglove/studio-base/test/mocks/mockTopicSelection";
+
+import {
+  GetBackfillMessagesArgs,
+  IIterableSource,
+  ISerializedIterableSource,
+  Initalization,
+  IteratorResult,
+  MessageIteratorArgs,
+} from "./IIterableSource";
+import { WorkerIterableSourceWorker } from "./WorkerIterableSourceWorker";
+import { WorkerSerializedIterableSourceWorker } from "./WorkerSerializedIterableSourceWorker";
+
+class TestSource implements IIterableSource {
+  public messageIteratorArgs: MessageIteratorArgs | undefined;
+
+  public async initialize(): Promise<Initalization> {
+    return {
+      start: { sec: 0, nsec: 0 },
+      end: { sec: 1, nsec: 0 },
+      topics: [],
+      topicStats: new Map(),
+      profile: undefined,
+      problems: [],
+      datatypes: new Map(),
+      publishersByTopic: new Map(),
+    };
+  }
+
+  public async *messageIterator(
+    args: MessageIteratorArgs,
+  ): AsyncIterableIterator<Readonly<IteratorResult>> {
+    this.messageIteratorArgs = args;
+  }
+
+  public async getBackfillMessages(_args: GetBackfillMessagesArgs): Promise<MessageEvent[]> {
+    return [];
+  }
+}
+
+class TestSerializedSource implements ISerializedIterableSource {
+  public readonly sourceType = "serialized";
+  public messageIteratorArgs: MessageIteratorArgs | undefined;
+
+  public async initialize(): Promise<Initalization> {
+    return {
+      start: { sec: 0, nsec: 0 },
+      end: { sec: 1, nsec: 0 },
+      topics: [],
+      topicStats: new Map(),
+      profile: undefined,
+      problems: [],
+      datatypes: new Map(),
+      publishersByTopic: new Map(),
+    };
+  }
+
+  public async *messageIterator(
+    args: MessageIteratorArgs,
+  ): AsyncIterableIterator<Readonly<IteratorResult<Uint8Array>>> {
+    this.messageIteratorArgs = args;
+  }
+
+  public async getBackfillMessages(
+    _args: GetBackfillMessagesArgs,
+  ): Promise<MessageEvent<Uint8Array>[]> {
+    return [];
+  }
+}
+
+describe("WorkerIterableSourceWorker", () => {
+  it("passes the cursor abort signal to the source message iterator args", async () => {
+    const source = new TestSource();
+    const worker = new WorkerIterableSourceWorker(source);
+    const abortController = new AbortController();
+
+    const cursor = worker.getMessageCursor(
+      {
+        topics: mockTopicSelection("a"),
+        start: { sec: 0, nsec: 0 },
+      },
+      abortController.signal,
+    );
+    await cursor.next();
+
+    expect(source.messageIteratorArgs?.abortSignal).toBe(abortController.signal);
+  });
+});
+
+describe("WorkerSerializedIterableSourceWorker", () => {
+  it("passes the cursor abort signal to the serialized source message iterator args", async () => {
+    const source = new TestSerializedSource();
+    const worker = new WorkerSerializedIterableSourceWorker(source);
+    const abortController = new AbortController();
+
+    const cursor = worker.getMessageCursor(
+      {
+        topics: mockTopicSelection("a"),
+        start: { sec: 0, nsec: 0 },
+      },
+      abortController.signal,
+    );
+    await cursor.next();
+
+    expect(source.messageIteratorArgs?.abortSignal).toBe(abortController.signal);
+  });
+});

--- a/packages/studio-base/src/players/IterablePlayer/WorkerIterableSourceWorker.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/WorkerIterableSourceWorker.test.ts
@@ -39,6 +39,7 @@ class TestSource implements IIterableSource {
     args: MessageIteratorArgs,
   ): AsyncIterableIterator<Readonly<IteratorResult>> {
     this.messageIteratorArgs = args;
+    yield* [];
   }
 
   public async getBackfillMessages(_args: GetBackfillMessagesArgs): Promise<MessageEvent[]> {
@@ -67,6 +68,7 @@ class TestSerializedSource implements ISerializedIterableSource {
     args: MessageIteratorArgs,
   ): AsyncIterableIterator<Readonly<IteratorResult<Uint8Array>>> {
     this.messageIteratorArgs = args;
+    yield* [];
   }
 
   public async getBackfillMessages(

--- a/packages/studio-base/src/players/IterablePlayer/WorkerIterableSourceWorker.ts
+++ b/packages/studio-base/src/players/IterablePlayer/WorkerIterableSourceWorker.ts
@@ -50,10 +50,10 @@ export class WorkerIterableSourceWorker implements IIterableSource {
   }
 
   public getMessageCursor(
-    args: Omit<Immutable<MessageIteratorArgs>, "abort">,
+    args: Omit<Immutable<MessageIteratorArgs>, "abortSignal">,
     abort?: AbortSignal,
   ): IMessageCursor & Comlink.ProxyMarked {
-    const iter = this._source.messageIterator(args);
+    const iter = this._source.messageIterator({ ...args, abortSignal: abort });
     const cursor = new IteratorCursor(iter, abort);
     return Comlink.proxy(cursor);
   }

--- a/packages/studio-base/src/players/IterablePlayer/WorkerSerializedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/WorkerSerializedIterableSource.ts
@@ -105,8 +105,11 @@ export class WorkerSerializedIterableSource implements ISerializedIterableSource
     // An AbortSignal is not clonable, so we remove it from the args and send it as a separate argumet
     // to our worker getBackfillMessages call. Our installed Comlink handler for AbortSignal handles
     // making the abort signal available within the worker.
-    const { abort, ...rest } = args;
-    const messageCursorPromise = this.#sourceWorkerRemote.getMessageCursor(rest, abort);
+    const { abort, abortSignal, ...rest } = args;
+    const messageCursorPromise = this.#sourceWorkerRemote.getMessageCursor(
+      rest,
+      abort ?? abortSignal,
+    );
 
     const cursor: IMessageCursor<Uint8Array> = {
       async next() {

--- a/packages/studio-base/src/players/IterablePlayer/WorkerSerializedIterableSourceWorker.ts
+++ b/packages/studio-base/src/players/IterablePlayer/WorkerSerializedIterableSourceWorker.ts
@@ -56,10 +56,10 @@ export class WorkerSerializedIterableSourceWorker implements ISerializedIterable
   }
 
   public getMessageCursor(
-    args: Omit<Immutable<MessageIteratorArgs>, "abort">,
+    args: Omit<Immutable<MessageIteratorArgs>, "abortSignal">,
     abort?: AbortSignal,
   ): IMessageCursor<Uint8Array> & Comlink.ProxyMarked {
-    const iter = this.#source.messageIterator(args);
+    const iter = this.#source.messageIterator({ ...args, abortSignal: abort });
     const cursor = new ComlinkTransferIteratorCursor(new IteratorCursor<Uint8Array>(iter, abort));
     return Comlink.proxy(cursor);
   }

--- a/packages/studio-base/src/players/IterablePlayer/coScene-data-platform/DataPlatformIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/coScene-data-platform/DataPlatformIterableSource.test.ts
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { mockTopicSelection } from "@foxglove/studio-base/test/mocks/mockTopicSelection";
+
+import {
+  DataPlatformInterableSourceConsoleApi,
+  DataPlatformIterableSource,
+} from "./DataPlatformIterableSource";
+
+function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  return new Promise((resolve, reject) => {
+    const check = () => {
+      if (predicate()) {
+        resolve();
+        return;
+      }
+      if (Date.now() > deadline) {
+        reject(new Error("Timed out waiting for predicate"));
+        return;
+      }
+      setTimeout(check, 10);
+    };
+    check();
+  });
+}
+
+function delay(ms: number): Promise<"timeout"> {
+  return new Promise((resolve) => setTimeout(() => resolve("timeout"), ms));
+}
+
+describe("DataPlatformIterableSource", () => {
+  it("aborts the active getStreams request when the iterator abort signal fires", async () => {
+    let getStreamsSignal: AbortSignal | undefined;
+
+    const api: DataPlatformInterableSourceConsoleApi = {
+      async topics() {
+        return {
+          start: "1970-01-01T00:00:00.000Z",
+          end: "1970-01-01T00:00:01.000Z",
+          metaData: [
+            {
+              topic: "/json",
+              encoding: "json",
+              schemaName: "JsonMessage",
+              schemaEncoding: "jsonschema",
+              schema: new TextEncoder().encode(JSON.stringify({ type: "object" })),
+              version: "1",
+            },
+          ],
+        };
+      },
+      async getStreams({ signal }) {
+        getStreamsSignal = signal;
+        return await new Promise<Response>((_resolve, reject) => {
+          signal.addEventListener(
+            "abort",
+            () => reject(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          );
+        });
+      },
+    };
+
+    const source = new DataPlatformIterableSource({
+      api,
+      params: { key: "record-id", projectName: "warehouses/w/projects/p" },
+      requestWindow: { sec: 1, nsec: 0 },
+    });
+    await source.initialize();
+
+    const abortController = new AbortController();
+    const iterator = source.messageIterator({
+      topics: mockTopicSelection("/json"),
+      start: { sec: 0, nsec: 0 },
+      end: { sec: 0, nsec: 0 },
+      consumptionType: "partial",
+      abortSignal: abortController.signal,
+    } as Parameters<DataPlatformIterableSource["messageIterator"]>[0] & {
+      abortSignal: AbortSignal;
+    });
+
+    const nextPromise = iterator.next();
+    await waitFor(() => getStreamsSignal != undefined);
+
+    abortController.abort();
+
+    expect(getStreamsSignal?.aborted).toBe(true);
+    await expect(Promise.race([nextPromise, delay(50)])).resolves.toMatchObject({
+      done: true,
+    });
+  });
+});

--- a/packages/studio-base/src/players/IterablePlayer/coScene-data-platform/DataPlatformIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/coScene-data-platform/DataPlatformIterableSource.test.ts
@@ -5,6 +5,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import race from "race-as-promised";
+
 import { mockTopicSelection } from "@foxglove/studio-base/test/mocks/mockTopicSelection";
 
 import {
@@ -12,26 +14,22 @@ import {
   DataPlatformIterableSource,
 } from "./DataPlatformIterableSource";
 
-function waitFor(predicate: () => boolean): Promise<void> {
+async function waitFor(predicate: () => boolean): Promise<void> {
   const deadline = Date.now() + 1_000;
-  return new Promise((resolve, reject) => {
-    const check = () => {
-      if (predicate()) {
-        resolve();
-        return;
-      }
-      if (Date.now() > deadline) {
-        reject(new Error("Timed out waiting for predicate"));
-        return;
-      }
-      setTimeout(check, 10);
-    };
-    check();
-  });
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    await delay(10);
+  }
+  expect(predicate()).toBe(true);
 }
 
-function delay(ms: number): Promise<"timeout"> {
-  return new Promise((resolve) => setTimeout(() => resolve("timeout"), ms));
+async function delay(ms: number): Promise<"timeout"> {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+  return "timeout";
 }
 
 describe("DataPlatformIterableSource", () => {
@@ -60,7 +58,9 @@ describe("DataPlatformIterableSource", () => {
         return await new Promise<Response>((_resolve, reject) => {
           signal.addEventListener(
             "abort",
-            () => reject(new DOMException("Aborted", "AbortError")),
+            () => {
+              reject(new DOMException("Aborted", "AbortError"));
+            },
             { once: true },
           );
         });
@@ -91,7 +91,7 @@ describe("DataPlatformIterableSource", () => {
     abortController.abort();
 
     expect(getStreamsSignal?.aborted).toBe(true);
-    await expect(Promise.race([nextPromise, delay(50)])).resolves.toMatchObject({
+    await expect(race([nextPromise, delay(50)])).resolves.toMatchObject({
       done: true,
     });
   });

--- a/packages/studio-base/src/players/IterablePlayer/coScene-data-platform/DataPlatformIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/coScene-data-platform/DataPlatformIterableSource.ts
@@ -237,6 +237,7 @@ export class DataPlatformIterableSource implements IIterableSource {
 
       const stream = streamMessages({
         api: this.#consoleApi,
+        signal: args.abortSignal,
         parsedChannelsByTopic,
         params: streamByParams,
       });
@@ -269,6 +270,7 @@ export class DataPlatformIterableSource implements IIterableSource {
 
       const stream = streamMessages({
         api: this.#consoleApi,
+        signal: args.abortSignal,
         parsedChannelsByTopic,
         params: streamByParams,
       });

--- a/packages/studio-base/src/players/IterablePlayer/coScene-data-platform/streamMessages.ts
+++ b/packages/studio-base/src/players/IterablePlayer/coScene-data-platform/streamMessages.ts
@@ -333,7 +333,10 @@ export async function* streamMessages({
     }
   } catch (err) {
     // Capture errors from manually aborting the request via the abort controller.
-    if (err instanceof DOMException && err.message === "The user aborted a request.") {
+    if (
+      err instanceof DOMException &&
+      (err.name === "AbortError" || err.message === "The user aborted a request.")
+    ) {
       return;
     }
     throw err;

--- a/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/ShardManifestIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/ShardManifestIterableSource.ts
@@ -372,7 +372,7 @@ export class ShardManifestIterableSource implements ISerializedIterableSource {
     if (iterators.length === 0) {
       return;
     }
-    yield* mergeShards<Uint8Array>(iterators);
+    yield* mergeShards<Uint8Array>(iterators, args.abortSignal);
   }
 
   public async getBackfillMessages(


### PR DESCRIPTION
## Summary
- Thread `abortSignal` through iterable source and worker cursor paths so in-flight reads can be cancelled consistently.
- Abort buffered producers and stop pending source iterators when cursors are returned or producers are stopped.
- Pass cancellation through the data platform and shard merge paths, and treat standard `AbortError` DOMExceptions as expected cancellation.
- Add tests covering abort propagation across buffered, worker, and data platform iterable sources.

## Testing
- Added unit tests for abort propagation and cancellation behavior in iterable source and worker flows.
- Added a DataPlatform iterable source test that verifies an active `getStreams` request is cancelled when the iterator aborts.
- Not run (not requested).