### PR TITLE
Fix event mark drag update loop

### DIFF
--- a/packages/studio-base/src/components/PlaybackControls/EventsOverlay.test.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/EventsOverlay.test.tsx
@@ -1,0 +1,244 @@
+/** @jest-environment jsdom */
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { act, render, waitFor } from "@testing-library/react";
+import * as _ from "lodash-es";
+import type { AsyncState } from "react-use/lib/useAsyncFn";
+import { createStore } from "zustand";
+import type { StoreApi } from "zustand";
+
+import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
+import AppConfigurationContext from "@foxglove/studio-base/context/AppConfigurationContext";
+import CoSceneConsoleApiContext from "@foxglove/studio-base/context/CoSceneConsoleApiContext";
+import {
+  EventsContext,
+  type EventsStore,
+  type TimelinePositionedEvent,
+  type TimelinePositionedEventMark,
+} from "@foxglove/studio-base/context/EventsContext";
+import {
+  TimelineInteractionStateContext,
+  type SyncBounds,
+  type TimelineInteractionStateStore,
+} from "@foxglove/studio-base/context/TimelineInteractionStateContext";
+import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
+import type { HoverValue } from "@foxglove/studio-base/types/hoverValue";
+import { makeMockAppConfiguration } from "@foxglove/studio-base/util/makeMockAppConfiguration";
+
+import { EventsOverlay } from "./EventsOverlay";
+import { makeTimelineViewport } from "./timelineViewport";
+
+jest.mock("@foxglove/studio-base/components/Events/CreateEventContainer/index", () => ({
+  CreateEventContainer: () => <div data-testid="create-event-container" />,
+}));
+
+jest.mock("react-resize-detector", () => ({
+  useResizeDetector: () => ({ width: 1000, ref: jest.fn() }),
+}));
+
+const viewport = makeTimelineViewport(0, 10);
+
+function makeEventsStore({
+  eventMarks,
+  setEventMarks,
+}: {
+  eventMarks: TimelinePositionedEventMark[];
+  setEventMarks: jest.Mock<void, [TimelinePositionedEventMark[]]>;
+}): StoreApi<EventsStore> {
+  return createStore<EventsStore>((set) => ({
+    eventFetchCount: 0,
+    events: { loading: false, value: [] },
+    filter: "",
+    selectedEventId: undefined,
+    deviceId: undefined,
+    eventMarks,
+    toModifyEvent: undefined,
+    customFieldSchema: undefined,
+
+    refreshEvents: () => {
+      set((old) => ({ eventFetchCount: old.eventFetchCount + 1 }));
+    },
+    selectEvent: (id: undefined | string) => {
+      set({ selectedEventId: id });
+    },
+    setEvents: (events: AsyncState<TimelinePositionedEvent[]>) => {
+      set({ events, selectedEventId: undefined });
+    },
+    setFilter: (filter: string) => {
+      set({ filter });
+    },
+    setDeviceId: (deviceId: string | undefined) => {
+      set({ deviceId });
+    },
+    setEventMarks: (marks: TimelinePositionedEventMark[]) => {
+      setEventMarks(marks);
+      set({ eventMarks: marks });
+    },
+    setToModifyEvent: (toModifyEvent) => {
+      set({ toModifyEvent });
+    },
+    setCustomFieldSchema: (customFieldSchema) => {
+      set({ customFieldSchema });
+    },
+  }));
+}
+
+function makeTimelineInteractionStore(
+  hoverValue: HoverValue = {
+    componentId: "test-component",
+    type: "PLAYBACK_SECONDS",
+    value: 1,
+  },
+): StoreApi<TimelineInteractionStateStore> {
+  return createStore<TimelineInteractionStateStore>((set) => ({
+    eventsAtHoverValue: {},
+    bagsAtHoverValue: {},
+    globalBounds: undefined,
+    hoveredEvent: undefined,
+    hoveredBag: undefined,
+    hoverValue,
+    loopedEvent: undefined,
+
+    clearHoverValue: (componentId: string) => {
+      set((store) => ({
+        hoverValue: store.hoverValue?.componentId === componentId ? undefined : store.hoverValue,
+      }));
+    },
+    setEventsAtHoverValue: (eventsAtHoverValue: TimelinePositionedEvent[]) => {
+      set({ eventsAtHoverValue: _.keyBy(eventsAtHoverValue, (event) => event.event.name) });
+    },
+    setBagsAtHoverValue: () => {
+      set({ bagsAtHoverValue: {} });
+    },
+    setGlobalBounds: (
+      newBounds:
+        | undefined
+        | SyncBounds
+        | ((oldValue: undefined | SyncBounds) => undefined | SyncBounds),
+    ) => {
+      set((store) => ({
+        globalBounds: typeof newBounds === "function" ? newBounds(store.globalBounds) : newBounds,
+      }));
+    },
+    setHoveredEvent: (hoveredEvent: undefined | TimelinePositionedEvent) => {
+      set({ hoveredEvent });
+    },
+    setHoveredBag: () => {
+      set({ hoveredBag: undefined });
+    },
+    setHoverValue: (hoverValue: HoverValue) => {
+      set({ hoverValue });
+    },
+    setLoopedEvent: (loopedEvent: undefined | TimelinePositionedEvent) => {
+      set({ loopedEvent });
+    },
+  }));
+}
+
+function Wrapper({
+  children,
+  eventsStore,
+  timelineInteractionStore,
+}: React.PropsWithChildren<{
+  eventsStore: StoreApi<EventsStore>;
+  timelineInteractionStore: StoreApi<TimelineInteractionStateStore>;
+}>): React.JSX.Element {
+  return (
+    <ThemeProvider isDark>
+      <AppConfigurationContext.Provider value={makeMockAppConfiguration()}>
+        <CoSceneConsoleApiContext.Provider value={{} as never}>
+          <MockMessagePipelineProvider
+            startTime={{ sec: 0, nsec: 0 }}
+            endTime={{ sec: 10, nsec: 0 }}
+            currentTime={{ sec: 1, nsec: 0 }}
+          >
+            <TimelineInteractionStateContext.Provider value={timelineInteractionStore}>
+              <EventsContext.Provider value={eventsStore}>{children}</EventsContext.Provider>
+            </TimelineInteractionStateContext.Provider>
+          </MockMessagePipelineProvider>
+        </CoSceneConsoleApiContext.Provider>
+      </AppConfigurationContext.Provider>
+    </ThemeProvider>
+  );
+}
+
+describe("<EventsOverlay />", () => {
+  it("does not rewrite event marks when a dragged create mark stays at the same position", async () => {
+    const setEventMarks = jest.fn<void, [TimelinePositionedEventMark[]]>();
+    const eventsStore = makeEventsStore({
+      eventMarks: [
+        { key: "start", position: 0.1, time: { sec: 1, nsec: 0 } },
+        { key: "end", position: 0.5, time: { sec: 5, nsec: 0 } },
+      ],
+      setEventMarks,
+    });
+    const timelineInteractionStore = makeTimelineInteractionStore();
+
+    render(
+      <Wrapper eventsStore={eventsStore} timelineInteractionStore={timelineInteractionStore}>
+        <EventsOverlay
+          componentId="test-component"
+          canWriteEvents
+          isDragging
+          eventContextMenuRequest={undefined}
+          onEventContextMenuHandled={jest.fn()}
+          setCursor={jest.fn()}
+          viewport={viewport}
+        />
+      </Wrapper>,
+    );
+
+    await waitFor(() => {
+      expect(setEventMarks).not.toHaveBeenCalled();
+    });
+  });
+
+  it("updates the dragged create mark when the hover position changes", async () => {
+    const setEventMarks = jest.fn<void, [TimelinePositionedEventMark[]]>();
+    const eventsStore = makeEventsStore({
+      eventMarks: [
+        { key: "start", position: 0.1, time: { sec: 1, nsec: 0 } },
+        { key: "end", position: 0.5, time: { sec: 5, nsec: 0 } },
+      ],
+      setEventMarks,
+    });
+    const timelineInteractionStore = makeTimelineInteractionStore();
+
+    render(
+      <Wrapper eventsStore={eventsStore} timelineInteractionStore={timelineInteractionStore}>
+        <EventsOverlay
+          componentId="test-component"
+          canWriteEvents
+          isDragging
+          eventContextMenuRequest={undefined}
+          onEventContextMenuHandled={jest.fn()}
+          setCursor={jest.fn()}
+          viewport={viewport}
+        />
+      </Wrapper>,
+    );
+
+    expect(setEventMarks).not.toHaveBeenCalled();
+
+    act(() => {
+      timelineInteractionStore.getState().setHoverValue({
+        componentId: "test-component",
+        type: "PLAYBACK_SECONDS",
+        value: 2,
+      });
+    });
+
+    await waitFor(() => {
+      expect(setEventMarks).toHaveBeenCalledTimes(1);
+    });
+    expect(setEventMarks).toHaveBeenCalledWith([
+      { key: "start", position: 0.2, time: { sec: 2, nsec: 0 } },
+      { key: "end", position: 0.5, time: { sec: 5, nsec: 0 } },
+    ]);
+  });
+});

--- a/packages/studio-base/src/components/PlaybackControls/EventsOverlay.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/EventsOverlay.tsx
@@ -806,6 +806,24 @@ function areEventTimeRangesEqual(left: EventTimeRange, right: EventTimeRange): b
   );
 }
 
+function areEventMarksEqual(
+  left: TimelinePositionedEventMark[],
+  right: TimelinePositionedEventMark[],
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((leftMark, index) => {
+      const rightMark = right[index];
+      return (
+        rightMark != undefined &&
+        leftMark.key === rightMark.key &&
+        Math.abs(leftMark.position - rightMark.position) < 1e-9 &&
+        areEqual(leftMark.time, rightMark.time)
+      );
+    })
+  );
+}
+
 function snapRangeToLaneBoundaries({
   activeEventName,
   edge,
@@ -1428,18 +1446,20 @@ function UnmemoizedEventsOverlay(props: Props): React.JSX.Element | ReactNull {
         });
         const markOrder = new Map(eventMarks.map((mark, index) => [mark.key, index]));
 
-        setEventMarks(
-          eventMarks
-            .map((mark) => (mark.key === dragPointKey ? nextMark : mark))
-            .sort((a, b) => {
-              const positionDelta = a.position - b.position;
-              if (positionDelta !== 0) {
-                return positionDelta;
-              }
+        const nextEventMarks = eventMarks
+          .map((mark) => (mark.key === dragPointKey ? nextMark : mark))
+          .sort((a, b) => {
+            const positionDelta = a.position - b.position;
+            if (positionDelta !== 0) {
+              return positionDelta;
+            }
 
-              return (markOrder.get(a.key) ?? 0) - (markOrder.get(b.key) ?? 0);
-            }),
-        );
+            return (markOrder.get(a.key) ?? 0) - (markOrder.get(b.key) ?? 0);
+          });
+
+        if (!areEventMarksEqual(eventMarks, nextEventMarks)) {
+          setEventMarks(nextEventMarks);
+        }
       }
     }
   }, [


### PR DESCRIPTION
## Summary
- Avoid rewriting `eventMarks` during create-mark drag unless the next mark list actually differs
- Add a regression test covering both the no-op drag case and a real hover-position update

## Testing
- `yarn test packages/studio-base/src/components/PlaybackControls/EventsOverlay.test.tsx --runInBand`
- `git diff --check`
- `yarn run tsc --noEmit`
- `yarn eslint --cache --cache-strategy content --cache-location .eslintcache --report-unused-disable-directives --config eslint.config.ci.cjs packages/studio-base/src/components/PlaybackControls/EventsOverlay.tsx packages/studio-base/src/components/PlaybackControls/EventsOverlay.test.tsx`