### PR TITLE
Fix loading-state seek cancellation and progress-bar hit testing

### DIFF
--- a/packages/studio-base/src/components/PlaybackControls/BagsOverlay.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/BagsOverlay.tsx
@@ -21,7 +21,7 @@ import {
 const useStyles = makeStyles()(({ transitions, palette }) => ({
   root: {
     inset: 0,
-    pointerBags: "none",
+    pointerEvents: "none",
     position: "absolute",
     display: "flex",
     alignItems: "center",

--- a/packages/studio-base/src/components/PlaybackControls/PlaybackBarHoverTicks.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackBarHoverTicks.tsx
@@ -109,7 +109,7 @@ function UnmemoizedPlaybackBarHoverTicks(props: Props): React.JSX.Element {
   const displayHoverTime = hoverValue != undefined && hoverValue.componentId !== componentId;
 
   return (
-    <Stack ref={ref} flex="auto">
+    <Stack ref={ref} flex="auto" style={{ pointerEvents: "none" }}>
       {scaleBounds && (
         <HoverBar componentId={componentId} scales={scaleBounds} isPlaybackSeconds>
           <Tooltip

--- a/packages/studio-base/src/components/PlaybackControls/PlaybackBarPointerEvents.test.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/PlaybackBarPointerEvents.test.tsx
@@ -1,0 +1,83 @@
+/** @jest-environment jsdom */
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { render } from "@testing-library/react";
+
+import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
+import AppConfigurationContext from "@foxglove/studio-base/context/AppConfigurationContext";
+import CoScenePlaylistProvider from "@foxglove/studio-base/providers/CoScenePlaylistProvider";
+import TimelineInteractionStateProvider from "@foxglove/studio-base/providers/TimelineInteractionStateProvider";
+import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
+import { makeMockAppConfiguration } from "@foxglove/studio-base/util/makeMockAppConfiguration";
+
+import { BagsOverlay } from "./BagsOverlay";
+import { PlaybackBarHoverTicks } from "./PlaybackBarHoverTicks";
+import { ProgressPlot } from "./ProgressPlot";
+
+function Wrapper({ children }: React.PropsWithChildren): React.JSX.Element {
+  return (
+    <ThemeProvider isDark>
+      <AppConfigurationContext.Provider value={makeMockAppConfiguration()}>
+        <MockMessagePipelineProvider
+          startTime={{ sec: 0, nsec: 0 }}
+          endTime={{ sec: 10, nsec: 0 }}
+          progress={{ fullyLoadedFractionRanges: [{ start: 0.25, end: 0.5 }] }}
+        >
+          <TimelineInteractionStateProvider>
+            <CoScenePlaylistProvider>{children}</CoScenePlaylistProvider>
+          </TimelineInteractionStateProvider>
+        </MockMessagePipelineProvider>
+      </AppConfigurationContext.Provider>
+    </ThemeProvider>
+  );
+}
+
+describe("Playback bar pointer events", () => {
+  it("keeps progress plot visual layers out of hit testing", () => {
+    const { container } = render(
+      <Wrapper>
+        <ProgressPlot loading />
+      </Wrapper>,
+    );
+
+    const progressRoot = container.firstElementChild;
+    const loadingIndicator = container.querySelector('[class*="ProgressPlot-loadingIndicator"]');
+    const range = container.querySelector('[class*="ProgressPlot-range"]');
+
+    expect(progressRoot).not.toBeNull();
+    expect(loadingIndicator).not.toBeNull();
+    expect(range).not.toBeNull();
+    expect(getComputedStyle(progressRoot!).pointerEvents).toBe("none");
+    expect(getComputedStyle(loadingIndicator!).pointerEvents).toBe("none");
+    expect(getComputedStyle(range!).pointerEvents).toBe("none");
+  });
+
+  it("keeps bags overlay out of hit testing", () => {
+    const { container } = render(
+      <Wrapper>
+        <BagsOverlay />
+      </Wrapper>,
+    );
+
+    const root = container.firstElementChild;
+    expect(root).not.toBeNull();
+    expect(getComputedStyle(root!).pointerEvents).toBe("none");
+  });
+
+  it("keeps playback hover ticks out of hit testing", () => {
+    const { container } = render(
+      <Wrapper>
+        <PlaybackBarHoverTicks componentId="test-component" />
+      </Wrapper>,
+    );
+
+    const root = container.firstElementChild;
+    expect(root).not.toBeNull();
+    expect(getComputedStyle(root!).pointerEvents).toBe("none");
+  });
+});

--- a/packages/studio-base/src/components/PlaybackControls/ProgressPlot.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/ProgressPlot.tsx
@@ -35,6 +35,7 @@ const useStyles = makeStyles()((theme) => ({
   loadingIndicator: {
     label: "ProgressPlot-loadingIndicator",
     position: "absolute",
+    pointerEvents: "none",
     width: "100%",
     height: "100%",
     animation: `${animatedBackground} 300ms linear infinite`,
@@ -51,6 +52,7 @@ const useStyles = makeStyles()((theme) => ({
   range: {
     label: "ProgressPlot-range",
     position: "absolute",
+    pointerEvents: "none",
     backgroundColor:
       theme.palette.mode === "dark"
         ? tinycolor(theme.palette.text.secondary).darken(25).toHexString()
@@ -104,7 +106,7 @@ function UnmemoizedProgressPlot(props: ProgressProps): React.JSX.Element {
   }, [clampedRanges, classes.range]);
 
   return (
-    <Stack position="relative" fullHeight>
+    <Stack position="relative" fullHeight style={{ pointerEvents: "none" }}>
       {loading && <div className={classes.loadingIndicator} />}
       {ranges}
     </Stack>

--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
@@ -265,7 +265,10 @@ export class BlockLoader {
       const cursor =
         this.#source.getMessageCursor?.({ ...iteratorArgs, abort: this.#abortController.signal }) ??
         new IteratorCursor(
-          this.#source.messageIterator(iteratorArgs),
+          this.#source.messageIterator({
+            ...iteratorArgs,
+            abortSignal: this.#abortController.signal,
+          }),
           this.#abortController.signal,
         );
 

--- a/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.test.ts
@@ -6,6 +6,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import * as _ from "lodash-es";
+import race from "race-as-promised";
 
 import { MessageEvent } from "@foxglove/studio";
 import { mockTopicSelection } from "@foxglove/studio-base/test/mocks/mockTopicSelection";
@@ -148,7 +149,13 @@ describe("BufferedIterableSource", () => {
     ): AsyncIterableIterator<Readonly<IteratorResult>> {
       sourceStarted.notify();
       await new Promise<void>((resolve) => {
-        args.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+        args.abortSignal?.addEventListener(
+          "abort",
+          () => {
+            resolve();
+          },
+          { once: true },
+        );
       });
       yield* [];
     };
@@ -159,7 +166,7 @@ describe("BufferedIterableSource", () => {
     });
     await sourceStarted.wait();
 
-    const result = await Promise.race([
+    const result = await race([
       messageIterator.return?.().then(() => "returned" as const) ?? Promise.resolve("no-return"),
       delay(50),
     ]);
@@ -180,7 +187,13 @@ describe("BufferedIterableSource", () => {
     ): AsyncIterableIterator<Readonly<IteratorResult>> {
       sourceStarted.notify();
       await new Promise<void>((resolve) => {
-        args.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+        args.abortSignal?.addEventListener(
+          "abort",
+          () => {
+            resolve();
+          },
+          { once: true },
+        );
       });
       yield* [];
     };
@@ -191,7 +204,7 @@ describe("BufferedIterableSource", () => {
     });
     await sourceStarted.wait();
 
-    const result = await Promise.race([
+    const result = await race([
       bufferedSource.stopProducer().then(() => "stopped" as const),
       delay(50),
     ]);

--- a/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.test.ts
@@ -42,6 +42,13 @@ function waiter(count: number) {
   };
 }
 
+async function delay(ms: number): Promise<"timeout"> {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+  return "timeout";
+}
+
 class TestSource implements IIterableSource {
   public async initialize(): Promise<Initalization> {
     return {
@@ -126,6 +133,71 @@ describe("BufferedIterableSource", () => {
     });
 
     expect(bufferedSource.loadedRanges()).toEqual([{ start: 0, end: 1 }]);
+  });
+
+  it("aborts the pending source iterator when the buffered iterator is returned", async () => {
+    const source = new TestSource();
+    const bufferedSource = new BufferedIterableSource(source);
+
+    await bufferedSource.initialize();
+
+    const sourceStarted = waiter(1);
+
+    source.messageIterator = async function* messageIterator(
+      args: MessageIteratorArgs & { abortSignal?: AbortSignal },
+    ): AsyncIterableIterator<Readonly<IteratorResult>> {
+      sourceStarted.notify();
+      await new Promise<void>((resolve) => {
+        args.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+      });
+      yield* [];
+    };
+
+    const messageIterator = bufferedSource.messageIterator({
+      topics: mockTopicSelection("a"),
+      start: { sec: 0, nsec: 0 },
+    });
+    await sourceStarted.wait();
+
+    const result = await Promise.race([
+      messageIterator.return?.().then(() => "returned" as const) ?? Promise.resolve("no-return"),
+      delay(50),
+    ]);
+
+    expect(result).toBe("returned");
+  });
+
+  it("aborts the pending source iterator when the producer is stopped", async () => {
+    const source = new TestSource();
+    const bufferedSource = new BufferedIterableSource(source);
+
+    await bufferedSource.initialize();
+
+    const sourceStarted = waiter(1);
+
+    source.messageIterator = async function* messageIterator(
+      args: MessageIteratorArgs & { abortSignal?: AbortSignal },
+    ): AsyncIterableIterator<Readonly<IteratorResult>> {
+      sourceStarted.notify();
+      await new Promise<void>((resolve) => {
+        args.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+      });
+      yield* [];
+    };
+
+    const messageIterator = bufferedSource.messageIterator({
+      topics: mockTopicSelection("a"),
+      start: { sec: 0, nsec: 0 },
+    });
+    await sourceStarted.wait();
+
+    const result = await Promise.race([
+      bufferedSource.stopProducer().then(() => "stopped" as const),
+      delay(50),
+    ]);
+
+    expect(result).toBe("stopped");
+    await messageIterator.return?.();
   });
 
   it("should produce messages after buffering is complete", async () => {
@@ -419,12 +491,15 @@ describe("BufferedIterableSource", () => {
     source.messageIterator = async function* messageIterator(
       args: MessageIteratorArgs,
     ): AsyncIterableIterator<Readonly<IteratorResult>> {
-      expect(args).toEqual({
-        topics: mockTopicSelection("a"),
-        start: { sec: 0, nsec: 0 },
-        end: { sec: 10, nsec: 0 },
-        consumptionType: "partial",
-      });
+      expect(args).toEqual(
+        expect.objectContaining({
+          topics: mockTopicSelection("a"),
+          start: { sec: 0, nsec: 0 },
+          end: { sec: 10, nsec: 0 },
+          consumptionType: "partial",
+        }),
+      );
+      expect(args.abortSignal).toBeInstanceOf(AbortSignal);
       messageIteratorCount += 1;
 
       for (let i = 0; i < 8; ++i) {
@@ -483,12 +558,15 @@ describe("BufferedIterableSource", () => {
     source.messageIterator = async function* messageIterator(
       args: MessageIteratorArgs,
     ): AsyncIterableIterator<Readonly<IteratorResult>> {
-      expect(args).toEqual({
-        topics: mockTopicSelection("a"),
-        start: { sec: 0, nsec: 0 },
-        end: { sec: 10, nsec: 0 },
-        consumptionType: "partial",
-      });
+      expect(args).toEqual(
+        expect.objectContaining({
+          topics: mockTopicSelection("a"),
+          start: { sec: 0, nsec: 0 },
+          end: { sec: 10, nsec: 0 },
+          consumptionType: "partial",
+        }),
+      );
+      expect(args.abortSignal).toBeInstanceOf(AbortSignal);
       messageIteratorCount += 1;
 
       for (let i = 0; i < 8; ++i) {
@@ -598,12 +676,15 @@ describe("BufferedIterableSource", () => {
     source.messageIterator = async function* messageIterator(
       args: MessageIteratorArgs,
     ): AsyncIterableIterator<Readonly<IteratorResult>> {
-      expect(args).toEqual({
-        topics: mockTopicSelection("a"),
-        start: { sec: 0, nsec: 0 },
-        end: { sec: 10, nsec: 0 },
-        consumptionType: "partial",
-      });
+      expect(args).toEqual(
+        expect.objectContaining({
+          topics: mockTopicSelection("a"),
+          start: { sec: 0, nsec: 0 },
+          end: { sec: 10, nsec: 0 },
+          consumptionType: "partial",
+        }),
+      );
+      expect(args.abortSignal).toBeInstanceOf(AbortSignal);
       messageIteratorCount += 1;
 
       for (let i = 0; i < 8; ++i) {
@@ -655,12 +736,15 @@ describe("BufferedIterableSource", () => {
     source.messageIterator = async function* messageIterator(
       args: MessageIteratorArgs,
     ): AsyncIterableIterator<Readonly<IteratorResult>> {
-      expect(args).toEqual({
-        topics: mockTopicSelection("a"),
-        start: { sec: 0, nsec: 0 },
-        end: { sec: 10, nsec: 0 },
-        consumptionType: "partial",
-      });
+      expect(args).toEqual(
+        expect.objectContaining({
+          topics: mockTopicSelection("a"),
+          start: { sec: 0, nsec: 0 },
+          end: { sec: 10, nsec: 0 },
+          consumptionType: "partial",
+        }),
+      );
+      expect(args.abortSignal).toBeInstanceOf(AbortSignal);
       messageIteratorCount += 1;
 
       for (let i = 0; i < 8; ++i) {

--- a/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BufferedIterableSource.ts
@@ -85,6 +85,7 @@ class BufferedIterableSource<MessageType = unknown>
   // The promise for the current producer. The message generator starts a producer and awaits the
   // producer before exiting.
   #producer?: Promise<void>;
+  #producerAbortController?: AbortController;
 
   #initResult?: Initalization;
 
@@ -137,12 +138,28 @@ class BufferedIterableSource<MessageType = unknown>
     // the start of the array.
     this.#cache.clear();
 
+    const producerAbortController = new AbortController();
+    this.#producerAbortController = producerAbortController;
+    const abortProducer = () => {
+      this.#aborted = true;
+      producerAbortController.abort();
+      this.#readSignal.notifyAll();
+      this.#writeSignal.notifyAll();
+    };
+
+    if (args.abortSignal?.aborted === true) {
+      abortProducer();
+    } else {
+      args.abortSignal?.addEventListener("abort", abortProducer, { once: true });
+    }
+
     try {
       const sourceIterator = this.#source.messageIterator({
         topics: args.topics,
         start: this.#readHead,
         consumptionType: "partial",
         fetchCompleteTopicState: args.fetchCompleteTopicState,
+        abortSignal: producerAbortController.signal,
       });
 
       // Messages are read from the source until reaching the readUntil time. Then we wait for the read head
@@ -230,6 +247,10 @@ class BufferedIterableSource<MessageType = unknown>
         await this.#writeSignal.wait();
       }
     } finally {
+      args.abortSignal?.removeEventListener("abort", abortProducer);
+      if (this.#producerAbortController === producerAbortController) {
+        this.#producerAbortController = undefined;
+      }
       // Indicate to the consumer that it can try reading again
       this.#readSignal.notifyAll();
       this.#readDone = true;
@@ -249,6 +270,8 @@ class BufferedIterableSource<MessageType = unknown>
   public async stopProducer(): Promise<void> {
     log.debug("Stopping producer");
     this.#aborted = true;
+    this.#producerAbortController?.abort();
+    this.#readSignal.notifyAll();
     this.#writeSignal.notifyAll();
     await this.#producer;
     this.#producer = undefined;

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.test.ts
@@ -685,6 +685,53 @@ describe("CachingIterableSource", () => {
     ]);
   });
 
+  it("does not mark an aborted source range as fully loaded", async () => {
+    const source = new TestSource();
+    const bufferedSource = new CachingIterableSource(source);
+    const abortController = new AbortController();
+
+    await bufferedSource.initialize();
+
+    source.messageIterator = async function* messageIterator(
+      _args: MessageIteratorArgs,
+    ): AsyncIterableIterator<Readonly<IteratorResult>> {
+      const aborted = new Promise<void>((resolve) => {
+        if (abortController.signal.aborted) {
+          resolve();
+          return;
+        }
+        abortController.signal.addEventListener("abort", () => resolve(), { once: true });
+      });
+      yield {
+        type: "message-event",
+        msgEvent: {
+          topic: "a",
+          receiveTime: { sec: 1, nsec: 0 },
+          message: undefined,
+          sizeInBytes: 0,
+          schemaName: "foo",
+        },
+      };
+      await aborted;
+    };
+
+    const iterator = bufferedSource.messageIterator({
+      topics: mockTopicSelection("a"),
+      start: { sec: 0, nsec: 0 },
+      end: { sec: 10, nsec: 0 },
+      abortSignal: abortController.signal,
+    } as MessageIteratorArgs & { abortSignal: AbortSignal });
+
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: { type: "message-event" },
+    });
+    abortController.abort();
+    await expect(iterator.next()).resolves.toEqual({ done: true });
+
+    expect(bufferedSource.loadedRanges()).toEqual([{ start: 0, end: 0.0999999999 }]);
+  });
+
   it("should getBackfillMessages from multiple cache blocks", async () => {
     const source = new TestSource();
     const bufferedSource = new CachingIterableSource(source, { maxBlockSize: 100 });
@@ -1176,6 +1223,75 @@ describe("CachingIterableSource", () => {
     expect(source.messageIteratorCalls).toBe(1);
 
     await bufferedSource.terminate();
+  });
+
+  it("does not record playback spill loaded ranges for aborted source ranges", async () => {
+    const source = new TestSource();
+    const bufferedSource = new CachingIterableSource(source, {
+      spillCache: { sourceId: "test-source", sourceKey: "aborted-range" },
+    });
+    const abortController = new AbortController();
+
+    await bufferedSource.initialize();
+
+    source.messageIterator = async function* messageIterator(
+      _args: MessageIteratorArgs,
+    ): AsyncIterableIterator<Readonly<IteratorResult>> {
+      const aborted = new Promise<void>((resolve) => {
+        if (abortController.signal.aborted) {
+          resolve();
+          return;
+        }
+        abortController.signal.addEventListener("abort", () => resolve(), { once: true });
+      });
+      yield {
+        type: "message-event",
+        msgEvent: {
+          topic: "a",
+          receiveTime: { sec: 1, nsec: 0 },
+          message: { value: 1 },
+          sizeInBytes: 10,
+          schemaName: "foo",
+        },
+      };
+      await aborted;
+    };
+
+    const iterator = bufferedSource.messageIterator({
+      topics: mockTopicSelection("a"),
+      start: { sec: 0, nsec: 0 },
+      end: { sec: 5, nsec: 0 },
+      abortSignal: abortController.signal,
+    } as MessageIteratorArgs & { abortSignal: AbortSignal });
+
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: { type: "message-event" },
+    });
+    let reader: IndexedDbMessageStore | undefined;
+    try {
+      abortController.abort();
+      await expect(iterator.next()).resolves.toEqual({ done: true });
+      expect(bufferedSource.loadedRanges()).toEqual([{ start: 0, end: 0.0999999999 }]);
+      expect(bufferedSource.getCacheSize()).toBe(0);
+
+      const sessions = await getPlaybackSpillSessions();
+      expect(sessions).toHaveLength(1);
+      const session = sessions[0]!;
+      reader = new IndexedDbMessageStore({
+        sessionId: session.sessionId,
+        kind: "playback-spill",
+      });
+      await reader.init();
+      const topicFingerprint = (await reader.getSessionMetadata())?.topicFingerprint;
+      if (topicFingerprint == undefined) {
+        throw new Error("Expected playback spill topic fingerprint to be recorded");
+      }
+      await expect(reader.getLoadedRanges(topicFingerprint)).resolves.toEqual([]);
+    } finally {
+      await reader?.close();
+      await bufferedSource.terminate();
+    }
   });
 
   it("falls back to source when a stale spill range points at a deleted session", async () => {

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.test.ts
@@ -1720,6 +1720,120 @@ describe("CachingIterableSource", () => {
     await bufferedSource.terminate();
   });
 
+  it("does not call source for complete topic-state fetches when already aborted", async () => {
+    const source = new TestSource();
+    const bufferedSource = new CachingIterableSource(source);
+    const abortController = new AbortController();
+
+    await bufferedSource.initialize();
+
+    source.messageIterator = function messageIterator(): AsyncIterableIterator<
+      Readonly<IteratorResult>
+    > {
+      throw new Error("should not read from source");
+    };
+
+    abortController.abort();
+
+    const iterator = bufferedSource.messageIterator({
+      topics: mockTopicSelection("a"),
+      start: { sec: 0, nsec: 0 },
+      end: { sec: 2, nsec: 0 },
+      fetchCompleteTopicState: "complete",
+      abortSignal: abortController.signal,
+    });
+
+    await expect(iterator.next()).resolves.toEqual({ done: true });
+    expect(source.messageIteratorCalls).toBe(0);
+  });
+
+  it("finishes complete topic-state fetches when abort makes source throw AbortError", async () => {
+    const source = new TestSource();
+    const bufferedSource = new CachingIterableSource(source);
+    const abortController = new AbortController();
+    let sourceStarted!: () => void;
+    const sourceStartedPromise = new Promise<void>((resolve) => {
+      sourceStarted = resolve;
+    });
+
+    await bufferedSource.initialize();
+
+    source.messageIterator = function messageIterator(
+      args: MessageIteratorArgs,
+    ): AsyncIterableIterator<Readonly<IteratorResult>> {
+      source.messageIteratorCalls++;
+      sourceStarted();
+      let read = false;
+      return {
+        async next() {
+          if (read) {
+            return { done: true, value: undefined };
+          }
+          read = true;
+          await new Promise<void>((resolve) => {
+            args.abortSignal?.addEventListener(
+              "abort",
+              () => {
+                resolve();
+              },
+              { once: true },
+            );
+          });
+          throw new DOMException("signal is aborted without reason", "AbortError");
+        },
+        [Symbol.asyncIterator]() {
+          return this;
+        },
+      };
+    };
+
+    const iterator = bufferedSource.messageIterator({
+      topics: mockTopicSelection("a"),
+      start: { sec: 0, nsec: 0 },
+      end: { sec: 2, nsec: 0 },
+      fetchCompleteTopicState: "complete",
+      abortSignal: abortController.signal,
+    });
+
+    const next = iterator.next();
+    await sourceStartedPromise;
+    abortController.abort();
+
+    await expect(next).resolves.toEqual({ done: true });
+    expect(source.messageIteratorCalls).toBe(1);
+  });
+
+  it("preserves non-abort errors from complete topic-state fetches", async () => {
+    const source = new TestSource();
+    const bufferedSource = new CachingIterableSource(source);
+
+    await bufferedSource.initialize();
+
+    source.messageIterator = function messageIterator(): AsyncIterableIterator<
+      Readonly<IteratorResult>
+    > {
+      source.messageIteratorCalls++;
+      return {
+        async next() {
+          throw new Error("source failed");
+        },
+        [Symbol.asyncIterator]() {
+          return this;
+        },
+      };
+    };
+
+    const iterator = bufferedSource.messageIterator({
+      topics: mockTopicSelection("a"),
+      start: { sec: 0, nsec: 0 },
+      end: { sec: 2, nsec: 0 },
+      fetchCompleteTopicState: "complete",
+    });
+
+    await expect(iterator.next()).rejects.toThrow("source failed");
+    expect(source.messageIteratorCalls).toBe(1);
+  });
+
   it("records playback spill loaded ranges at stamp boundaries", async () => {
     const source = new TestSource();
     const bufferedSource = new CachingIterableSource(source, {

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.test.ts
@@ -700,7 +700,13 @@ describe("CachingIterableSource", () => {
           resolve();
           return;
         }
-        abortController.signal.addEventListener("abort", () => resolve(), { once: true });
+        abortController.signal.addEventListener(
+          "abort",
+          () => {
+            resolve();
+          },
+          { once: true },
+        );
       });
       yield {
         type: "message-event",
@@ -1242,7 +1248,13 @@ describe("CachingIterableSource", () => {
           resolve();
           return;
         }
-        abortController.signal.addEventListener("abort", () => resolve(), { once: true });
+        abortController.signal.addEventListener(
+          "abort",
+          () => {
+            resolve();
+          },
+          { once: true },
+        );
       });
       yield {
         type: "message-event",

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
@@ -71,6 +71,21 @@ function topicFingerprint(topics: TopicSelection): string {
   return stringHash(JSON.stringify(canonicalize(entries)) ?? "").toString(36);
 }
 
+function isAbortError(error: unknown): boolean {
+  return (
+    (error instanceof DOMException && error.name === "AbortError") ||
+    (error instanceof Error && error.name === "AbortError") ||
+    (typeof error === "object" &&
+      error != undefined &&
+      "name" in error &&
+      error.name === "AbortError")
+  );
+}
+
+function isAborted(abortSignal: AbortSignal | undefined): boolean {
+  return abortSignal?.aborted === true;
+}
+
 // An individual cache item represents a continuous range of CacheIteratorItems
 type CacheBlock<MessageType> = {
   // Unique id of the cache item.
@@ -639,14 +654,20 @@ class CachingIterableSource<MessageType = unknown>
     topics: TopicSelection;
     consumptionType: MessageIteratorArgs["consumptionType"];
     fetchCompleteTopicState: MessageIteratorArgs["fetchCompleteTopicState"];
+    abortSignal?: AbortSignal;
     writeSpill: boolean;
-  }): AsyncIterableIterator<Readonly<IteratorResult<MessageType>>> {
+  }): AsyncGenerator<Readonly<IteratorResult<MessageType>>, boolean, void> {
+    if (isAborted(args.abortSignal)) {
+      return false;
+    }
+
     const sourceMessageIterator = this.#source.messageIterator({
       topics: args.topics,
       start: args.start,
       end: args.end,
       consumptionType: args.consumptionType,
       fetchCompleteTopicState: args.fetchCompleteTopicState,
+      abortSignal: args.abortSignal,
     });
 
     // The cache is indexed on time, but iterator results that are problems might not have a time.
@@ -659,103 +680,133 @@ class CachingIterableSource<MessageType = unknown>
     let block: CacheBlock<MessageType> | undefined;
 
     const pendingIterResults: [bigint, IteratorResult<MessageType>][] = [];
-
-    for await (const iterResult of sourceMessageIterator) {
-      if (iterResult.type === "problem") {
-        sourceHadProblemInRange = true;
+    const discardPendingIterResults = () => {
+      for (const pendingIterResult of pendingIterResults) {
+        const item = pendingIterResult[1];
+        const pendingSizeInBytes = item.type === "message-event" ? item.msgEvent.sizeInBytes : 0;
+        this.#totalSizeBytes -= pendingSizeInBytes;
       }
+      pendingIterResults.length = 0;
+    };
 
-      // if there is no block, we make a new block
-      if (!block) {
-        const newBlock: CacheBlock<MessageType> = {
-          id: this.#nextBlockId++,
-          start: readHead,
-          end: readHead,
-          items: [],
-          size: 0,
-          lastAccess: Date.now(),
-        };
+    try {
+      for await (const iterResult of sourceMessageIterator) {
+        if (isAborted(args.abortSignal)) {
+          discardPendingIterResults();
+          return false;
+        }
 
-        // Find where we need to insert our new block.
-        // It should come before any blocks with a start time > than new block start time.
-        const insertIndex = _.sortedIndexBy(this.#cache, newBlock, (item) => toNanoSec(item.start));
-        this.#cache.splice(insertIndex, 0, newBlock);
+        if (iterResult.type === "problem") {
+          sourceHadProblemInRange = true;
+        }
 
-        block = newBlock;
-        this.#recomputeLoadedRangeCache();
-      }
+        // if there is no block, we make a new block
+        if (!block) {
+          const newBlock: CacheBlock<MessageType> = {
+            id: this.#nextBlockId++,
+            start: readHead,
+            end: readHead,
+            items: [],
+            size: 0,
+            lastAccess: Date.now(),
+          };
 
-      // When receiving a message event or stamp, we update our known time on the block to the
-      // stamp or receiveTime because we know we've received all the results up to this time
-      if (iterResult.type === "message-event" || iterResult.type === "stamp") {
-        const receiveTime =
-          iterResult.type === "stamp" ? iterResult.stamp : iterResult.msgEvent.receiveTime;
-        const receiveTimeNs = toNanoSec(receiveTime);
+          // Find where we need to insert our new block.
+          // It should come before any blocks with a start time > than new block start time.
+          const insertIndex = _.sortedIndexBy(this.#cache, newBlock, (item) =>
+            toNanoSec(item.start),
+          );
+          this.#cache.splice(insertIndex, 0, newBlock);
 
-        // There might be multiple messages at the same time, and since block end time
-        // is inclusive we only update the end time once we've moved to the next time
-        if (receiveTimeNs > lastTime) {
-          // write any pending messages to the block
-          for (const pendingIterResult of pendingIterResults) {
-            const item = pendingIterResult[1];
-            const pendingSizeInBytes =
-              item.type === "message-event" ? item.msgEvent.sizeInBytes : 0;
-            block.items.push(pendingIterResult);
-            block.size += pendingSizeInBytes;
-          }
-
-          pendingIterResults.length = 0;
-
-          // update the last time this block was accessed
-          block.lastAccess = Date.now();
-
-          // Set the end time to 1 nanosecond before the current receive time since we know we've
-          // read up to this receive time.
-          block.end = subtract(receiveTime, { sec: 0, nsec: 1 });
-
-          lastTime = receiveTimeNs;
+          block = newBlock;
           this.#recomputeLoadedRangeCache();
         }
-      }
 
-      // Block is too big so we close it and will start a new one next loop
-      if (block.size >= this.#maxBlockSizeBytes) {
-        // The new block starts right after our previous one
-        readHead = add(block.end, { sec: 0, nsec: 1 });
+        // When receiving a message event or stamp, we update our known time on the block to the
+        // stamp or receiveTime because we know we've received all the results up to this time
+        if (iterResult.type === "message-event" || iterResult.type === "stamp") {
+          const receiveTime =
+            iterResult.type === "stamp" ? iterResult.stamp : iterResult.msgEvent.receiveTime;
+          const receiveTimeNs = toNanoSec(receiveTime);
 
-        // Will force creation of a new block on the next loop
-        block = undefined;
-      }
+          // There might be multiple messages at the same time, and since block end time
+          // is inclusive we only update the end time once we've moved to the next time
+          if (receiveTimeNs > lastTime) {
+            // write any pending messages to the block
+            for (const pendingIterResult of pendingIterResults) {
+              const item = pendingIterResult[1];
+              const pendingSizeInBytes =
+                item.type === "message-event" ? item.msgEvent.sizeInBytes : 0;
+              block.items.push(pendingIterResult);
+              block.size += pendingSizeInBytes;
+            }
 
-      const sizeInBytes = iterResult.type === "message-event" ? iterResult.msgEvent.sizeInBytes : 0;
-      if (
-        this.#maybePurgeCache({
-          activeBlock: block,
-          sizeInBytes,
-        })
-      ) {
-        this.#recomputeLoadedRangeCache();
-      }
+            pendingIterResults.length = 0;
 
-      // As we add items to pending we also consider them as part of the total size
-      this.#totalSizeBytes += sizeInBytes;
+            // update the last time this block was accessed
+            block.lastAccess = Date.now();
 
-      // Store the latest message in pending results and flush to the block when time moves forward
-      pendingIterResults.push([lastTime, iterResult]);
-      if (args.writeSpill) {
-        await this.#appendSpill(iterResult);
-      }
+            // Set the end time to 1 nanosecond before the current receive time since we know we've
+            // read up to this receive time.
+            block.end = subtract(receiveTime, { sec: 0, nsec: 1 });
 
-      if (args.writeSpill && iterResult.type === "stamp") {
-        const spillRangeEnd = compare(iterResult.stamp, args.end) > 0 ? args.end : iterResult.stamp;
-        if (!sourceHadProblemInRange && compare(spillRangeStart, spillRangeEnd) <= 0) {
-          await this.#recordSpillLoadedRange(spillRangeStart, spillRangeEnd);
+            lastTime = receiveTimeNs;
+            this.#recomputeLoadedRangeCache();
+          }
         }
-        sourceHadProblemInRange = false;
-        spillRangeStart = add(spillRangeEnd, { sec: 0, nsec: 1 });
-      }
 
-      yield iterResult;
+        // Block is too big so we close it and will start a new one next loop
+        if (block.size >= this.#maxBlockSizeBytes) {
+          // The new block starts right after our previous one
+          readHead = add(block.end, { sec: 0, nsec: 1 });
+
+          // Will force creation of a new block on the next loop
+          block = undefined;
+        }
+
+        const sizeInBytes =
+          iterResult.type === "message-event" ? iterResult.msgEvent.sizeInBytes : 0;
+        if (
+          this.#maybePurgeCache({
+            activeBlock: block,
+            sizeInBytes,
+          })
+        ) {
+          this.#recomputeLoadedRangeCache();
+        }
+
+        // As we add items to pending we also consider them as part of the total size
+        this.#totalSizeBytes += sizeInBytes;
+
+        // Store the latest message in pending results and flush to the block when time moves forward
+        pendingIterResults.push([lastTime, iterResult]);
+        if (args.writeSpill) {
+          await this.#appendSpill(iterResult);
+        }
+
+        if (args.writeSpill && iterResult.type === "stamp") {
+          const spillRangeEnd =
+            compare(iterResult.stamp, args.end) > 0 ? args.end : iterResult.stamp;
+          if (!sourceHadProblemInRange && compare(spillRangeStart, spillRangeEnd) <= 0) {
+            await this.#recordSpillLoadedRange(spillRangeStart, spillRangeEnd);
+          }
+          sourceHadProblemInRange = false;
+          spillRangeStart = add(spillRangeEnd, { sec: 0, nsec: 1 });
+        }
+
+        yield iterResult;
+      }
+    } catch (error) {
+      if (isAborted(args.abortSignal) && isAbortError(error)) {
+        discardPendingIterResults();
+        return false;
+      }
+      throw error;
+    }
+
+    if (isAborted(args.abortSignal)) {
+      discardPendingIterResults();
+      return false;
     }
 
     // We've finished reading our source to the end, close out the block
@@ -807,6 +858,7 @@ class CachingIterableSource<MessageType = unknown>
     if (args.writeSpill && !sourceHadProblemInRange && compare(spillRangeStart, args.end) <= 0) {
       await this.#recordSpillLoadedRange(spillRangeStart, args.end);
     }
+    return true;
   }
 
   public async *messageIterator(
@@ -832,6 +884,7 @@ class CachingIterableSource<MessageType = unknown>
         end: maxEnd,
         consumptionType: args.consumptionType,
         fetchCompleteTopicState: args.fetchCompleteTopicState,
+        abortSignal: args.abortSignal,
       });
       return;
     }
@@ -928,14 +981,18 @@ class CachingIterableSource<MessageType = unknown>
       }
 
       if (!this.#hasActiveSpillCache()) {
-        yield* this.#yieldSourceRange({
+        const sourceRangeComplete = yield* this.#yieldSourceRange({
           start: sourceReadStart,
           end: sourceReadEnd,
           topics: this.#cachedTopics,
           consumptionType: args.consumptionType,
           fetchCompleteTopicState: args.fetchCompleteTopicState,
+          abortSignal: args.abortSignal,
           writeSpill: false,
         });
+        if (!sourceRangeComplete) {
+          return;
+        }
         readHead = add(sourceReadEnd, { sec: 0, nsec: 1 });
         continue;
       }
@@ -971,14 +1028,18 @@ class CachingIterableSource<MessageType = unknown>
             yield result.value;
           }
           if (!spillReadSucceeded) {
-            yield* this.#yieldSourceRange({
+            const sourceRangeComplete = yield* this.#yieldSourceRange({
               start: segmentStart,
               end: segmentEnd,
               topics: this.#cachedTopics,
               consumptionType: args.consumptionType,
               fetchCompleteTopicState: args.fetchCompleteTopicState,
+              abortSignal: args.abortSignal,
               writeSpill: true,
             });
+            if (!sourceRangeComplete) {
+              return;
+            }
           }
           segmentStart = add(segmentEnd, { sec: 0, nsec: 1 });
           continue;
@@ -995,14 +1056,18 @@ class CachingIterableSource<MessageType = unknown>
           ? subtract(nextSpillRange.start, { sec: 0, nsec: 1 })
           : sourceReadEnd;
 
-        yield* this.#yieldSourceRange({
+        const sourceRangeComplete = yield* this.#yieldSourceRange({
           start: segmentStart,
           end: segmentEnd,
           topics: this.#cachedTopics,
           consumptionType: args.consumptionType,
           fetchCompleteTopicState: args.fetchCompleteTopicState,
+          abortSignal: args.abortSignal,
           writeSpill: true,
         });
+        if (!sourceRangeComplete) {
+          return;
+        }
         segmentStart = add(segmentEnd, { sec: 0, nsec: 1 });
       }
 

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
@@ -878,14 +878,24 @@ class CachingIterableSource<MessageType = unknown>
     let readHead = args.start ?? this.#initResult.start;
 
     if (args.fetchCompleteTopicState === "complete") {
-      yield* this.#source.messageIterator({
-        topics: args.topics,
-        start: readHead,
-        end: maxEnd,
-        consumptionType: args.consumptionType,
-        fetchCompleteTopicState: args.fetchCompleteTopicState,
-        abortSignal: args.abortSignal,
-      });
+      if (isAborted(args.abortSignal)) {
+        return;
+      }
+      try {
+        yield* this.#source.messageIterator({
+          topics: args.topics,
+          start: readHead,
+          end: maxEnd,
+          consumptionType: args.consumptionType,
+          fetchCompleteTopicState: args.fetchCompleteTopicState,
+          abortSignal: args.abortSignal,
+        });
+      } catch (error) {
+        if (isAborted(args.abortSignal) && isAbortError(error)) {
+          return;
+        }
+        throw error;
+      }
       return;
     }
 

--- a/packages/studio-base/src/players/IterablePlayer/IIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IIterableSource.ts
@@ -78,6 +78,12 @@ export type MessageIteratorArgs = {
    * return map message in every time, we need this param to notify the backend help us find last message in target time`s topic
    */
   fetchCompleteTopicState?: "complete" | "incremental";
+
+  /**
+   * Allows callers to cancel an in-flight iterator read. This is needed for streaming sources whose
+   * next result may be blocked on network I/O.
+   */
+  abortSignal?: AbortSignal;
 };
 
 /**

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
@@ -494,7 +494,13 @@ describe("IterablePlayer", () => {
       iteratorStarted.resolve();
       await new Promise<void>((resolve) => {
         releaseIterator = resolve;
-        args.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+        args.abortSignal?.addEventListener(
+          "abort",
+          () => {
+            resolve();
+          },
+          { once: true },
+        );
       });
       yield* [];
     };

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.test.ts
@@ -129,6 +129,17 @@ class PlayerStateStore {
   }
 }
 
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = performance.now() + 1_000;
+  while (performance.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  expect(predicate()).toBe(true);
+}
+
 describe("IterablePlayer", () => {
   let mockDateNow: jest.SpyInstance<number, []>;
   beforeEach(() => {
@@ -460,6 +471,81 @@ describe("IterablePlayer", () => {
 
     void player.close();
     await player.isClosed;
+  });
+
+  it("aborts pending playback iterator so seek can run while playback is buffering", async () => {
+    const source = new TestSource();
+    const player = new IterablePlayer({
+      source,
+      enablePreload: false,
+      sourceId: "test",
+    });
+
+    let releaseIterator: (() => void) | undefined;
+    const playbackAbortSignals: AbortSignal[] = [];
+    const iteratorStarted = signal();
+
+    source.messageIterator = async function* messageIterator(
+      args: MessageIteratorArgs & { abortSignal?: AbortSignal },
+    ): AsyncIterableIterator<Readonly<IteratorResult>> {
+      if (args.abortSignal) {
+        playbackAbortSignals.push(args.abortSignal);
+      }
+      iteratorStarted.resolve();
+      await new Promise<void>((resolve) => {
+        releaseIterator = resolve;
+        args.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+      });
+      yield* [];
+    };
+
+    player.setSubscriptions([{ topic: "foo" }]);
+
+    let initialized = false;
+    let buffering = false;
+    player.setListener(async (state) => {
+      if (
+        state.presence === PlayerPresence.PRESENT &&
+        state.activeData?.isPlaying === false &&
+        compare(state.activeData.currentTime, { sec: 0, nsec: 99000000 }) === 0
+      ) {
+        initialized = true;
+      }
+      if (state.presence === PlayerPresence.BUFFERING && state.activeData?.isPlaying === true) {
+        buffering = true;
+      }
+    });
+
+    try {
+      await waitFor(() => initialized);
+      await iteratorStarted;
+
+      player.startPlayback();
+      await waitFor(() => buffering);
+
+      let seekBackfillCalled = false;
+      source.getBackfillMessages = async () => {
+        seekBackfillCalled = true;
+        return [
+          {
+            topic: "foo",
+            receiveTime: { sec: 0, nsec: 500000000 },
+            message: undefined,
+            sizeInBytes: 4,
+            schemaName: "foo",
+          },
+        ];
+      };
+
+      player.seekPlayback({ sec: 0, nsec: 500000000 });
+
+      await waitFor(() => seekBackfillCalled);
+      expect(playbackAbortSignals[0]?.aborted).toBe(true);
+    } finally {
+      releaseIterator?.();
+      void player.close();
+      await player.isClosed;
+    }
   });
 
   it("startPlayback emits when seek-backfill state is active", async () => {
@@ -878,22 +964,22 @@ describe("IterablePlayer", () => {
 
     expect(messageIteratorSpy.mock.calls).toEqual([
       [
-        {
+        expect.objectContaining({
           start: { sec: 0, nsec: 99000001 },
           end: { sec: 1, nsec: 0 },
           topics: mockTopicSelection("foo"),
           consumptionType: "partial",
           fetchCompleteTopicState: undefined,
-        },
+        }),
       ],
       [
-        {
+        expect.objectContaining({
           start: { sec: 0, nsec: 99000001 },
           end: { sec: 1, nsec: 0 },
           topics: mockTopicSelection("foo", "bar"),
           consumptionType: "partial",
           fetchCompleteTopicState: undefined,
-        },
+        }),
       ],
     ]);
 
@@ -925,13 +1011,13 @@ describe("IterablePlayer", () => {
 
     expect(messageIteratorSpy.mock.calls).toEqual([
       [
-        {
+        expect.objectContaining({
           start: { sec: 0, nsec: 99000001 },
           end: { sec: 1, nsec: 0 },
           topics: mockTopicSelection("foo"),
           consumptionType: "partial",
           fetchCompleteTopicState: undefined,
-        },
+        }),
       ],
     ]);
 

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -193,6 +193,7 @@ export class IterablePlayer implements Player {
 
   // The iterator for reading messages during playback
   #playbackIterator?: AsyncIterator<Readonly<IteratorResult>>;
+  #playbackIteratorAbort?: AbortController;
 
   #blockLoader?: BlockLoader;
   #blockLoadingProcess?: Promise<void>;
@@ -474,7 +475,15 @@ export class IterablePlayer implements Player {
     this.#nextState = newState;
     this.#abort?.abort();
     this.#abort = undefined;
+    if (newState !== "idle" && newState !== "play") {
+      this.#abortPlaybackIterator();
+    }
     void this.#runState();
+  }
+
+  #abortPlaybackIterator(): void {
+    this.#playbackIteratorAbort?.abort();
+    this.#playbackIteratorAbort = undefined;
   }
 
   /**
@@ -499,6 +508,7 @@ export class IterablePlayer implements Player {
         // we will need to make a new one.
         if (state !== "idle" && state !== "play" && this.#playbackIterator) {
           log.debug("Ending playback iterator because next state is not IDLE or PLAY");
+          this.#abortPlaybackIterator();
           await this.#playbackIterator.return?.();
           this.#playbackIterator = undefined;
         }
@@ -696,17 +706,21 @@ export class IterablePlayer implements Player {
         : add(this.#currentTime, { sec: 0, nsec: 1 });
 
     log.debug("Ending previous iterator");
+    this.#abortPlaybackIterator();
     await this.#playbackIterator?.return?.();
 
     // set the playIterator to the seek time
     await this.#bufferImpl.stopProducer();
 
     log.debug("Initializing forward iterator from", next);
+    const playbackIteratorAbort = new AbortController();
+    this.#playbackIteratorAbort = playbackIteratorAbort;
     this.#playbackIterator = this.#bufferedSource.messageIterator({
       topics: this.#allTopics,
       start: next,
       consumptionType: "partial",
       fetchCompleteTopicState,
+      abortSignal: playbackIteratorAbort.signal,
     });
 
     // Yield to the macrotask queue so that all pending microtasks from the new
@@ -1181,6 +1195,7 @@ export class IterablePlayer implements Player {
 
   async #stateClose() {
     this.#isPlaying = false;
+    this.#abortPlaybackIterator();
     await this.#blockLoader?.stopLoading();
     await this.#blockLoadingProcess;
     // Note: #bufferedSource and #bufferImpl are the same object now,

--- a/packages/studio-base/src/players/IterablePlayer/WorkerIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/WorkerIterableSource.ts
@@ -106,8 +106,11 @@ export class WorkerIterableSource implements IDeserializedIterableSource {
     // An AbortSignal is not clonable, so we remove it from the args and send it as a separate argumet
     // to our worker getBackfillMessages call. Our installed Comlink handler for AbortSignal handles
     // making the abort signal available within the worker.
-    const { abort, ...rest } = args;
-    const messageCursorPromise = this.#sourceWorkerRemote.getMessageCursor(rest, abort);
+    const { abort, abortSignal, ...rest } = args;
+    const messageCursorPromise = this.#sourceWorkerRemote.getMessageCursor(
+      rest,
+      abort ?? abortSignal,
+    );
 
     const cursor: IMessageCursor = {
       async next() {

--- a/packages/studio-base/src/players/IterablePlayer/WorkerIterableSourceWorker.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/WorkerIterableSourceWorker.test.ts
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { MessageEvent } from "@foxglove/studio";
+import { mockTopicSelection } from "@foxglove/studio-base/test/mocks/mockTopicSelection";
+
+import {
+  GetBackfillMessagesArgs,
+  IIterableSource,
+  ISerializedIterableSource,
+  Initalization,
+  IteratorResult,
+  MessageIteratorArgs,
+} from "./IIterableSource";
+import { WorkerIterableSourceWorker } from "./WorkerIterableSourceWorker";
+import { WorkerSerializedIterableSourceWorker } from "./WorkerSerializedIterableSourceWorker";
+
+class TestSource implements IIterableSource {
+  public messageIteratorArgs: MessageIteratorArgs | undefined;
+
+  public async initialize(): Promise<Initalization> {
+    return {
+      start: { sec: 0, nsec: 0 },
+      end: { sec: 1, nsec: 0 },
+      topics: [],
+      topicStats: new Map(),
+      profile: undefined,
+      problems: [],
+      datatypes: new Map(),
+      publishersByTopic: new Map(),
+    };
+  }
+
+  public async *messageIterator(
+    args: MessageIteratorArgs,
+  ): AsyncIterableIterator<Readonly<IteratorResult>> {
+    this.messageIteratorArgs = args;
+    yield* [];
+  }
+
+  public async getBackfillMessages(_args: GetBackfillMessagesArgs): Promise<MessageEvent[]> {
+    return [];
+  }
+}
+
+class TestSerializedSource implements ISerializedIterableSource {
+  public readonly sourceType = "serialized";
+  public messageIteratorArgs: MessageIteratorArgs | undefined;
+
+  public async initialize(): Promise<Initalization> {
+    return {
+      start: { sec: 0, nsec: 0 },
+      end: { sec: 1, nsec: 0 },
+      topics: [],
+      topicStats: new Map(),
+      profile: undefined,
+      problems: [],
+      datatypes: new Map(),
+      publishersByTopic: new Map(),
+    };
+  }
+
+  public async *messageIterator(
+    args: MessageIteratorArgs,
+  ): AsyncIterableIterator<Readonly<IteratorResult<Uint8Array>>> {
+    this.messageIteratorArgs = args;
+    yield* [];
+  }
+
+  public async getBackfillMessages(
+    _args: GetBackfillMessagesArgs,
+  ): Promise<MessageEvent<Uint8Array>[]> {
+    return [];
+  }
+}
+
+describe("WorkerIterableSourceWorker", () => {
+  it("passes the cursor abort signal to the source message iterator args", async () => {
+    const source = new TestSource();
+    const worker = new WorkerIterableSourceWorker(source);
+    const abortController = new AbortController();
+
+    const cursor = worker.getMessageCursor(
+      {
+        topics: mockTopicSelection("a"),
+        start: { sec: 0, nsec: 0 },
+      },
+      abortController.signal,
+    );
+    await cursor.next();
+
+    expect(source.messageIteratorArgs?.abortSignal).toBe(abortController.signal);
+  });
+});
+
+describe("WorkerSerializedIterableSourceWorker", () => {
+  it("passes the cursor abort signal to the serialized source message iterator args", async () => {
+    const source = new TestSerializedSource();
+    const worker = new WorkerSerializedIterableSourceWorker(source);
+    const abortController = new AbortController();
+
+    const cursor = worker.getMessageCursor(
+      {
+        topics: mockTopicSelection("a"),
+        start: { sec: 0, nsec: 0 },
+      },
+      abortController.signal,
+    );
+    await cursor.next();
+
+    expect(source.messageIteratorArgs?.abortSignal).toBe(abortController.signal);
+  });
+});

--- a/packages/studio-base/src/players/IterablePlayer/WorkerIterableSourceWorker.ts
+++ b/packages/studio-base/src/players/IterablePlayer/WorkerIterableSourceWorker.ts
@@ -50,10 +50,10 @@ export class WorkerIterableSourceWorker implements IIterableSource {
   }
 
   public getMessageCursor(
-    args: Omit<Immutable<MessageIteratorArgs>, "abort">,
+    args: Omit<Immutable<MessageIteratorArgs>, "abortSignal">,
     abort?: AbortSignal,
   ): IMessageCursor & Comlink.ProxyMarked {
-    const iter = this._source.messageIterator(args);
+    const iter = this._source.messageIterator({ ...args, abortSignal: abort });
     const cursor = new IteratorCursor(iter, abort);
     return Comlink.proxy(cursor);
   }

--- a/packages/studio-base/src/players/IterablePlayer/WorkerSerializedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/WorkerSerializedIterableSource.ts
@@ -105,8 +105,11 @@ export class WorkerSerializedIterableSource implements ISerializedIterableSource
     // An AbortSignal is not clonable, so we remove it from the args and send it as a separate argumet
     // to our worker getBackfillMessages call. Our installed Comlink handler for AbortSignal handles
     // making the abort signal available within the worker.
-    const { abort, ...rest } = args;
-    const messageCursorPromise = this.#sourceWorkerRemote.getMessageCursor(rest, abort);
+    const { abort, abortSignal, ...rest } = args;
+    const messageCursorPromise = this.#sourceWorkerRemote.getMessageCursor(
+      rest,
+      abort ?? abortSignal,
+    );
 
     const cursor: IMessageCursor<Uint8Array> = {
       async next() {

--- a/packages/studio-base/src/players/IterablePlayer/WorkerSerializedIterableSourceWorker.ts
+++ b/packages/studio-base/src/players/IterablePlayer/WorkerSerializedIterableSourceWorker.ts
@@ -56,10 +56,10 @@ export class WorkerSerializedIterableSourceWorker implements ISerializedIterable
   }
 
   public getMessageCursor(
-    args: Omit<Immutable<MessageIteratorArgs>, "abort">,
+    args: Omit<Immutable<MessageIteratorArgs>, "abortSignal">,
     abort?: AbortSignal,
   ): IMessageCursor<Uint8Array> & Comlink.ProxyMarked {
-    const iter = this.#source.messageIterator(args);
+    const iter = this.#source.messageIterator({ ...args, abortSignal: abort });
     const cursor = new ComlinkTransferIteratorCursor(new IteratorCursor<Uint8Array>(iter, abort));
     return Comlink.proxy(cursor);
   }

--- a/packages/studio-base/src/players/IterablePlayer/coScene-data-platform/DataPlatformIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/coScene-data-platform/DataPlatformIterableSource.test.ts
@@ -33,14 +33,14 @@ async function waitFor(predicate: () => boolean): Promise<void> {
 }
 
 describe("DataPlatformIterableSource", () => {
-  it("aborts the active getStreams request when the iterator abort signal fires", async () => {
-    let getStreamsSignal: AbortSignal | undefined;
-
-    const api: DataPlatformInterableSourceConsoleApi = {
+  function makeApi(
+    getStreams: DataPlatformInterableSourceConsoleApi["getStreams"],
+  ): DataPlatformInterableSourceConsoleApi {
+    return {
       async topics() {
         return {
           start: "1970-01-01T00:00:00.000Z",
-          end: "1970-01-01T00:00:01.000Z",
+          end: "1970-01-01T00:00:03.000Z",
           metaData: [
             {
               topic: "/json",
@@ -53,19 +53,25 @@ describe("DataPlatformIterableSource", () => {
           ],
         };
       },
-      async getStreams({ signal }) {
-        getStreamsSignal = signal;
-        return await new Promise<Response>((_resolve, reject) => {
-          signal.addEventListener(
-            "abort",
-            () => {
-              reject(new DOMException("Aborted", "AbortError"));
-            },
-            { once: true },
-          );
-        });
-      },
+      getStreams,
     };
+  }
+
+  it("aborts the active getStreams request when the iterator abort signal fires", async () => {
+    let getStreamsSignal: AbortSignal | undefined;
+
+    const api = makeApi(async ({ signal }) => {
+      getStreamsSignal = signal;
+      return await new Promise<Response>((_resolve, reject) => {
+        signal.addEventListener(
+          "abort",
+          () => {
+            reject(new DOMException("Aborted", "AbortError"));
+          },
+          { once: true },
+        );
+      });
+    });
 
     const source = new DataPlatformIterableSource({
       api,
@@ -94,5 +100,67 @@ describe("DataPlatformIterableSource", () => {
     await expect(race([nextPromise, delay(50)])).resolves.toMatchObject({
       done: true,
     });
+  });
+
+  it("does not request the next partial window after the iterator abort signal fires", async () => {
+    const abortController = new AbortController();
+    const getStreams = jest.fn(async ({ signal }) => {
+      return await new Promise<Response>((_resolve, reject) => {
+        signal.addEventListener(
+          "abort",
+          () => {
+            reject(new DOMException("Aborted", "AbortError"));
+          },
+          { once: true },
+        );
+        abortController.abort();
+        if (signal.aborted === true) {
+          reject(new DOMException("Aborted", "AbortError"));
+        }
+      });
+    });
+    const source = new DataPlatformIterableSource({
+      api: makeApi(getStreams),
+      params: { key: "record-id", projectName: "warehouses/w/projects/p" },
+      requestWindow: { sec: 1, nsec: 0 },
+    });
+    await source.initialize();
+
+    const iterator = source.messageIterator({
+      topics: mockTopicSelection("/json"),
+      start: { sec: 0, nsec: 0 },
+      end: { sec: 3, nsec: 0 },
+      consumptionType: "partial",
+      abortSignal: abortController.signal,
+    });
+
+    await expect(race([iterator.next(), delay(50)])).resolves.toEqual({ done: true });
+    expect(getStreams).toHaveBeenCalledTimes(1);
+    expect(getStreams.mock.calls[0]?.[0].signal.aborted).toBe(true);
+  });
+
+  it("does not request streams when the iterator abort signal is already aborted", async () => {
+    const abortController = new AbortController();
+    abortController.abort();
+    const getStreams = jest.fn(async () => {
+      throw new Error("should not request streams");
+    });
+    const source = new DataPlatformIterableSource({
+      api: makeApi(getStreams),
+      params: { key: "record-id", projectName: "warehouses/w/projects/p" },
+      requestWindow: { sec: 1, nsec: 0 },
+    });
+    await source.initialize();
+
+    const iterator = source.messageIterator({
+      topics: mockTopicSelection("/json"),
+      start: { sec: 0, nsec: 0 },
+      end: { sec: 3, nsec: 0 },
+      consumptionType: "partial",
+      abortSignal: abortController.signal,
+    });
+
+    await expect(iterator.next()).resolves.toEqual({ done: true });
+    expect(getStreams).not.toHaveBeenCalled();
   });
 });

--- a/packages/studio-base/src/players/IterablePlayer/coScene-data-platform/DataPlatformIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/coScene-data-platform/DataPlatformIterableSource.test.ts
@@ -5,6 +5,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import race from "race-as-promised";
+
 import { mockTopicSelection } from "@foxglove/studio-base/test/mocks/mockTopicSelection";
 
 import {
@@ -89,7 +91,7 @@ describe("DataPlatformIterableSource", () => {
     abortController.abort();
 
     expect(getStreamsSignal?.aborted).toBe(true);
-    await expect(Promise.race([nextPromise, delay(50)])).resolves.toMatchObject({
+    await expect(race([nextPromise, delay(50)])).resolves.toMatchObject({
       done: true,
     });
   });

--- a/packages/studio-base/src/players/IterablePlayer/coScene-data-platform/DataPlatformIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/coScene-data-platform/DataPlatformIterableSource.test.ts
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { mockTopicSelection } from "@foxglove/studio-base/test/mocks/mockTopicSelection";
+
+import {
+  DataPlatformInterableSourceConsoleApi,
+  DataPlatformIterableSource,
+} from "./DataPlatformIterableSource";
+
+async function delay(ms: number): Promise<"timeout"> {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+  return "timeout";
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    await delay(10);
+  }
+  expect(predicate()).toBe(true);
+}
+
+describe("DataPlatformIterableSource", () => {
+  it("aborts the active getStreams request when the iterator abort signal fires", async () => {
+    let getStreamsSignal: AbortSignal | undefined;
+
+    const api: DataPlatformInterableSourceConsoleApi = {
+      async topics() {
+        return {
+          start: "1970-01-01T00:00:00.000Z",
+          end: "1970-01-01T00:00:01.000Z",
+          metaData: [
+            {
+              topic: "/json",
+              encoding: "json",
+              schemaName: "JsonMessage",
+              schemaEncoding: "jsonschema",
+              schema: new TextEncoder().encode(JSON.stringify({ type: "object" })),
+              version: "1",
+            },
+          ],
+        };
+      },
+      async getStreams({ signal }) {
+        getStreamsSignal = signal;
+        return await new Promise<Response>((_resolve, reject) => {
+          signal.addEventListener(
+            "abort",
+            () => {
+              reject(new DOMException("Aborted", "AbortError"));
+            },
+            { once: true },
+          );
+        });
+      },
+    };
+
+    const source = new DataPlatformIterableSource({
+      api,
+      params: { key: "record-id", projectName: "warehouses/w/projects/p" },
+      requestWindow: { sec: 1, nsec: 0 },
+    });
+    await source.initialize();
+
+    const abortController = new AbortController();
+    const iterator = source.messageIterator({
+      topics: mockTopicSelection("/json"),
+      start: { sec: 0, nsec: 0 },
+      end: { sec: 0, nsec: 0 },
+      consumptionType: "partial",
+      abortSignal: abortController.signal,
+    } as Parameters<DataPlatformIterableSource["messageIterator"]>[0] & {
+      abortSignal: AbortSignal;
+    });
+
+    const nextPromise = iterator.next();
+    await waitFor(() => getStreamsSignal != undefined);
+
+    abortController.abort();
+
+    expect(getStreamsSignal?.aborted).toBe(true);
+    await expect(Promise.race([nextPromise, delay(50)])).resolves.toMatchObject({
+      done: true,
+    });
+  });
+});

--- a/packages/studio-base/src/players/IterablePlayer/coScene-data-platform/DataPlatformIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/coScene-data-platform/DataPlatformIterableSource.ts
@@ -237,6 +237,7 @@ export class DataPlatformIterableSource implements IIterableSource {
 
       const stream = streamMessages({
         api: this.#consoleApi,
+        signal: args.abortSignal,
         parsedChannelsByTopic,
         params: streamByParams,
       });
@@ -269,6 +270,7 @@ export class DataPlatformIterableSource implements IIterableSource {
 
       const stream = streamMessages({
         api: this.#consoleApi,
+        signal: args.abortSignal,
         parsedChannelsByTopic,
         params: streamByParams,
       });

--- a/packages/studio-base/src/players/IterablePlayer/coScene-data-platform/DataPlatformIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/coScene-data-platform/DataPlatformIterableSource.ts
@@ -33,6 +33,10 @@ import {
 
 const log = Logger.getLogger(__filename);
 
+function isAborted(signal: AbortSignal | undefined): boolean {
+  return signal?.aborted === true;
+}
+
 /**
  * The console api methods used by DataPlatformIterableSource.
  *
@@ -194,6 +198,10 @@ export class DataPlatformIterableSource implements IIterableSource {
   ): AsyncIterableIterator<Readonly<IteratorResult>> {
     log.debug("message iterator", args);
 
+    if (isAborted(args.abortSignal)) {
+      return;
+    }
+
     const topics = args.topics;
     const topicNames = Array.from(topics.keys());
 
@@ -226,6 +234,10 @@ export class DataPlatformIterableSource implements IIterableSource {
     const streamEnd = clampTime(args.end ?? this.#end, this.#start, this.#end);
 
     if (args.consumptionType === "full") {
+      if (isAborted(args.abortSignal)) {
+        return;
+      }
+
       const streamByParams: StreamParams = {
         start: streamStart,
         end: streamEnd,
@@ -243,9 +255,19 @@ export class DataPlatformIterableSource implements IIterableSource {
       });
 
       for await (const messages of stream) {
+        if (isAborted(args.abortSignal)) {
+          return;
+        }
         for (const message of messages) {
+          if (isAborted(args.abortSignal)) {
+            return;
+          }
           yield message;
         }
+      }
+
+      if (isAborted(args.abortSignal)) {
+        return;
       }
 
       if (fetchCompleteTopicState === "complete") {
@@ -259,6 +281,10 @@ export class DataPlatformIterableSource implements IIterableSource {
     let localEnd = clampTime(addTime(localStart, this.#requestWindow), streamStart, streamEnd);
 
     for (;;) {
+      if (isAborted(args.abortSignal)) {
+        return;
+      }
+
       const streamByParams: StreamParams = {
         start: localStart,
         end: localEnd,
@@ -276,9 +302,19 @@ export class DataPlatformIterableSource implements IIterableSource {
       });
 
       for await (const messages of stream) {
+        if (isAborted(args.abortSignal)) {
+          return;
+        }
         for (const message of messages) {
+          if (isAborted(args.abortSignal)) {
+            return;
+          }
           yield message;
         }
+      }
+
+      if (isAborted(args.abortSignal)) {
+        return;
       }
 
       if (compare(localEnd, streamEnd) >= 0) {

--- a/packages/studio-base/src/players/IterablePlayer/coScene-data-platform/streamMessages.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/coScene-data-platform/streamMessages.test.ts
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { loadDecompressHandlers } from "@foxglove/mcap-support";
+
+import { streamMessages } from "./streamMessages";
+
+jest.mock("@foxglove/mcap-support", () => ({
+  loadDecompressHandlers: jest.fn(),
+  parseChannel: jest.fn(),
+}));
+
+const mockLoadDecompressHandlers = loadDecompressHandlers as jest.MockedFunction<
+  typeof loadDecompressHandlers
+>;
+
+type StreamResponse = Awaited<
+  ReturnType<Parameters<typeof streamMessages>[0]["api"]["getStreams"]>
+>;
+
+function response(
+  status: number,
+  options?: { body?: ReadableStream; message?: string },
+): StreamResponse {
+  return {
+    status,
+    body: options?.body,
+    json: async () => ({ message: options?.message }),
+  } as StreamResponse;
+}
+
+describe("streamMessages", () => {
+  beforeEach(() => {
+    mockLoadDecompressHandlers.mockReset();
+    mockLoadDecompressHandlers.mockResolvedValue({});
+  });
+
+  it("removes the abort listener when abort happens while loading decompress handlers", async () => {
+    const abortController = new AbortController();
+    const removeEventListenerSpy = jest.spyOn(abortController.signal, "removeEventListener");
+    const getStreams = jest.fn(async () => {
+      throw new Error("should not request streams");
+    });
+
+    mockLoadDecompressHandlers.mockImplementation(async () => {
+      abortController.abort();
+      return {};
+    });
+
+    const iterator = streamMessages({
+      api: { getStreams },
+      signal: abortController.signal,
+      parsedChannelsByTopic: new Map(),
+      params: {
+        start: { sec: 0, nsec: 0 },
+        end: { sec: 0, nsec: 0 },
+        id: "record-id",
+        projectName: "warehouses/w/projects/p",
+        topics: ["/json"],
+      },
+    });
+
+    await expect(iterator.next()).resolves.toEqual({ done: true, value: undefined });
+    expect(getStreams).not.toHaveBeenCalled();
+    expect(removeEventListenerSpy).toHaveBeenCalledTimes(1);
+    expect(removeEventListenerSpy.mock.calls[0]?.[0]).toBe("abort");
+    expect(removeEventListenerSpy.mock.calls[0]?.[1]).toEqual(expect.any(Function));
+  });
+
+  it.each([
+    {
+      name: "getStreams rejects",
+      getStreams: jest.fn(async () => {
+        throw new Error("request failed");
+      }),
+      expectedError: "request failed",
+    },
+    {
+      name: "401 response",
+      getStreams: jest.fn(async () => response(401)),
+      expectedError: "Login expired, please login again",
+    },
+    {
+      name: "404 response",
+      getStreams: jest.fn(async () => response(404)),
+    },
+    {
+      name: "non-200 response",
+      getStreams: jest.fn(async () => response(500, { message: "backend failed" })),
+      expectedError: "backend failed",
+    },
+    {
+      name: "missing response body",
+      getStreams: jest.fn(async () => response(200)),
+      expectedError: "Unable to stream response body",
+    },
+  ])(
+    "removes the abort listener when $name exits before parsing",
+    async ({ getStreams, expectedError }) => {
+      const abortController = new AbortController();
+      const removeEventListenerSpy = jest.spyOn(abortController.signal, "removeEventListener");
+
+      const iterator = streamMessages({
+        api: { getStreams },
+        signal: abortController.signal,
+        parsedChannelsByTopic: new Map(),
+        params: {
+          start: { sec: 0, nsec: 0 },
+          end: { sec: 0, nsec: 0 },
+          id: "record-id",
+          projectName: "warehouses/w/projects/p",
+          topics: ["/json"],
+        },
+      });
+
+      if (expectedError != undefined) {
+        await expect(iterator.next()).rejects.toThrow(expectedError);
+      } else {
+        await expect(iterator.next()).resolves.toEqual({ done: true, value: undefined });
+      }
+
+      expect(removeEventListenerSpy).toHaveBeenCalledTimes(1);
+      expect(removeEventListenerSpy.mock.calls[0]?.[0]).toBe("abort");
+      expect(removeEventListenerSpy.mock.calls[0]?.[1]).toEqual(expect.any(Function));
+    },
+  );
+});

--- a/packages/studio-base/src/players/IterablePlayer/coScene-data-platform/streamMessages.ts
+++ b/packages/studio-base/src/players/IterablePlayer/coScene-data-platform/streamMessages.ts
@@ -75,6 +75,10 @@ export async function* streamMessages({
    */
   parsedChannelsByTopic: Map<string, ParsedChannelAndEncodings[]>;
 }): AsyncGenerator<IteratorResult[]> {
+  if (signal?.aborted === true) {
+    return;
+  }
+
   // Local connection ID management for this streaming session
   const connectionIdByTopic: Record<string, number> = {};
   let nextConnectionId = 0;

--- a/packages/studio-base/src/players/IterablePlayer/coScene-data-platform/streamMessages.ts
+++ b/packages/studio-base/src/players/IterablePlayer/coScene-data-platform/streamMessages.ts
@@ -88,277 +88,300 @@ export async function* streamMessages({
     log.debug("Manual abort of streamMessages", params);
     controller.abort();
   };
-  signal?.addEventListener("abort", abortHandler);
-  const decompressHandlers = await loadDecompressHandlers();
-
-  log.debug("streamMessages", params);
-  const startTimer = performance.now();
-
-  if (controller.signal.aborted) {
-    return;
+  let abortHandlerInstalled = false;
+  const removeAbortHandler = () => {
+    if (abortHandlerInstalled) {
+      signal?.removeEventListener("abort", abortHandler);
+      abortHandlerInstalled = false;
+    }
+  };
+  if (signal != undefined) {
+    signal.addEventListener("abort", abortHandler);
+    abortHandlerInstalled = true;
   }
 
-  let totalMessages = 0;
-  let results: IteratorResult[] = [];
-
-  // Limit batch size to avoid blocking consumer too long
-  const MAX_BATCH_SIZE = 500; // Yield every 500 messages
-  const MAX_BATCH_TIME_MS = 50; // Or every 50ms
-  let lastYieldTime = performance.now();
-
-  const schemasById = new Map<number, McapTypes.TypedMcapRecords["Schema"]>();
-  const channelInfoById = new Map<
-    number,
-    {
-      channel: McapTypes.TypedMcapRecords["Channel"];
-      parsedChannel: ParsedChannel;
-      schemaName: string;
-    }
-  >();
-
-  function processRecord(record: McapTypes.TypedMcapRecord) {
-    switch (record.type) {
-      default:
-        return;
-
-      case "Schema":
-        schemasById.set(record.id, record);
-        return;
-
-      case "Channel": {
-        if (channelInfoById.has(record.id)) {
-          return;
-        }
-        if (record.schemaId === 0) {
-          throw new Error(
-            `Channel ${record.id} (topic ${record.topic}) has no schema; channels without schemas are not supported`,
-          );
-        }
-        const schema = schemasById.get(record.schemaId);
-        if (!schema) {
-          throw new Error(
-            `Missing schema info for schema id ${record.schemaId} (channel ${record.id}, topic ${record.topic})`,
-          );
-        }
-        const parsedChannels = parsedChannelsByTopic.get(record.topic) ?? [];
-        for (const info of parsedChannels) {
-          if (
-            info.messageEncoding === record.messageEncoding &&
-            info.schemaEncoding === schema.encoding &&
-            _.isEqual(info.schema, schema.data)
-          ) {
-            channelInfoById.set(record.id, {
-              channel: record,
-              parsedChannel: info.parsedChannel,
-              schemaName: schema.name,
-            });
-            return;
-          }
-        }
-
-        // We've not found a previously parsed channel with matching schema
-        // Create one here just-in-time
-        const parsedChannel = parseChannel({
-          messageEncoding: record.messageEncoding,
-          schema,
-        });
-
-        parsedChannels.push({
-          messageEncoding: record.messageEncoding,
-          schemaEncoding: schema.encoding,
-          schema: schema.data,
-          parsedChannel,
-        });
-
-        parsedChannelsByTopic.set(record.topic, parsedChannels);
-
-        channelInfoById.set(record.id, {
-          channel: record,
-          parsedChannel,
-          schemaName: schema.name,
-        });
-
-        const err = new Error(
-          `No pre-initialized reader for ${record.topic} (message encoding ${record.messageEncoding}, schema encoding ${schema.encoding}, schema name ${schema.name})`,
-        );
-        captureException(err);
-        return;
-      }
-
-      case "Message": {
-        const info = channelInfoById.get(record.channelId);
-        if (!info) {
-          throw new Error(`message for channel ${record.channelId} with no prior channel/schema`);
-        }
-        const receiveTime = fromNanoSec(record.logTime);
-        totalMessages++;
-
-        try {
-          const deserializedMessage = info.parsedChannel.deserialize(record.data);
-          results.push({
-            type: "message-event",
-            msgEvent: {
-              topic: info.channel.topic,
-              receiveTime,
-              message: deserializedMessage,
-              sizeInBytes: record.data.byteLength,
-              schemaName: info.schemaName,
-            },
-          });
-        } catch (err) {
-          // Similar to DeserializingIterableSource error handling - create a problem for the main thread
-          console.error(`Failed to deserialize message on topic ${info.channel.topic}:`, err);
-          captureException(err, {
-            extra: {
-              topic: info.channel.topic,
-              channelId: record.channelId,
-              messageSize: record.data.byteLength,
-              schemaName: info.schemaName,
-            },
-          });
-
-          // Assign a unique connection ID for each topic in this streaming session
-          if (connectionIdByTopic[info.channel.topic] == undefined) {
-            connectionIdByTopic[info.channel.topic] = nextConnectionId++;
-          }
-          const connectionId = connectionIdByTopic[info.channel.topic]!;
-
-          results.push({
-            type: "problem",
-            connectionId,
-            problem: {
-              severity: "error",
-              message: `Failed to deserialize message on topic ${
-                info.channel.topic
-              }. ${err.toString()}`,
-              tip: `Check that your input file is not corrupted.`,
-            },
-          });
-        }
-        return;
-      }
+  let decompressHandlers: Awaited<ReturnType<typeof loadDecompressHandlers>>;
+  let decompressHandlersLoaded = false;
+  try {
+    decompressHandlers = await loadDecompressHandlers();
+    decompressHandlersLoaded = true;
+  } finally {
+    if (!decompressHandlersLoaded || controller.signal.aborted) {
+      removeAbortHandler();
     }
   }
-
-  let fetchStartTime = 0;
-  let fetchEndTime = 0;
-  let decodeEndTime = 0;
 
   try {
-    // Since every request is signed with a new token, there's no benefit to caching.
-    fetchStartTime = performance.now();
+    log.debug("streamMessages", params);
+    const startTimer = performance.now();
 
-    const response = await api.getStreams({
-      start: toMillis(params.start),
-      end: toMillis(params.end),
-      topics: params.topics,
-      id: params.id,
-      signal: controller.signal,
-      projectName: params.projectName ?? "",
-      fetchCompleteTopicState: params.fetchCompleteTopicState,
-    });
-
-    fetchEndTime = performance.now();
-
-    if (response.status === 401) {
-      throw new Error("Login expired, please login again");
-    }
-    if (response.status === 404) {
+    if (controller.signal.aborted) {
       return;
-    } else if (response.status !== 200) {
-      const errorBody = (await response.json()) as { message?: string };
-      if (errorBody.message) {
-        throw new Error(errorBody.message);
+    }
+
+    let totalMessages = 0;
+    let results: IteratorResult[] = [];
+
+    // Limit batch size to avoid blocking consumer too long
+    const MAX_BATCH_SIZE = 500; // Yield every 500 messages
+    const MAX_BATCH_TIME_MS = 50; // Or every 50ms
+    let lastYieldTime = performance.now();
+
+    const schemasById = new Map<number, McapTypes.TypedMcapRecords["Schema"]>();
+    const channelInfoById = new Map<
+      number,
+      {
+        channel: McapTypes.TypedMcapRecords["Channel"];
+        parsedChannel: ParsedChannel;
+        schemaName: string;
       }
-      throw new Error(`Unexpected response status ${response.status}`);
-    }
-    if (!response.body) {
-      throw new Error("Unable to stream response body");
-    }
-    const streamReader = response.body.getReader();
+    >();
 
-    let normalReturn = false;
-    parseLoop: try {
-      const reader = new McapStreamReader({ decompressHandlers });
-      for (let result; (result = await streamReader.read()), !result.done; ) {
-        reader.append(result.value);
-        for (let record; (record = reader.nextRecord()); ) {
-          if (record.type === "DataEnd") {
-            normalReturn = true;
-            break;
+    function processRecord(record: McapTypes.TypedMcapRecord) {
+      switch (record.type) {
+        default:
+          return;
+
+        case "Schema":
+          schemasById.set(record.id, record);
+          return;
+
+        case "Channel": {
+          if (channelInfoById.has(record.id)) {
+            return;
           }
-          processRecord(record);
+          if (record.schemaId === 0) {
+            throw new Error(
+              `Channel ${record.id} (topic ${record.topic}) has no schema; channels without schemas are not supported`,
+            );
+          }
+          const schema = schemasById.get(record.schemaId);
+          if (!schema) {
+            throw new Error(
+              `Missing schema info for schema id ${record.schemaId} (channel ${record.id}, topic ${record.topic})`,
+            );
+          }
+          const parsedChannels = parsedChannelsByTopic.get(record.topic) ?? [];
+          for (const info of parsedChannels) {
+            if (
+              info.messageEncoding === record.messageEncoding &&
+              info.schemaEncoding === schema.encoding &&
+              _.isEqual(info.schema, schema.data)
+            ) {
+              channelInfoById.set(record.id, {
+                channel: record,
+                parsedChannel: info.parsedChannel,
+                schemaName: schema.name,
+              });
+              return;
+            }
+          }
 
-          // 只检查数量，避免频繁调用 performance.now()
-          if (results.length >= MAX_BATCH_SIZE) {
+          // We've not found a previously parsed channel with matching schema
+          // Create one here just-in-time
+          const parsedChannel = parseChannel({
+            messageEncoding: record.messageEncoding,
+            schema,
+          });
+
+          parsedChannels.push({
+            messageEncoding: record.messageEncoding,
+            schemaEncoding: schema.encoding,
+            schema: schema.data,
+            parsedChannel,
+          });
+
+          parsedChannelsByTopic.set(record.topic, parsedChannels);
+
+          channelInfoById.set(record.id, {
+            channel: record,
+            parsedChannel,
+            schemaName: schema.name,
+          });
+
+          const err = new Error(
+            `No pre-initialized reader for ${record.topic} (message encoding ${record.messageEncoding}, schema encoding ${schema.encoding}, schema name ${schema.name})`,
+          );
+          captureException(err);
+          return;
+        }
+
+        case "Message": {
+          const info = channelInfoById.get(record.channelId);
+          if (!info) {
+            throw new Error(`message for channel ${record.channelId} with no prior channel/schema`);
+          }
+          const receiveTime = fromNanoSec(record.logTime);
+          totalMessages++;
+
+          try {
+            const deserializedMessage = info.parsedChannel.deserialize(record.data);
+            results.push({
+              type: "message-event",
+              msgEvent: {
+                topic: info.channel.topic,
+                receiveTime,
+                message: deserializedMessage,
+                sizeInBytes: record.data.byteLength,
+                schemaName: info.schemaName,
+              },
+            });
+          } catch (err) {
+            // Similar to DeserializingIterableSource error handling - create a problem for the main thread
+            console.error(`Failed to deserialize message on topic ${info.channel.topic}:`, err);
+            captureException(err, {
+              extra: {
+                topic: info.channel.topic,
+                channelId: record.channelId,
+                messageSize: record.data.byteLength,
+                schemaName: info.schemaName,
+              },
+            });
+
+            // Assign a unique connection ID for each topic in this streaming session
+            if (connectionIdByTopic[info.channel.topic] == undefined) {
+              connectionIdByTopic[info.channel.topic] = nextConnectionId++;
+            }
+            const connectionId = connectionIdByTopic[info.channel.topic]!;
+
+            results.push({
+              type: "problem",
+              connectionId,
+              problem: {
+                severity: "error",
+                message: `Failed to deserialize message on topic ${
+                  info.channel.topic
+                }. ${err.toString()}`,
+                tip: `Check that your input file is not corrupted.`,
+              },
+            });
+          }
+          return;
+        }
+      }
+    }
+
+    let fetchStartTime = 0;
+    let fetchEndTime = 0;
+    let decodeEndTime = 0;
+
+    try {
+      // Since every request is signed with a new token, there's no benefit to caching.
+      fetchStartTime = performance.now();
+
+      const response = await api.getStreams({
+        start: toMillis(params.start),
+        end: toMillis(params.end),
+        topics: params.topics,
+        id: params.id,
+        signal: controller.signal,
+        projectName: params.projectName ?? "",
+        fetchCompleteTopicState: params.fetchCompleteTopicState,
+      });
+
+      fetchEndTime = performance.now();
+
+      if (response.status === 401) {
+        throw new Error("Login expired, please login again");
+      }
+      if (response.status === 404) {
+        return;
+      } else if (response.status !== 200) {
+        const errorBody = (await response.json()) as { message?: string };
+        if (errorBody.message) {
+          throw new Error(errorBody.message);
+        }
+        throw new Error(`Unexpected response status ${response.status}`);
+      }
+      if (!response.body) {
+        throw new Error("Unable to stream response body");
+      }
+      const streamReader = response.body.getReader();
+
+      let normalReturn = false;
+      parseLoop: try {
+        const reader = new McapStreamReader({ decompressHandlers });
+        for (let result; (result = await streamReader.read()), !result.done; ) {
+          reader.append(result.value);
+          for (let record; (record = reader.nextRecord()); ) {
+            if (record.type === "DataEnd") {
+              normalReturn = true;
+              break;
+            }
+            processRecord(record);
+
+            // 只检查数量，避免频繁调用 performance.now()
+            if (results.length >= MAX_BATCH_SIZE) {
+              yield results;
+              results = [];
+              lastYieldTime = performance.now();
+            }
+          }
+
+          // 处理完一个 chunk 后，检查时间或剩余数据
+          const now = performance.now();
+          const timeSinceLastYield = now - lastYieldTime;
+          if (results.length > 0 && timeSinceLastYield >= MAX_BATCH_TIME_MS) {
             yield results;
             results = [];
             lastYieldTime = performance.now();
           }
+
+          if (normalReturn) {
+            break parseLoop;
+          }
+        }
+        if (!reader.done()) {
+          throw new Error("Incomplete mcap file");
         }
 
-        // 处理完一个 chunk 后，检查时间或剩余数据
-        const now = performance.now();
-        const timeSinceLastYield = now - lastYieldTime;
-        if (results.length > 0 && timeSinceLastYield >= MAX_BATCH_TIME_MS) {
+        // Yield any remaining messages
+        if (results.length > 0) {
           yield results;
           results = [];
-          lastYieldTime = performance.now();
         }
 
-        if (normalReturn) {
-          break parseLoop;
+        normalReturn = true;
+      } finally {
+        // Flush any remaining buffered messages before cleanup, even if aborted/errored
+        if (results.length > 0) {
+          yield results;
+          results = [];
         }
-      }
-      if (!reader.done()) {
-        throw new Error("Incomplete mcap file");
-      }
 
-      // Yield any remaining messages
-      if (results.length > 0) {
-        yield results;
-        results = [];
+        if (!normalReturn) {
+          // If the caller called generator.return() in between body chunks, automatically cancel the request.
+          log.debug("Automatic abort of streamMessages", params);
+        }
+        controller.abort();
       }
-
-      normalReturn = true;
-    } finally {
-      // Flush any remaining buffered messages before cleanup, even if aborted/errored
-      if (results.length > 0) {
-        yield results;
-        results = [];
+    } catch (err) {
+      // Capture errors from manually aborting the request via the abort controller.
+      const errorName =
+        typeof err === "object" && err != undefined && "name" in err ? err.name : undefined;
+      const errorMessage =
+        typeof err === "object" && err != undefined && "message" in err ? err.message : undefined;
+      if (errorName === "AbortError" || errorMessage === "The user aborted a request.") {
+        return;
       }
-
-      if (!normalReturn) {
-        // If the caller called generator.return() in between body chunks, automatically cancel the request.
-        log.debug("Automatic abort of streamMessages", params);
-      }
-      signal?.removeEventListener("abort", abortHandler);
-      controller.abort();
+      throw err;
     }
-  } catch (err) {
-    // Capture errors from manually aborting the request via the abort controller.
-    const errorName =
-      typeof err === "object" && err != undefined && "name" in err ? err.name : undefined;
-    const errorMessage =
-      typeof err === "object" && err != undefined && "message" in err ? err.message : undefined;
-    if (errorName === "AbortError" || errorMessage === "The user aborted a request.") {
-      return;
-    }
-    throw err;
+
+    decodeEndTime = performance.now();
+
+    log.debug(
+      "message",
+      results,
+      "total message",
+      totalMessages,
+      "fetch time",
+      `${(fetchEndTime - fetchStartTime) / 1000}s`,
+      "decode time",
+      `${(decodeEndTime - fetchEndTime) / 1000}s`,
+      "total time",
+      `${(decodeEndTime - startTimer) / 1000}s`,
+    );
+  } finally {
+    removeAbortHandler();
   }
-
-  decodeEndTime = performance.now();
-
-  log.debug(
-    "message",
-    results,
-    "total message",
-    totalMessages,
-    "fetch time",
-    `${(fetchEndTime - fetchStartTime) / 1000}s`,
-    "decode time",
-    `${(decodeEndTime - fetchEndTime) / 1000}s`,
-    "total time",
-    `${(decodeEndTime - startTimer) / 1000}s`,
-  );
 }

--- a/packages/studio-base/src/players/IterablePlayer/coScene-data-platform/streamMessages.ts
+++ b/packages/studio-base/src/players/IterablePlayer/coScene-data-platform/streamMessages.ts
@@ -333,7 +333,11 @@ export async function* streamMessages({
     }
   } catch (err) {
     // Capture errors from manually aborting the request via the abort controller.
-    if (err instanceof DOMException && err.message === "The user aborted a request.") {
+    const errorName =
+      typeof err === "object" && err != undefined && "name" in err ? err.name : undefined;
+    const errorMessage =
+      typeof err === "object" && err != undefined && "message" in err ? err.message : undefined;
+    if (errorName === "AbortError" || errorMessage === "The user aborted a request.") {
       return;
     }
     throw err;

--- a/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/CoalescingRemoteReadable.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/CoalescingRemoteReadable.test.ts
@@ -97,4 +97,54 @@ describe("CoalescingRemoteReadable", () => {
       global.fetch = originalFetch;
     }
   });
+
+  it("aborts an in-flight range when the external abort signal fires", async () => {
+    const chunk = deferred<Uint8Array>();
+    const abortController = new AbortController();
+    const abortSignals: AbortSignal[] = [];
+    const originalFetch = global.fetch;
+
+    global.fetch = jest.fn().mockImplementation(async (_url: string, init?: RequestInit) => {
+      const signal = init?.signal as AbortSignal | undefined;
+      if (signal != undefined) {
+        abortSignals.push(signal);
+      }
+
+      return {
+        ok: true,
+        status: 206,
+        body: {
+          getReader: () => ({
+            read: async () => {
+              if (signal?.aborted === true) {
+                throw new DOMException("signal is aborted without reason", "AbortError");
+              }
+              await chunk.promise;
+              return { done: false, value: new Uint8Array([1, 2, 3, 4]) };
+            },
+          }),
+        },
+      };
+    }) as jest.MockedFunction<typeof fetch>;
+
+    try {
+      const readable = new CoalescingRemoteReadable(
+        "https://example.com/shard.mcap",
+        4,
+        16,
+        abortController.signal,
+      );
+
+      const read = readable.read(0n, 4n);
+      await Promise.resolve();
+
+      abortController.abort();
+
+      expect(abortSignals[0]?.aborted).toBe(true);
+      await expect(read).rejects.toThrow("aborted");
+    } finally {
+      chunk.resolve(new Uint8Array([1, 2, 3, 4]));
+      global.fetch = originalFetch;
+    }
+  });
 });

--- a/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/CoalescingRemoteReadable.ts
+++ b/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/CoalescingRemoteReadable.ts
@@ -48,6 +48,8 @@ type ActiveFetch = {
   offset: bigint;
   end: bigint;
   abortController: AbortController;
+  externalAbortSignal?: AbortSignal;
+  externalAbortHandler?: () => void;
   buffer: Uint8Array;
   bytesDownloaded: number;
   waiters: { needed: number; resolve: () => void; reject: (e: unknown) => void }[];
@@ -59,15 +61,22 @@ export class CoalescingRemoteReadable implements McapTypes.IReadable {
   #url: string;
   #readAhead: bigint;
   #fileSize: bigint;
+  #abortSignal?: AbortSignal;
   #active?: ActiveFetch;
 
-  public constructor(url: string, readAheadBytes: number, fileSizeBytes: number) {
+  public constructor(
+    url: string,
+    readAheadBytes: number,
+    fileSizeBytes: number,
+    abortSignal?: AbortSignal,
+  ) {
     if (!Number.isFinite(fileSizeBytes) || fileSizeBytes < 0) {
       throw new Error(`CoalescingRemoteReadable invalid file size: ${fileSizeBytes}`);
     }
     this.#url = url;
     this.#readAhead = BigInt(Math.max(0, Math.floor(readAheadBytes)));
     this.#fileSize = BigInt(Math.floor(fileSizeBytes));
+    this.#abortSignal = abortSignal;
   }
 
   public async open(): Promise<void> {
@@ -79,6 +88,10 @@ export class CoalescingRemoteReadable implements McapTypes.IReadable {
   }
 
   public async read(offset: bigint, size: bigint): Promise<Uint8Array> {
+    if (isAborted(this.#abortSignal)) {
+      throw abortError();
+    }
+
     if (size === 0n) {
       return new Uint8Array();
     }
@@ -119,6 +132,9 @@ export class CoalescingRemoteReadable implements McapTypes.IReadable {
 
     const neededBytes = Number(size);
     await waitForBytes(next, neededBytes);
+    if (isAborted(this.#abortSignal)) {
+      throw abortError();
+    }
     return next.buffer.subarray(0, neededBytes);
   }
 
@@ -135,6 +151,19 @@ export class CoalescingRemoteReadable implements McapTypes.IReadable {
       waiters: [],
       done: false,
     };
+    const externalAbortSignal = this.#abortSignal;
+    if (externalAbortSignal != undefined) {
+      const externalAbortHandler = () => {
+        abortController.abort();
+      };
+      state.externalAbortSignal = externalAbortSignal;
+      state.externalAbortHandler = externalAbortHandler;
+      if (externalAbortSignal.aborted) {
+        abortController.abort();
+      } else {
+        externalAbortSignal.addEventListener("abort", externalAbortHandler, { once: true });
+      }
+    }
 
     const end = offset + size - 1n;
     void runFetch(this.#url, offset, end, sizeNum, abortController.signal, state);
@@ -180,6 +209,14 @@ function asError(value: unknown): Error {
   } catch {
     return new Error("Unknown error");
   }
+}
+
+function abortError(): DOMException {
+  return new DOMException("signal is aborted without reason", "AbortError");
+}
+
+function isAborted(signal: AbortSignal | undefined): boolean {
+  return signal?.aborted === true;
 }
 
 async function runFetch(
@@ -242,5 +279,9 @@ async function runFetch(
   } catch (err) {
     state.error = err;
     notifyWaiters(state);
+  } finally {
+    if (state.externalAbortSignal != undefined && state.externalAbortHandler != undefined) {
+      state.externalAbortSignal.removeEventListener("abort", state.externalAbortHandler);
+    }
   }
 }

--- a/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/ShardManifestIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/ShardManifestIterableSource.test.ts
@@ -1,0 +1,282 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { McapIndexedReader, McapTypes } from "@mcap/core";
+
+import { loadDecompressHandlers } from "@foxglove/mcap-support";
+import { Initalization } from "@foxglove/studio-base/players/IterablePlayer/IIterableSource";
+import { McapIndexedIterableSource } from "@foxglove/studio-base/players/IterablePlayer/Mcap/McapIndexedIterableSource";
+import { mockTopicSelection } from "@foxglove/studio-base/test/mocks/mockTopicSelection";
+
+import { ShardManifestIterableSource } from "./ShardManifestIterableSource";
+import { Manifest, ShardEntry } from "./manifest";
+
+jest.mock("@mcap/core", () => ({
+  McapIndexedReader: {
+    Initialize: jest.fn(),
+  },
+}));
+
+jest.mock("@foxglove/mcap-support", () => ({
+  loadDecompressHandlers: jest.fn(),
+}));
+
+jest.mock("@foxglove/studio-base/players/IterablePlayer/Mcap/McapIndexedIterableSource", () => ({
+  McapIndexedIterableSource: jest.fn(),
+}));
+
+const mockInitializeReader = McapIndexedReader.Initialize as jest.MockedFunction<
+  typeof McapIndexedReader.Initialize
+>;
+const mockLoadDecompressHandlers = loadDecompressHandlers as jest.MockedFunction<
+  typeof loadDecompressHandlers
+>;
+const mockMcapIndexedIterableSource = McapIndexedIterableSource as jest.MockedClass<
+  typeof McapIndexedIterableSource
+>;
+const mockReader = {} as unknown as McapIndexedReader;
+const mockDecompressHandlers: McapTypes.DecompressHandlers = {};
+
+function mockDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function shard(id: string): ShardEntry {
+  return {
+    id,
+    kind: "topic",
+    topic: "/cam/h264",
+    schema: "CompressedImage",
+    profile: "480p10",
+    filename: `${id}.mcap`,
+    sizeBytes: 1024,
+    sha256: "0".repeat(64),
+    timeRange: { startNs: "0", endNs: "1000000000" },
+    topics: [{ name: "/cam/h264", schema: "CompressedImage", messageCount: 1 }],
+    messageCount: 1,
+  };
+}
+
+function manifest(): Manifest {
+  return {
+    version: 1,
+    sourceFiles: [
+      {
+        name: "record",
+        sha256: "0".repeat(64),
+        sizeBytes: 2048,
+        timeRange: { startNs: "0", endNs: "1000000000" },
+      },
+    ],
+    profiles: [{ id: "480p10", modality: "video", label: "480p", params: { h: 480, fps: 10 } }],
+    shards: [shard("input-a"), shard("input-b")],
+  };
+}
+
+function initResult(): Initalization {
+  return {
+    start: { sec: 0, nsec: 0 },
+    end: { sec: 1, nsec: 0 },
+    topics: [{ name: "/cam/h264", schemaName: "CompressedImage" }],
+    topicStats: new Map(),
+    datatypes: new Map(),
+    profile: undefined,
+    problems: [],
+    publishersByTopic: new Map(),
+  };
+}
+
+function indexedSource(): McapIndexedIterableSource {
+  return {
+    sourceType: "serialized",
+    initialize: jest.fn(async () => initResult()),
+    messageIterator: jest.fn(async function* () {
+      yield* [];
+    }),
+    getBackfillMessages: jest.fn(async () => []),
+  } as unknown as McapIndexedIterableSource;
+}
+
+describe("ShardManifestIterableSource", () => {
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    global.fetch = jest.fn(
+      async (..._args: Parameters<typeof fetch>): Promise<Response> =>
+        ({
+          ok: true,
+          json: async () => manifest(),
+        }) as Response,
+    ) as unknown as typeof fetch;
+
+    mockInitializeReader.mockReset();
+    mockInitializeReader.mockResolvedValue(mockReader);
+    mockLoadDecompressHandlers.mockReset();
+    mockLoadDecompressHandlers.mockResolvedValue(mockDecompressHandlers);
+    mockMcapIndexedIterableSource.mockReset();
+    mockMcapIndexedIterableSource.mockImplementation(() => indexedSource());
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("opens temporary message iterator shard readers in parallel", async () => {
+    const source = new ShardManifestIterableSource({
+      manifestUrl: "https://example.com/manifest.json",
+    });
+
+    await source.initialize();
+
+    const pendingOpens: Array<ReturnType<typeof mockDeferred<McapIndexedReader>>> = [];
+    mockInitializeReader.mockReset();
+    mockInitializeReader.mockImplementation(async () => {
+      const pending = mockDeferred<McapIndexedReader>();
+      pendingOpens.push(pending);
+      return await pending.promise;
+    });
+
+    const iterator = source.messageIterator({
+      topics: mockTopicSelection("/cam/h264"),
+      start: { sec: 0, nsec: 0 },
+      end: { sec: 1, nsec: 0 },
+      consumptionType: "partial",
+    });
+
+    const next = iterator.next();
+    await Promise.resolve();
+
+    expect(pendingOpens).toHaveLength(2);
+
+    pendingOpens[0]!.resolve(mockReader);
+    pendingOpens[1]!.resolve(mockReader);
+
+    await expect(next).resolves.toEqual({ done: true, value: undefined });
+  });
+
+  it("cancels temporary reader opens without caching them", async () => {
+    const source = new ShardManifestIterableSource({
+      manifestUrl: "https://example.com/manifest.json",
+    });
+    const abortController = new AbortController();
+
+    await source.initialize();
+
+    const pendingOpens: Array<ReturnType<typeof mockDeferred<McapIndexedReader>>> = [];
+    mockInitializeReader.mockReset();
+    mockInitializeReader.mockImplementation(async () => {
+      const pending = mockDeferred<McapIndexedReader>();
+      pendingOpens.push(pending);
+      return await pending.promise;
+    });
+
+    const iterator = source.messageIterator({
+      topics: mockTopicSelection("/cam/h264"),
+      start: { sec: 0, nsec: 0 },
+      end: { sec: 1, nsec: 0 },
+      consumptionType: "partial",
+      abortSignal: abortController.signal,
+    });
+
+    const next = iterator.next();
+    await Promise.resolve();
+    expect(pendingOpens).toHaveLength(2);
+
+    abortController.abort();
+    const abortError = new DOMException("signal is aborted without reason", "AbortError");
+    pendingOpens[0]!.reject(abortError);
+    pendingOpens[1]!.reject(abortError);
+
+    await expect(next).resolves.toEqual({ done: true, value: undefined });
+
+    mockInitializeReader.mockReset();
+    mockInitializeReader.mockResolvedValue(mockReader);
+
+    await source.getBackfillMessages({
+      topics: mockTopicSelection("/cam/h264"),
+      time: { sec: 0, nsec: 0 },
+    });
+
+    expect(mockInitializeReader).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels abortable backfill shard opens without reusing cached eager readers", async () => {
+    const source = new ShardManifestIterableSource({
+      manifestUrl: "https://example.com/manifest.json",
+    });
+    const abortController = new AbortController();
+    const abortPromise = new Promise<void>((resolve) => {
+      abortController.signal.addEventListener(
+        "abort",
+        () => {
+          resolve();
+        },
+        { once: true },
+      );
+    });
+
+    await source.initialize();
+
+    mockInitializeReader.mockReset();
+    mockInitializeReader.mockImplementation(async ({ readable }) => {
+      await abortPromise;
+      await readable.read(0n, 1n);
+      return mockReader;
+    });
+
+    const backfill = source.getBackfillMessages({
+      topics: mockTopicSelection("/cam/h264"),
+      time: { sec: 0, nsec: 0 },
+      abortSignal: abortController.signal,
+    });
+
+    await Promise.resolve();
+    abortController.abort();
+
+    await expect(backfill).resolves.toEqual([]);
+    expect(mockInitializeReader).toHaveBeenCalledTimes(2);
+
+    mockInitializeReader.mockReset();
+    mockInitializeReader.mockResolvedValue(mockReader);
+
+    await source.getBackfillMessages({
+      topics: mockTopicSelection("/cam/h264"),
+      time: { sec: 0, nsec: 0 },
+    });
+
+    expect(mockInitializeReader).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves non-abort errors from backfill lazy shard opens", async () => {
+    const source = new ShardManifestIterableSource({
+      manifestUrl: "https://example.com/manifest.json",
+    });
+
+    await source.initialize();
+
+    mockInitializeReader.mockReset();
+    mockInitializeReader.mockRejectedValue(new Error("open failed"));
+
+    await expect(
+      source.getBackfillMessages({
+        topics: mockTopicSelection("/cam/h264"),
+        time: { sec: 0, nsec: 0 },
+      }),
+    ).rejects.toThrow("open failed");
+  });
+});

--- a/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/ShardManifestIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/ShardManifestIterableSource.ts
@@ -52,6 +52,17 @@ function isAborted(signal: AbortSignal | undefined): boolean {
   return signal?.aborted === true;
 }
 
+function isAbortError(error: unknown): boolean {
+  return (
+    (error instanceof DOMException && error.name === "AbortError") ||
+    (error instanceof Error && error.name === "AbortError") ||
+    (typeof error === "object" &&
+      error != undefined &&
+      "name" in error &&
+      error.name === "AbortError")
+  );
+}
+
 // Pick a read-ahead window for a shard. Two regimes:
 //   1. Small shards (sizeBytes ≤ WHOLE_FILE_THRESHOLD): fetch the entire
 //      shard in one HTTP request. Avoids the chunking overhead for tiny
@@ -347,7 +358,7 @@ export class ShardManifestIterableSource implements ISerializedIterableSource {
       return;
     }
 
-    const iterators: AsyncIterator<Readonly<IteratorResult<Uint8Array>>>[] = [];
+    const shardsToOpen: Array<{ shard: ShardEntry; topics: MessageIteratorArgs["topics"] }> = [];
     for (const shard of matchingShards) {
       if (isAborted(args.abortSignal)) {
         return;
@@ -370,13 +381,43 @@ export class ShardManifestIterableSource implements ISerializedIterableSource {
       if (childSelection.size === 0) {
         continue;
       }
-      const child = await this.#openShardSource(shard, args.abortSignal);
-      if (isAborted(args.abortSignal)) {
+      shardsToOpen.push({
+        shard,
+        topics: childSelection as MessageIteratorArgs["topics"],
+      });
+    }
+
+    if (shardsToOpen.length === 0 || isAborted(args.abortSignal)) {
+      return;
+    }
+
+    let children: Array<{ child: ShardChild; topics: MessageIteratorArgs["topics"] }>;
+    try {
+      // P2 tradeoff: playback uses temporary readers instead of #openChildren because cached
+      // readers are not bound to this iterator's abortSignal. Revisit when reads can be
+      // canceled per iterator without binding cancellation to the reader lifetime.
+      children = await Promise.all(
+        shardsToOpen.map(async ({ shard, topics }) => ({
+          child: await this.#openShardSource(shard, args.abortSignal),
+          topics,
+        })),
+      );
+    } catch (error) {
+      if (isAborted(args.abortSignal) && isAbortError(error)) {
         return;
       }
+      throw error;
+    }
+
+    if (isAborted(args.abortSignal)) {
+      return;
+    }
+
+    const iterators: AsyncIterator<Readonly<IteratorResult<Uint8Array>>>[] = [];
+    for (const { child, topics } of children) {
       const childArgs: MessageIteratorArgs = {
         ...args,
-        topics: childSelection as MessageIteratorArgs["topics"],
+        topics,
       };
       iterators.push(
         child.source.messageIterator(childArgs)[Symbol.asyncIterator]() as AsyncIterator<
@@ -416,10 +457,36 @@ export class ShardManifestIterableSource implements ISerializedIterableSource {
       return [];
     }
 
-    const children = await Promise.all(matchingShards.map(async (s) => await this.#ensureOpen(s)));
+    if (isAborted(args.abortSignal)) {
+      return [];
+    }
+
+    let children: ShardChild[];
+    try {
+      children = await Promise.all(
+        matchingShards.map(async (shard) => {
+          return args.abortSignal != undefined
+            ? await this.#openShardSource(shard, args.abortSignal)
+            : await this.#ensureOpen(shard);
+        }),
+      );
+    } catch (error) {
+      if (isAborted(args.abortSignal) && isAbortError(error)) {
+        return [];
+      }
+      throw error;
+    }
+
+    if (isAborted(args.abortSignal)) {
+      return [];
+    }
 
     const out: MessageEvent<Uint8Array>[] = [];
     for (const child of children) {
+      if (isAborted(args.abortSignal)) {
+        return [];
+      }
+
       const childTopicNames = new Set(child.init.topics.map((t) => t.name));
       const childSelection = new Map<string, unknown>();
       for (const [topic, value] of requestedTopics) {
@@ -430,10 +497,21 @@ export class ShardManifestIterableSource implements ISerializedIterableSource {
       if (childSelection.size === 0) {
         continue;
       }
-      const childMsgs = await child.source.getBackfillMessages({
-        ...args,
-        topics: childSelection as GetBackfillMessagesArgs["topics"],
-      });
+      let childMsgs: MessageEvent<Uint8Array>[];
+      try {
+        childMsgs = await child.source.getBackfillMessages({
+          ...args,
+          topics: childSelection as GetBackfillMessagesArgs["topics"],
+        });
+      } catch (error) {
+        if (isAborted(args.abortSignal) && isAbortError(error)) {
+          return [];
+        }
+        throw error;
+      }
+      if (isAborted(args.abortSignal)) {
+        return [];
+      }
       for (const m of childMsgs) {
         out.push(m);
       }

--- a/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/ShardManifestIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/ShardManifestIterableSource.ts
@@ -372,7 +372,7 @@ export class ShardManifestIterableSource implements ISerializedIterableSource {
     if (iterators.length === 0) {
       return;
     }
-    yield* mergeShards<Uint8Array>(iterators);
+    yield* mergeShards<Uint8Array>(iterators, args.abortSignal);
   }
 
   public async getBackfillMessages(

--- a/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/ShardManifestIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/ShardManifestIterableSource.ts
@@ -48,6 +48,10 @@ function manifestTopicSet(shard: ShardEntry): Set<string> {
   return new Set(shard.topics.map((t) => t.name));
 }
 
+function isAborted(signal: AbortSignal | undefined): boolean {
+  return signal?.aborted === true;
+}
+
 // Pick a read-ahead window for a shard. Two regimes:
 //   1. Small shards (sizeBytes ≤ WHOLE_FILE_THRESHOLD): fetch the entire
 //      shard in one HTTP request. Avoids the chunking overhead for tiny
@@ -276,6 +280,29 @@ export class ShardManifestIterableSource implements ISerializedIterableSource {
 
   // Open a single shard if it isn't already open. Concurrent callers share
   // one in-flight open. Returns the resolved ShardChild.
+  async #openShardSource(shard: ShardEntry, abortSignal?: AbortSignal): Promise<ShardChild> {
+    const handlers = this.#decompressHandlers;
+    if (!handlers) {
+      throw new Error("decompressHandlers not loaded; initialize() must run first");
+    }
+    const url = new URL(shard.filename, this.#manifestUrl).toString();
+    const readAhead = readAheadBytesForShard(shard);
+    log.info(
+      `opening shard ${shard.id} (${shard.filename}, read-ahead ${(readAhead / 1024 / 1024).toFixed(
+        1,
+      )} MiB)`,
+    );
+    const readable = new CoalescingRemoteReadable(url, readAhead, shard.sizeBytes, abortSignal);
+    await readable.open();
+    const reader = await McapIndexedReader.Initialize({
+      readable,
+      decompressHandlers: handlers,
+    });
+    const source = new McapIndexedIterableSource(reader);
+    const init = await source.initialize();
+    return { shard, source, init };
+  }
+
   async #ensureOpen(shard: ShardEntry): Promise<ShardChild> {
     const cached = this.#openChildren.get(shard.id);
     if (cached) {
@@ -285,28 +312,7 @@ export class ShardManifestIterableSource implements ISerializedIterableSource {
     let pending = this.#openPromises.get(shard.id);
     if (!pending) {
       pending = (async () => {
-        const handlers = this.#decompressHandlers;
-        if (!handlers) {
-          throw new Error("decompressHandlers not loaded; initialize() must run first");
-        }
-        const url = new URL(shard.filename, this.#manifestUrl).toString();
-        const readAhead = readAheadBytesForShard(shard);
-        log.info(
-          `opening shard ${shard.id} (${shard.filename}, read-ahead ${(
-            readAhead /
-            1024 /
-            1024
-          ).toFixed(1)} MiB)`,
-        );
-        const readable = new CoalescingRemoteReadable(url, readAhead, shard.sizeBytes);
-        await readable.open();
-        const reader = await McapIndexedReader.Initialize({
-          readable,
-          decompressHandlers: handlers,
-        });
-        const source = new McapIndexedIterableSource(reader);
-        const init = await source.initialize();
-        const child: ShardChild = { shard, source, init };
+        const child = await this.#openShardSource(shard);
         this.#openChildren.set(shard.id, child);
         return child;
       })();
@@ -341,14 +347,20 @@ export class ShardManifestIterableSource implements ISerializedIterableSource {
       return;
     }
 
-    const children = await Promise.all(matchingShards.map(async (s) => await this.#ensureOpen(s)));
-
     const iterators: AsyncIterator<Readonly<IteratorResult<Uint8Array>>>[] = [];
-    for (const child of children) {
+    for (const shard of matchingShards) {
+      if (isAborted(args.abortSignal)) {
+        return;
+      }
+
       // Re-narrow against the shard's actual topic set (post-open) — for
       // tail this can differ from the manifest's `topics[]` if the shard
       // was written by a future tool.
-      const childTopicNames = new Set(child.init.topics.map((t) => t.name));
+      const cachedChild = this.#openChildren.get(shard.id);
+      const childTopicNames =
+        cachedChild != undefined
+          ? new Set(cachedChild.init.topics.map((t) => t.name))
+          : manifestTopicSet(shard);
       const childSelection = new Map<string, unknown>();
       for (const [topic, value] of requestedTopics) {
         if (childTopicNames.has(topic)) {
@@ -357,6 +369,10 @@ export class ShardManifestIterableSource implements ISerializedIterableSource {
       }
       if (childSelection.size === 0) {
         continue;
+      }
+      const child = await this.#openShardSource(shard, args.abortSignal);
+      if (isAborted(args.abortSignal)) {
+        return;
       }
       const childArgs: MessageIteratorArgs = {
         ...args,

--- a/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/mergeShards.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/mergeShards.test.ts
@@ -40,6 +40,20 @@ async function collect(
   return out;
 }
 
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 const t = (sec: number, nsec = 0): Time => ({ sec, nsec });
 
 describe("mergeShards", () => {
@@ -141,5 +155,26 @@ describe("mergeShards", () => {
       }
     }
     expect(out.length).toBe(3);
+  });
+
+  it("finishes without throwing when a pending shard next rejects after abort", async () => {
+    const ctrl = new AbortController();
+    const blockedNext = deferred<void>();
+    const iterator: AsyncIterator<Readonly<IteratorResult<Uint8Array>>> = {
+      async next() {
+        await blockedNext.promise;
+        throw new DOMException("signal is aborted without reason", "AbortError");
+      },
+      async return() {
+        return { done: true, value: undefined };
+      },
+    };
+    const merged = mergeShards([iterator], ctrl.signal);
+    const next = merged.next();
+
+    ctrl.abort();
+    blockedNext.resolve();
+
+    await expect(next).resolves.toEqual({ done: true, value: undefined });
   });
 });

--- a/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/mergeShards.ts
+++ b/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/mergeShards.ts
@@ -38,6 +38,17 @@ function timeOf<T>(result: IteratorResult<T>): Time | undefined {
   return undefined;
 }
 
+function isAbortError(error: unknown): boolean {
+  return (
+    (error instanceof DOMException && error.name === "AbortError") ||
+    (error instanceof Error && error.name === "AbortError") ||
+    (typeof error === "object" &&
+      error != undefined &&
+      "name" in error &&
+      error.name === "AbortError")
+  );
+}
+
 export async function* mergeShards<T>(
   iterators: AsyncIterator<Readonly<IteratorResult<T>>>[],
   abortSignal?: AbortSignal,
@@ -53,7 +64,16 @@ export async function* mergeShards<T>(
   }));
 
   const advance = async (entry: IteratorEntry<T>): Promise<void> => {
-    const next = await entry.iterator.next();
+    let next: Awaited<ReturnType<AsyncIterator<Readonly<IteratorResult<T>>>["next"]>>;
+    try {
+      next = await entry.iterator.next();
+    } catch (error) {
+      if (abortSignal?.aborted === true && isAbortError(error)) {
+        entry.buffered = EXHAUSTED;
+        return;
+      }
+      throw error;
+    }
     if (next.done === true) {
       entry.buffered = EXHAUSTED;
       return;


### PR DESCRIPTION
## Summary
- Add abort-signal propagation through `IterablePlayer` and the iterable source stack so a seek can cancel an in-flight playback iterator, producer, or request immediately.
- Prevent aborted source reads from being treated as fully loaded ranges or spill-cache completions, so cache state stays consistent after a seek interruption.
- Make playback control overlay visuals ignore pointer events so loading indicators, hover ticks, and bag overlays no longer block scrubbing.
- Add regression coverage for iterator aborts, worker/source signal forwarding, cache range handling, and playback control pointer events.

## Testing
- `yarn jest` on the affected `IterablePlayer`, data-platform, worker, and playback-controls test suites.
- `yarn tsc --build packages/studio-base/tsconfig.json --pretty false` reported existing repository type errors outside this change; no new type errors were introduced in the touched paths.
- `git diff --check` passed.