### PR TITLE
Add spacing between bag bars and event lanes

### DIFF
--- a/packages/studio-base/src/components/PlaybackControls/BagsOverlay.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/BagsOverlay.tsx
@@ -20,6 +20,10 @@ import {
 
 import { type TimelineViewport, timelineRangeToStyle } from "./timelineViewport";
 
+export const BAG_OVERLAY_HEIGHT_PX: number = 12;
+const BAG_TICK_HEIGHT_PX: number = 6;
+const BAG_TICK_HOVERED_HEIGHT_PX: number = 12;
+
 const useStyles = makeStyles()(({ transitions, palette }) => ({
   root: {
     inset: 0,
@@ -27,7 +31,7 @@ const useStyles = makeStyles()(({ transitions, palette }) => ({
     position: "absolute",
     display: "flex",
     alignItems: "center",
-    height: 10,
+    height: BAG_OVERLAY_HEIGHT_PX,
   },
   tick: {
     transition: transitions.create("height", { duration: transitions.duration.shortest }),
@@ -35,13 +39,13 @@ const useStyles = makeStyles()(({ transitions, palette }) => ({
     backgroundColor: "#93c5fd",
     opacity: 0.5,
     position: "absolute",
-    height: 6,
+    height: BAG_TICK_HEIGHT_PX,
   },
   tickHovered: {
     transition: transitions.create("height", { duration: transitions.duration.shortest }),
     backgroundColor: "#93c5fd",
     border: `1px solid ${palette.info.main}`,
-    height: 12,
+    height: BAG_TICK_HOVERED_HEIGHT_PX,
   },
 }));
 

--- a/packages/studio-base/src/components/PlaybackControls/EventsOverlay.test.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/EventsOverlay.test.tsx
@@ -7,6 +7,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { act, render, screen, waitFor } from "@testing-library/react";
+import i18n from "i18next";
 import * as _ from "lodash-es";
 import type { AsyncState } from "react-use/lib/useAsyncFn";
 import { createStore } from "zustand";
@@ -170,6 +171,43 @@ function Wrapper({
 describe("<EventsOverlay />", () => {
   afterEach(() => {
     jest.useRealTimers();
+  });
+
+  it("shows the shortcut hint when the timeline has no moments", async () => {
+    const originalLanguage = i18n.language;
+    await act(async () => {
+      await i18n.changeLanguage("zh");
+    });
+
+    try {
+      const eventsStore = makeEventsStore({
+        eventMarks: [],
+        setEventMarks: jest.fn(),
+      });
+      const timelineInteractionStore = makeTimelineInteractionStore();
+
+      render(
+        <Wrapper eventsStore={eventsStore} timelineInteractionStore={timelineInteractionStore}>
+          <EventsOverlay
+            componentId="test-component"
+            canWriteEvents
+            isDragging={false}
+            eventContextMenuRequest={undefined}
+            onEventContextMenuHandled={jest.fn()}
+            setCursor={jest.fn()}
+            viewport={viewport}
+          />
+        </Wrapper>,
+      );
+
+      expect(screen.getByTestId("timeline-empty-event-hint").textContent).toBe(
+        "使用快捷键 Alt+1 创建一刻，为数据打标注",
+      );
+    } finally {
+      await act(async () => {
+        await i18n.changeLanguage(originalLanguage || "en");
+      });
+    }
   });
 
   it("hides the single create mark tooltip after three seconds", async () => {

--- a/packages/studio-base/src/components/PlaybackControls/Scrubber.test.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Scrubber.test.tsx
@@ -1,0 +1,64 @@
+/** @jest-environment jsdom */
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { render, screen } from "@testing-library/react";
+
+import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
+import AppConfigurationContext from "@foxglove/studio-base/context/AppConfigurationContext";
+import CoSceneConsoleApiContext from "@foxglove/studio-base/context/CoSceneConsoleApiContext";
+import CoScenePlaylistProvider from "@foxglove/studio-base/providers/CoScenePlaylistProvider";
+import CoreDataProvider from "@foxglove/studio-base/providers/CoreDataProvider";
+import EventsProvider from "@foxglove/studio-base/providers/EventsProvider";
+import TimelineInteractionStateProvider from "@foxglove/studio-base/providers/TimelineInteractionStateProvider";
+import WorkspaceContextProvider from "@foxglove/studio-base/providers/WorkspaceContextProvider";
+import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
+import { makeMockAppConfiguration } from "@foxglove/studio-base/util/makeMockAppConfiguration";
+
+import Scrubber from "./Scrubber";
+
+function Wrapper({ children }: React.PropsWithChildren): React.JSX.Element {
+  return (
+    <ThemeProvider isDark>
+      <AppConfigurationContext.Provider value={makeMockAppConfiguration()}>
+        <CoSceneConsoleApiContext.Provider value={{} as never}>
+          <CoreDataProvider>
+            <WorkspaceContextProvider disablePersistenceForStorybook>
+              <MockMessagePipelineProvider
+                startTime={{ sec: 0, nsec: 0 }}
+                endTime={{ sec: 10, nsec: 0 }}
+                currentTime={{ sec: 1, nsec: 0 }}
+              >
+                <TimelineInteractionStateProvider>
+                  <CoScenePlaylistProvider>
+                    <EventsProvider>{children}</EventsProvider>
+                  </CoScenePlaylistProvider>
+                </TimelineInteractionStateProvider>
+              </MockMessagePipelineProvider>
+            </WorkspaceContextProvider>
+          </CoreDataProvider>
+        </CoSceneConsoleApiContext.Provider>
+      </AppConfigurationContext.Provider>
+    </ThemeProvider>
+  );
+}
+
+describe("<Scrubber />", () => {
+  it("keeps the first moment lane at least 4px below the bag file bar", () => {
+    render(
+      <Wrapper>
+        <Scrubber onSeek={jest.fn()} />
+      </Wrapper>,
+    );
+
+    const eventLaneLayerTop = Number.parseFloat(
+      getComputedStyle(screen.getByTestId("event-lane-layer")).top,
+    );
+
+    expect(eventLaneLayerTop).toBeGreaterThanOrEqual(28);
+  });
+});

--- a/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
@@ -45,7 +45,7 @@ import {
 import { useWorkspaceActions } from "@foxglove/studio-base/context/Workspace/useWorkspaceActions";
 import { PlayerPresence } from "@foxglove/studio-base/players/types";
 
-import { BagsOverlay } from "./BagsOverlay";
+import { BAG_OVERLAY_HEIGHT_PX, BagsOverlay } from "./BagsOverlay";
 import { EventsOverlay } from "./EventsOverlay";
 import { PlaybackBarHoverTicks } from "./PlaybackBarHoverTicks";
 import { PlaybackControlsTooltipContent } from "./PlaybackControlsTooltipContent";
@@ -65,6 +65,9 @@ import {
 
 const SCRUBBER_TOOLBAR_HEIGHT_PX: number = 32;
 const TIMELINE_RULER_HEIGHT_PX: number = 14;
+const TIMELINE_BAG_TO_EVENT_GAP_PX: number = 4;
+const EVENT_LANE_LAYER_TOP_PX: number =
+  TIMELINE_RULER_HEIGHT_PX + BAG_OVERLAY_HEIGHT_PX + TIMELINE_BAG_TO_EVENT_GAP_PX;
 const MIN_TIMELINE_CONTENT_HEIGHT_PX: number = 90;
 
 function isTimelineZoomEnabled(): boolean {
@@ -150,7 +153,7 @@ const useStyles = makeStyles()((theme) => ({
     pointerEvents: "none",
     position: "absolute",
     right: 0,
-    top: TIMELINE_RULER_HEIGHT_PX,
+    top: EVENT_LANE_LAYER_TOP_PX,
   },
   hoverTickLayer: {
     pointerEvents: "none",
@@ -456,7 +459,7 @@ export default function Scrubber(props: Props): React.JSX.Element {
 
     return Math.max(
       MIN_TIMELINE_CONTENT_HEIGHT_PX,
-      TIMELINE_RULER_HEIGHT_PX + Math.max(effectiveEventLaneCount, 1) * EVENT_LANE_HEIGHT_PX,
+      EVENT_LANE_LAYER_TOP_PX + Math.max(effectiveEventLaneCount, 1) * EVENT_LANE_HEIGHT_PX,
     );
   }, [eventLaneCount, previewEventLaneCount]);
 
@@ -575,7 +578,7 @@ export default function Scrubber(props: Props): React.JSX.Element {
               <Stack
                 position="absolute"
                 fullWidth
-                style={{ height: 10, top: TIMELINE_RULER_HEIGHT_PX }}
+                style={{ height: BAG_OVERLAY_HEIGHT_PX, top: TIMELINE_RULER_HEIGHT_PX }}
               >
                 <BagsOverlay viewport={resolvedViewport} />
               </Stack>

--- a/packages/studio-base/src/components/PlaybackControls/TimelinePositionIndicator.test.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/TimelinePositionIndicator.test.tsx
@@ -1,0 +1,36 @@
+/** @jest-environment jsdom */
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { render, screen } from "@testing-library/react";
+
+import { TimelinePositionIndicator } from "./TimelinePositionIndicator";
+
+describe("<TimelinePositionIndicator />", () => {
+  it("keeps the handle fixed while extending the line to the parent bottom", () => {
+    render(
+      <div style={{ height: 300, position: "relative" }}>
+        <TimelinePositionIndicator
+          color="currentColor"
+          dataTestId="timeline-position-indicator"
+        />
+      </div>,
+    );
+
+    const indicator = screen.getByTestId("timeline-position-indicator");
+    const indicatorStyle = getComputedStyle(indicator);
+    const handle = indicator.querySelector("svg");
+    const line = screen.getByTestId("timeline-position-indicator-line");
+
+    expect(indicatorStyle.top).toBe("0px");
+    expect(indicatorStyle.bottom).toBe("0px");
+    expect(indicatorStyle.zIndex).toBe("4");
+    expect(getComputedStyle(handle!).height).toBe("129px");
+    expect(getComputedStyle(line).top).toBe("128px");
+    expect(getComputedStyle(line).bottom).toBe("0px");
+  });
+});

--- a/packages/studio-base/src/components/PlaybackControls/TimelinePositionIndicator.test.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/TimelinePositionIndicator.test.tsx
@@ -14,10 +14,7 @@ describe("<TimelinePositionIndicator />", () => {
   it("keeps the handle fixed while extending the line to the parent bottom", () => {
     render(
       <div style={{ height: 300, position: "relative" }}>
-        <TimelinePositionIndicator
-          color="currentColor"
-          dataTestId="timeline-position-indicator"
-        />
+        <TimelinePositionIndicator color="currentColor" dataTestId="timeline-position-indicator" />
       </div>,
     );
 

--- a/packages/studio-base/src/components/PlaybackControls/TimelinePositionIndicator.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/TimelinePositionIndicator.tsx
@@ -17,16 +17,32 @@ const useStyles = makeStyles()(() => ({
     top: 0,
     transform: "translateX(-50%)",
     width: 9,
+    zIndex: TIMELINE_POSITION_INDICATOR_Z_INDEX,
+  },
+  line: {
+    backgroundColor: "currentColor",
+    borderRadius: 1,
+    bottom: 0,
+    left: 4,
+    position: "absolute",
+    top: TIMELINE_POSITION_INDICATOR_LINE_EXTENSION_TOP_PX,
+    width: 1,
   },
   svg: {
     display: "block",
-    height: "100%",
+    height: TIMELINE_POSITION_INDICATOR_HEIGHT_PX,
     overflow: "visible",
+    position: "relative",
     width: "100%",
+    zIndex: 1,
   },
 }));
 
 export const TIMELINE_POSITION_INDICATOR_HANDLE_HEIGHT_PX: number = 10;
+export const TIMELINE_POSITION_INDICATOR_HEIGHT_PX: number = 129;
+export const TIMELINE_POSITION_INDICATOR_LINE_EXTENSION_TOP_PX: number =
+  TIMELINE_POSITION_INDICATOR_HEIGHT_PX - 1;
+export const TIMELINE_POSITION_INDICATOR_Z_INDEX: number = 4;
 
 function makeDOMRect(x: number, y: number, width: number, height: number): DOMRect {
   if (typeof DOMRect !== "undefined") {
@@ -77,6 +93,12 @@ export const TimelinePositionIndicator: ForwardRefExoticComponent<
         data-testid={dataTestId}
         style={{ ...style, color }}
       >
+        <div
+          aria-hidden
+          className={classes.line}
+          data-testid={`${dataTestId}-line`}
+          style={{ opacity: fillOpacity }}
+        />
         <svg
           aria-hidden
           className={classes.svg}

--- a/packages/studio-base/src/i18n/en/event.ts
+++ b/packages/studio-base/src/i18n/en/event.ts
@@ -28,7 +28,7 @@ export const event = {
   editMomentFailed: "Save failed",
   editMomentSuccess: "Save success",
   elapsed: "Elapsed",
-  emptyTimelineHint: "Select start and end points to create a moment",
+  emptyTimelineHint: "Use Alt+1 to create a moment and annotate data",
   enableLinkedEventAdjustment: "Enable linked event adjustment",
   disableLinkedEventAdjustment: "Disable linked event adjustment",
   end: "End",

--- a/packages/studio-base/src/i18n/zh/event.ts
+++ b/packages/studio-base/src/i18n/zh/event.ts
@@ -30,7 +30,7 @@ export const event: Partial<TypeOptions["resources"]["event"]> = {
   editMomentFailed: "保存失败",
   editMomentSuccess: "保存成功",
   elapsed: "经过时间",
-  emptyTimelineHint: "选择起止点创建一刻",
+  emptyTimelineHint: "使用快捷键 Alt+1 创建一刻，为数据打标注",
   enableLinkedEventAdjustment: "开启联动调整",
   disableLinkedEventAdjustment: "关闭联动调整",
   end: "结束",


### PR DESCRIPTION
## Summary
- Increase the bag overlay height constant and make the event lane layer start below it with a 4px gap
- Keep the timeline content height in sync with the new lane offset
- Add a regression test that locks the bag-to-event spacing expectation

## Testing
- `yarn jest packages/studio-base/src/components/PlaybackControls/Scrubber.test.tsx --runInBand`
- `yarn jest packages/studio-base/src/components/PlaybackControls/Scrubber.test.tsx packages/studio-base/src/components/PlaybackControls/EventsOverlay.test.tsx packages/studio-base/src/components/PlaybackControls/eventLanes.test.ts packages/studio-base/src/components/PlaybackControls/PlaybackBarPointerEvents.test.tsx --runInBand`