### PR TITLE
Clamp negative Moment durations to zero

### DIFF
--- a/packages/studio-base/src/util/time.test.ts
+++ b/packages/studio-base/src/util/time.test.ts
@@ -82,3 +82,12 @@ describe("time.getTimestampForMessageEvent", () => {
     ).toEqual(undefined);
   });
 });
+
+describe("time.secondsToDuration", () => {
+  it("clamps negative durations to zero", () => {
+    expect(time.secondsToDuration(-1.5)).toMatchObject({
+      seconds: 0n,
+      nanos: 0,
+    });
+  });
+});

--- a/packages/studio-base/src/util/time.ts
+++ b/packages/studio-base/src/util/time.ts
@@ -97,8 +97,9 @@ export const durationToNanoSeconds = (duration?: DurationLike): bigint => {
 };
 
 export const secondsToDuration = (seconds: number): Duration => {
-  const sec = Math.floor(seconds);
-  const nsec = Math.round((seconds - sec) * 1e9);
+  const nonNegativeSeconds = Math.max(seconds, 0);
+  const sec = Math.floor(nonNegativeSeconds);
+  const nsec = Math.round((nonNegativeSeconds - sec) * 1e9);
 
   const duration = create(DurationSchema, {
     seconds: BigInt(sec),


### PR DESCRIPTION
## Summary
- Clamp `secondsToDuration` inputs to `>= 0` before building protobuf durations
- Add a unit test covering negative duration input

## Testing
- `yarn jest packages/studio-base/src/util/time.test.ts --runInBand`
- `git diff --check`
- `yarn run tsc --noEmit`
- `yarn eslint --cache --cache-strategy content --cache-location .eslintcache --report-unused-disable-directives --config eslint.config.ci.cjs packages/studio-base/src/util/time.ts packages/studio-base/src/util/time.test.ts`