### PR TITLE
Persist and remap shard profile preferences across manifest playback

### DIFF
--- a/packages/studio-base/src/components/AppBar/ShardProfileSelector.tsx
+++ b/packages/studio-base/src/components/AppBar/ShardProfileSelector.tsx
@@ -14,21 +14,24 @@ import {
   MessagePipelineContext,
   useMessagePipeline,
 } from "@foxglove/studio-base/components/MessagePipeline";
-
-type ProfileOption = { value: string; label: string };
-
-interface ManifestProfile {
-  id: string;
-  modality?: string;
-  label?: string;
-  params?: { h?: number; height?: number; fps?: number; codec?: string };
-}
+import {
+  findMatchingShardProfilePreference,
+  isDefaultVideoProfile,
+  loadShardProfilePreference,
+  profileHeight,
+  profileToOption,
+  RAW_PROFILE,
+  saveShardProfilePreference,
+} from "@foxglove/studio-base/players/IterablePlayer/coScene-shard-manifest/profilePreference";
+import type {
+  ManifestProfile,
+  ShardProfileOption,
+} from "@foxglove/studio-base/players/IterablePlayer/coScene-shard-manifest/profilePreference";
 
 interface MinimalManifest {
   profiles?: ManifestProfile[];
 }
 
-const RAW_PROFILE = "raw";
 const SHARD_MODE_PARAM = "shardMode";
 const SHARD_MODE_MANIFEST = "manifest";
 const SHARD_MODE_RAW = "raw";
@@ -47,53 +50,23 @@ const useStyles = makeStyles()(() => ({
   },
 }));
 
-function profileToOption(p: ManifestProfile): ProfileOption {
-  if (p.label != undefined && p.label.length > 0 && p.label !== p.id) {
-    return { value: p.id, label: p.label };
-  }
-  // Synthesize a label from params when the manifest's `label` is missing.
-  const h = p.params?.h ?? p.params?.height;
-  const fps = p.params?.fps;
-  if (h != undefined && h > 0 && fps != undefined && fps > 0) {
-    return { value: p.id, label: `${h}p · ${fps}fps` };
-  }
-  if (h != undefined && h > 0) {
-    return { value: p.id, label: `${h}p` };
-  }
-  return { value: p.id, label: p.id };
-}
-
-function profileHeight(p: ManifestProfile): number {
-  return p.params?.h ?? p.params?.height ?? 0;
-}
-
-function isDefaultVideoProfile(p: ManifestProfile): boolean {
-  return p.modality === "video" || p.params?.h != undefined || p.params?.height != undefined;
-}
-
 export function ShardProfileSelector(): React.JSX.Element | ReactNull {
   const { classes } = useStyles();
   const { t } = useTranslation("appBar");
   const urlState = useMessagePipeline(selectUrlState);
-  const search = useMemo(() => {
-    if (typeof window === "undefined") {
-      return new URLSearchParams();
-    }
-    return new URLSearchParams(window.location.search);
-  }, []);
 
   const isShardManifest =
     urlState?.sourceId === "coscene-data-platform" &&
     (urlState.parameters?.[SHARD_MODE_PARAM] === SHARD_MODE_MANIFEST ||
       urlState.parameters?.[SHARD_MODE_PARAM] === SHARD_MODE_RAW);
   const manifestUrl = urlState?.parameters?.[MANIFEST_URL_PARAM] ?? "";
-  const currentProfile = search.get("ds.profile") ?? "";
-  const rawOption = useMemo<ProfileOption>(
+  const currentProfile = urlState?.parameters?.profile ?? "";
+  const rawOption = useMemo<ShardProfileOption>(
     () => ({ value: RAW_PROFILE, label: t("rawData") }),
     [t],
   );
 
-  const [profileOptions, setProfileOptions] = useState<ProfileOption[]>([]);
+  const [profileOptions, setProfileOptions] = useState<ShardProfileOption[]>([]);
   const [defaultProfile, setDefaultProfile] = useState<string>("");
 
   useEffect(() => {
@@ -136,10 +109,42 @@ export function ShardProfileSelector(): React.JSX.Element | ReactNull {
     return [...profileOptions, rawOption];
   }, [profileOptions, rawOption]);
 
-  const selectedValue = currentProfile === "" ? defaultProfile : currentProfile;
+  const selectedValue =
+    currentProfile !== "" && options.some((option) => option.value === currentProfile)
+      ? currentProfile
+      : defaultProfile;
+
+  useEffect(() => {
+    if (!isShardManifest || options.length === 0) {
+      return;
+    }
+    const hasCurrentProfile =
+      currentProfile !== "" && options.some((option) => option.value === currentProfile);
+    if (hasCurrentProfile) {
+      return;
+    }
+    const savedOption = findMatchingShardProfilePreference(options, loadShardProfilePreference());
+    if (
+      savedOption == undefined ||
+      (savedOption.value === defaultProfile && currentProfile === "")
+    ) {
+      return;
+    }
+    const next = new URLSearchParams(window.location.search);
+    if (savedOption.value === defaultProfile) {
+      next.delete("ds.profile");
+    } else {
+      next.set("ds.profile", savedOption.value);
+    }
+    window.location.search = next.toString();
+  }, [currentProfile, defaultProfile, isShardManifest, options]);
 
   const onChange = useCallback(
     (value: string) => {
+      const selectedOption = options.find((option) => option.value === value);
+      if (selectedOption != undefined) {
+        saveShardProfilePreference(selectedOption);
+      }
       const next = new URLSearchParams(window.location.search);
       if (value !== "" && value !== defaultProfile) {
         next.set("ds.profile", value);
@@ -148,7 +153,7 @@ export function ShardProfileSelector(): React.JSX.Element | ReactNull {
       }
       window.location.search = next.toString();
     },
-    [defaultProfile],
+    [defaultProfile, options],
   );
 
   if (!isShardManifest) {

--- a/packages/studio-base/src/dataSources/CoSceneDataPlatformDataSourceFactory.test.ts
+++ b/packages/studio-base/src/dataSources/CoSceneDataPlatformDataSourceFactory.test.ts
@@ -19,6 +19,7 @@ import {
   ManifestStorageSource,
   getManifestStorageBaseUrl,
 } from "./manifestStorage";
+import { SHARD_PROFILE_PREFERENCE_STORAGE_KEY } from "../players/IterablePlayer/coScene-shard-manifest/profilePreference";
 
 const mockGetAppConfig = jest.fn();
 
@@ -91,6 +92,10 @@ describe("buildManifestUrl", () => {
 
 describe("CoSceneDataPlatformDataSourceFactory manifest storage selection", () => {
   const originalFetch = global.fetch;
+  const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "localStorage",
+  );
 
   beforeEach(() => {
     mockGetAppConfig.mockReturnValue({
@@ -104,12 +109,21 @@ describe("CoSceneDataPlatformDataSourceFactory manifest storage selection", () =
 
   afterEach(() => {
     global.fetch = originalFetch;
+    if (originalLocalStorageDescriptor) {
+      Object.defineProperty(globalThis, "localStorage", originalLocalStorageDescriptor);
+    } else {
+      delete (globalThis as Partial<typeof globalThis>).localStorage;
+    }
   });
 
-  async function initializeFactory(manifestStorageSource?: string) {
+  async function initializeFactory(
+    manifestStorageSource?: string,
+    params?: Record<string, string | undefined>,
+  ) {
     const factory = new CoSceneDataPlatformDataSourceFactory();
     return await factory.initialize({
       metricsCollector: undefined as never,
+      params,
       consoleApi: {
         getApiBaseInfo: () => ({ projectId: "project-id", recordId: "record-id" }),
         getAuthHeader: () => "Bearer token",
@@ -152,5 +166,78 @@ describe("CoSceneDataPlatformDataSourceFactory manifest storage selection", () =
     );
     expect(mockWorkerSerializedIterableSource).not.toHaveBeenCalled();
     expect(mockWorkerIterableSource).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses a saved shard profile when the new manifest has a matching profile label", async () => {
+    const manifestUrl =
+      "https://default-storage.example.com/projects/project-id/records/record-id/manifest.json";
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: (key: string) =>
+          key === SHARD_PROFILE_PREFERENCE_STORAGE_KEY
+            ? JSON.stringify({ value: "old-hd", label: "720p @ 15fps" })
+            : undefined,
+      },
+    });
+    global.fetch = jest.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === "HEAD") {
+        return { ok: true } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          profiles: [
+            { id: "sd10", modality: "video", label: "480p @ 10fps", params: { h: 480, fps: 10 } },
+            { id: "hd15", modality: "video", label: "720p @ 15fps", params: { h: 720, fps: 15 } },
+          ],
+        }),
+      } as Response;
+    });
+
+    await initializeFactory();
+
+    expect(global.fetch).toHaveBeenCalledWith(manifestUrl, { method: "HEAD" });
+    expect(global.fetch).toHaveBeenCalledWith(manifestUrl);
+    expect(mockWorkerSerializedIterableSource.mock.calls[0]?.[0]).toMatchObject({
+      initArgs: { params: { url: manifestUrl, profile: "hd15" } },
+    });
+    expect(mockIterablePlayer.mock.calls[0]?.[0]).toMatchObject({
+      urlParams: { profile: "hd15" },
+    });
+  });
+
+  it("remaps a stale requested profile when localStorage has the matching profile label", async () => {
+    const manifestUrl =
+      "https://default-storage.example.com/projects/project-id/records/record-id/manifest.json";
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: (key: string) =>
+          key === SHARD_PROFILE_PREFERENCE_STORAGE_KEY
+            ? JSON.stringify({ value: "old-hd", label: "720p @ 15fps" })
+            : undefined,
+      },
+    });
+    global.fetch = jest.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === "HEAD") {
+        return { ok: true } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          profiles: [
+            { id: "sd10", modality: "video", label: "480p @ 10fps", params: { h: 480, fps: 10 } },
+            { id: "hd15", modality: "video", label: "720p @ 15fps", params: { h: 720, fps: 15 } },
+          ],
+        }),
+      } as Response;
+    });
+
+    await initializeFactory(undefined, { profile: "old-hd" });
+
+    expect(mockWorkerSerializedIterableSource.mock.calls[0]?.[0]).toMatchObject({
+      initArgs: { params: { url: manifestUrl, profile: "hd15" } },
+    });
   });
 });

--- a/packages/studio-base/src/dataSources/CoSceneDataPlatformDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/CoSceneDataPlatformDataSourceFactory.ts
@@ -20,6 +20,16 @@ import {
   WorkerIterableSource,
   WorkerSerializedIterableSource,
 } from "@foxglove/studio-base/players/IterablePlayer";
+import {
+  findMatchingShardProfilePreference,
+  loadShardProfilePreference,
+  manifestProfileOptions,
+  RAW_PROFILE,
+} from "@foxglove/studio-base/players/IterablePlayer/coScene-shard-manifest/profilePreference";
+import type {
+  ManifestProfile,
+  ShardProfileOption,
+} from "@foxglove/studio-base/players/IterablePlayer/coScene-shard-manifest/profilePreference";
 import { Player } from "@foxglove/studio-base/players/types";
 import { getAppConfig, getDomainConfig } from "@foxglove/studio-base/util/appConfig";
 import { parseAppURLState } from "@foxglove/studio-base/util/appURLState";
@@ -28,11 +38,14 @@ import { buildManifestUrl, getManifestStorageBaseUrl, manifestExists } from "./m
 
 export { buildManifestUrl } from "./manifestStorage";
 
-const RAW_PROFILE = "raw";
 const SHARD_MODE_PARAM = "shardMode";
 const SHARD_MODE_MANIFEST = "manifest";
 const SHARD_MODE_RAW = "raw";
 const MANIFEST_URL_PARAM = "manifestUrl";
+
+interface MinimalManifest {
+  profiles?: ManifestProfile[];
+}
 
 function definedUrlParams(params?: Record<string, string | undefined>): Record<string, string> {
   const definedParams: Record<string, string> = {};
@@ -63,6 +76,29 @@ function sortJsonValue(value: unknown): unknown {
 
 function stableJsonStringify(value: unknown): string {
   return JSON.stringify(sortJsonValue(value)) ?? "";
+}
+
+async function fetchShardProfileOptions(manifestUrl: string): Promise<ShardProfileOption[]> {
+  try {
+    const response = await fetch(manifestUrl);
+    if (!response.ok) {
+      return [];
+    }
+    const manifest = (await response.json()) as MinimalManifest;
+    return manifestProfileOptions(manifest.profiles ?? []);
+  } catch {
+    return [];
+  }
+}
+
+function withProfile(
+  args: DataSourceFactoryInitializeArgs,
+  profile: string | undefined,
+): DataSourceFactoryInitializeArgs {
+  if (profile == undefined) {
+    return args;
+  }
+  return { ...args, params: { ...args.params, profile } };
 }
 
 class CoSceneDataPlatformDataSourceFactory implements IDataSourceFactory {
@@ -134,17 +170,48 @@ class CoSceneDataPlatformDataSourceFactory implements IDataSourceFactory {
     }
 
     const manifestUrl = buildManifestUrl(objectStorageBaseUrl, projectId, recordId);
-    if (args.params?.profile === RAW_PROFILE) {
+    const requestedProfile = args.params?.profile;
+    if (requestedProfile === RAW_PROFILE) {
       return this.#createDataPlatformPlayer(args, manifestUrl);
     }
 
     if (await manifestExists(manifestUrl)) {
+      const profile = await this.#resolveManifestProfile(manifestUrl, requestedProfile);
+      if (profile === RAW_PROFILE) {
+        return this.#createDataPlatformPlayer(withProfile(args, profile), manifestUrl);
+      }
       // Manifest playback reads directly from object storage and is intentionally
       // not subject to the OUTBOUND_TRAFFIC entitlement check for now.
-      return this.#createShardManifestPlayer(args, manifestUrl);
+      return this.#createShardManifestPlayer(withProfile(args, profile), manifestUrl);
     }
 
     return this.#createDataPlatformPlayer(args);
+  }
+
+  async #resolveManifestProfile(
+    manifestUrl: string,
+    requestedProfile: string | undefined,
+  ): Promise<string | undefined> {
+    const preference = loadShardProfilePreference();
+    if (requestedProfile == undefined && preference?.value === RAW_PROFILE) {
+      return RAW_PROFILE;
+    }
+    if (preference == undefined && requestedProfile != undefined) {
+      return requestedProfile;
+    }
+    if (preference == undefined) {
+      return undefined;
+    }
+
+    const options = await fetchShardProfileOptions(manifestUrl);
+    if (
+      requestedProfile != undefined &&
+      options.some((option) => option.value === requestedProfile)
+    ) {
+      return requestedProfile;
+    }
+
+    return findMatchingShardProfilePreference(options, preference)?.value ?? requestedProfile;
   }
 
   #createDataPlatformPlayer(

--- a/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/profilePreference.ts
+++ b/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/profilePreference.ts
@@ -90,7 +90,10 @@ export function saveShardProfilePreference(option: ShardProfileOption): void {
     return;
   }
   try {
-    localStorage.setItem(SHARD_PROFILE_PREFERENCE_STORAGE_KEY, JSON.stringify(option));
+    const serialized = JSON.stringify(option);
+    if (serialized != undefined) {
+      localStorage.setItem(SHARD_PROFILE_PREFERENCE_STORAGE_KEY, serialized);
+    }
   } catch {
     // Ignore quota/security errors; profile selection should still work for the current page.
   }

--- a/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/profilePreference.ts
+++ b/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/profilePreference.ts
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export const RAW_PROFILE = "raw";
+export const SHARD_PROFILE_PREFERENCE_STORAGE_KEY = "studio.shardProfilePreference";
+
+export type ShardProfileOption = { value: string; label: string };
+
+export type ShardProfilePreference = ShardProfileOption;
+
+export interface ManifestProfile {
+  id: string;
+  modality?: string;
+  label?: string;
+  params?: { h?: number; height?: number; fps?: number; codec?: string };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value != undefined && !Array.isArray(value);
+}
+
+export function profileToOption(p: ManifestProfile): ShardProfileOption {
+  if (p.label != undefined && p.label.length > 0 && p.label !== p.id) {
+    return { value: p.id, label: p.label };
+  }
+  const h = p.params?.h ?? p.params?.height;
+  const fps = p.params?.fps;
+  if (h != undefined && h > 0 && fps != undefined && fps > 0) {
+    return { value: p.id, label: `${h}p · ${fps}fps` };
+  }
+  if (h != undefined && h > 0) {
+    return { value: p.id, label: `${h}p` };
+  }
+  return { value: p.id, label: p.id };
+}
+
+export function profileHeight(p: ManifestProfile): number {
+  return p.params?.h ?? p.params?.height ?? 0;
+}
+
+export function isDefaultVideoProfile(p: ManifestProfile): boolean {
+  return p.modality === "video" || p.params?.h != undefined || p.params?.height != undefined;
+}
+
+export function manifestProfileOptions(profiles: readonly ManifestProfile[]): ShardProfileOption[] {
+  return profiles
+    .filter((p) => p.id !== "" && p.id !== "full" && p.id !== RAW_PROFILE)
+    .sort((a, b) => profileHeight(a) - profileHeight(b))
+    .map(profileToOption);
+}
+
+export function findMatchingShardProfilePreference(
+  options: readonly ShardProfileOption[],
+  preference: ShardProfilePreference | undefined,
+): ShardProfileOption | undefined {
+  if (preference == undefined) {
+    return undefined;
+  }
+  return (
+    options.find((option) => option.value === preference.value) ??
+    options.find((option) => option.label === preference.label)
+  );
+}
+
+export function loadShardProfilePreference(): ShardProfilePreference | undefined {
+  if (typeof localStorage === "undefined") {
+    return undefined;
+  }
+  try {
+    const item = localStorage.getItem(SHARD_PROFILE_PREFERENCE_STORAGE_KEY);
+    if (item == undefined) {
+      return undefined;
+    }
+    const parsed = JSON.parse(item) as unknown;
+    if (!isRecord(parsed) || typeof parsed.value !== "string" || typeof parsed.label !== "string") {
+      return undefined;
+    }
+    return { value: parsed.value, label: parsed.label };
+  } catch {
+    return undefined;
+  }
+}
+
+export function saveShardProfilePreference(option: ShardProfileOption): void {
+  if (typeof localStorage === "undefined") {
+    return;
+  }
+  try {
+    localStorage.setItem(SHARD_PROFILE_PREFERENCE_STORAGE_KEY, JSON.stringify(option));
+  } catch {
+    // Ignore quota/security errors; profile selection should still work for the current page.
+  }
+}


### PR DESCRIPTION
## Summary
- Extract shared shard profile preference helpers into a new module and use them from both the AppBar selector and the data source factory.
- Persist the user’s selected shard profile in `localStorage`, then restore or remap it when a newer manifest exposes the matching profile label.
- Keep `ds.profile` aligned with the resolved manifest profile so playback and the URL state stay consistent.

## Testing
- Added and updated unit coverage for manifest selection and profile remapping.
- Verified with targeted Jest, ESLint, `git diff --check`, and `tsc --noEmit`.