### PR TITLE
Temporarily disable timeline zoom controls

### DIFF
--- a/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
@@ -475,30 +475,31 @@ export default function Scrubber(props: Props): React.JSX.Element {
           {canCreateEvents && <MemoedEventButton disableControls={disableControls} />}
         </div>
         <div className={classes.toolbarActions}>
-          <div className={classes.zoomControl}>
-            <Tooltip title={t("zoomOut")}>
-              <ZoomOutIcon className={classes.zoomIcon} />
-            </Tooltip>
-            <MuiSlider
-              aria-label={t("timelineZoom")}
-              className={classes.zoomSlider}
-              disabled={
-                !isTimelineZoomEnabled() ||
-                zoomPercent == undefined ||
-                zoomAnchorSec == undefined ||
-                startTime == undefined ||
-                endTime == undefined
-              }
-              min={0}
-              max={100}
-              size="small"
-              value={zoomPercent ?? 0}
-              onChange={onZoomSliderChange}
-            />
-            <Tooltip title={t("zoomIn")}>
-              <ZoomInIcon className={classes.zoomIcon} />
-            </Tooltip>
-          </div>
+          {isTimelineZoomEnabled() && (
+            <div className={classes.zoomControl}>
+              <Tooltip title={t("zoomOut")}>
+                <ZoomOutIcon className={classes.zoomIcon} />
+              </Tooltip>
+              <MuiSlider
+                aria-label={t("timelineZoom")}
+                className={classes.zoomSlider}
+                disabled={
+                  zoomPercent == undefined ||
+                  zoomAnchorSec == undefined ||
+                  startTime == undefined ||
+                  endTime == undefined
+                }
+                min={0}
+                max={100}
+                size="small"
+                value={zoomPercent ?? 0}
+                onChange={onZoomSliderChange}
+              />
+              <Tooltip title={t("zoomIn")}>
+                <ZoomInIcon className={classes.zoomIcon} />
+              </Tooltip>
+            </div>
+          )}
           {canWriteEvents && (
             <HoverableIconButton
               size="small"

--- a/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
@@ -67,6 +67,10 @@ const SCRUBBER_TOOLBAR_HEIGHT_PX: number = 32;
 const TIMELINE_RULER_HEIGHT_PX: number = 14;
 const MIN_TIMELINE_CONTENT_HEIGHT_PX: number = 90;
 
+function isTimelineZoomEnabled(): boolean {
+  return false;
+}
+
 const useStyles = makeStyles()((theme) => ({
   root: {
     display: "flex",
@@ -361,6 +365,9 @@ export default function Scrubber(props: Props): React.JSX.Element {
       const rect = target.getBoundingClientRect();
       if (event.ctrlKey || event.metaKey) {
         event.preventDefault();
+        if (!isTimelineZoomEnabled()) {
+          return;
+        }
         const anchorSec = clientXToTime(event.clientX, rect, currentViewport);
         setViewport((oldViewport) => {
           const sourceViewport = oldViewport ?? currentViewport;
@@ -402,7 +409,7 @@ export default function Scrubber(props: Props): React.JSX.Element {
   const onZoomSliderChange = useCallback(
     (_event: Event, value: number | number[]): void => {
       const currentViewport = latestViewport.current;
-      if (currentViewport == undefined || zoomAnchorSec == undefined) {
+      if (!isTimelineZoomEnabled() || currentViewport == undefined || zoomAnchorSec == undefined) {
         return;
       }
 
@@ -476,6 +483,7 @@ export default function Scrubber(props: Props): React.JSX.Element {
               aria-label={t("timelineZoom")}
               className={classes.zoomSlider}
               disabled={
+                !isTimelineZoomEnabled() ||
                 zoomPercent == undefined ||
                 zoomAnchorSec == undefined ||
                 startTime == undefined ||


### PR DESCRIPTION
## Summary
- Added a temporary `isTimelineZoomEnabled()` gate in `Scrubber` that returns `false`
- Disabled both timeline zoom entry points: `Ctrl/Cmd` + wheel zoom and the zoom slider
- Left timeline panning and the rest of playback controls unchanged

## Testing
- `git diff --check`
- `yarn run tsc --noEmit`
- `yarn eslint --cache --cache-strategy content --cache-location .eslintcache --report-unused-disable-directives --config eslint.config.ci.cjs packages/studio-base/src/components/PlaybackControls/Scrubber.tsx`
- `yarn jest packages/studio-base/src/components/PlaybackControls/timelineViewport.test.ts`