### PR TITLE
让一刻起止点提示在 3 秒后自动隐藏

### DIFF
--- a/packages/studio-base/src/components/PlaybackControls/EventsOverlay.test.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/EventsOverlay.test.tsx
@@ -6,7 +6,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { act, render, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import * as _ from "lodash-es";
 import type { AsyncState } from "react-use/lib/useAsyncFn";
 import { createStore } from "zustand";
@@ -168,6 +168,84 @@ function Wrapper({
 }
 
 describe("<EventsOverlay />", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("hides the single create mark tooltip after three seconds", async () => {
+    jest.useFakeTimers();
+
+    const eventsStore = makeEventsStore({
+      eventMarks: [{ key: "start", position: 0.1, time: { sec: 1, nsec: 0 } }],
+      setEventMarks: jest.fn(),
+    });
+    const timelineInteractionStore = makeTimelineInteractionStore();
+
+    render(
+      <Wrapper eventsStore={eventsStore} timelineInteractionStore={timelineInteractionStore}>
+        <EventsOverlay
+          componentId="test-component"
+          canWriteEvents
+          isDragging={false}
+          eventContextMenuRequest={undefined}
+          onEventContextMenuHandled={jest.fn()}
+          setCursor={jest.fn()}
+          viewport={viewport}
+        />
+      </Wrapper>,
+    );
+
+    expect(await screen.findByText("Start Point")).toBeTruthy();
+
+    act(() => {
+      jest.advanceTimersByTime(2_999);
+    });
+    expect(screen.getByText("Start Point")).toBeTruthy();
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Start Point")).toBeNull();
+    });
+  });
+
+  it("keeps the create moment form open after the mark tooltip timeout", async () => {
+    jest.useFakeTimers();
+
+    const eventsStore = makeEventsStore({
+      eventMarks: [
+        { key: "start", position: 0.1, time: { sec: 1, nsec: 0 } },
+        { key: "end", position: 0.5, time: { sec: 5, nsec: 0 } },
+      ],
+      setEventMarks: jest.fn(),
+    });
+    const timelineInteractionStore = makeTimelineInteractionStore();
+
+    render(
+      <Wrapper eventsStore={eventsStore} timelineInteractionStore={timelineInteractionStore}>
+        <EventsOverlay
+          componentId="test-component"
+          canWriteEvents
+          isDragging={false}
+          eventContextMenuRequest={undefined}
+          onEventContextMenuHandled={jest.fn()}
+          setCursor={jest.fn()}
+          viewport={viewport}
+        />
+      </Wrapper>,
+    );
+
+    expect(await screen.findByTestId("create-event-container")).toBeTruthy();
+
+    act(() => {
+      jest.advanceTimersByTime(3_000);
+    });
+
+    expect(screen.getByTestId("create-event-container")).toBeTruthy();
+  });
+
   it("does not rewrite event marks when a dragged create mark stays at the same position", async () => {
     const setEventMarks = jest.fn<void, [TimelinePositionedEventMark[]]>();
     const eventsStore = makeEventsStore({

--- a/packages/studio-base/src/components/PlaybackControls/EventsOverlay.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/EventsOverlay.tsx
@@ -78,6 +78,7 @@ import EventMarkIcon from "../../assets/event-mark.svg";
 
 const HOTSPOT_WIDTH_PER_CENT = 0.01;
 const EVENT_CLICK_DRAG_THRESHOLD_PX = 4;
+const EVENT_MARK_TOOLTIP_AUTO_HIDE_MS = 3_000;
 
 const useStyles = makeStyles()(({ transitions, palette }) => ({
   root: {
@@ -451,10 +452,12 @@ function EventMark({
   const leftMarkRef = useRef<HTMLDivElement | ReactNull>(ReactNull);
   const [anchorEl, setAnchorEl] = useState<HTMLElement | ReactNull>(ReactNull);
   const [open, setOpen] = useState(false);
+  const [isMarkTooltipOpen, setIsMarkTooltipOpen] = useState(false);
   const setEventMarks = useEvents(selectSetEventMarks);
   const setToModifyEvent = useEvents(selectSetToModifyEvent);
   const { classes, cx } = useStyles();
   const { t } = useTranslation("event");
+  const singleMarkKey = marks.length === 1 ? marks[0]?.key : undefined;
 
   const leftMarkPosition =
     marks[0]?.time != undefined && timelineStartSec != undefined
@@ -479,13 +482,29 @@ function EventMark({
     }
   }, [marks]);
 
+  useEffect(() => {
+    if (singleMarkKey == undefined) {
+      setIsMarkTooltipOpen(false);
+      return;
+    }
+
+    setIsMarkTooltipOpen(true);
+    const timeoutId = window.setTimeout(() => {
+      setIsMarkTooltipOpen(false);
+    }, EVENT_MARK_TOOLTIP_AUTO_HIDE_MS);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [singleMarkKey]);
+
   return (
     <>
       <div className={classes.markLayer} data-testid="timeline-event-mark-layer">
         <Tooltip
           title={t("startPoint")}
           placement="top"
-          open={marks.length === 1}
+          open={isMarkTooltipOpen}
           slotProps={{
             popper: {
               modifiers: [{ name: "offset", options: { offset: [0, 4] } }],


### PR DESCRIPTION
## Summary
- 将创建一刻时的单点提示改为 3 秒后自动关闭，不再常驻显示。
- 保持双点后打开的创建一刻表单逻辑不变，不受 tooltip 自动隐藏影响。
- 增加回归测试，覆盖单点 tooltip 自动消失和双点表单持续显示。

## Testing
- `yarn jest packages/studio-base/src/components/PlaybackControls/EventsOverlay.test.tsx --runInBand`
- `git diff --check`
- `yarn run tsc --noEmit`
- `yarn eslint --cache --cache-strategy content --cache-location .eslintcache --report-unused-disable-directives --config eslint.config.ci.cjs packages/studio-base/src/components/PlaybackControls/EventsOverlay.tsx packages/studio-base/src/components/PlaybackControls/EventsOverlay.test.tsx`