### PR TITLE
Fix adjacent moment lane placement for created moments

### DIFF
--- a/packages/studio-base/src/components/Events/EventsSyncAdapter.test.tsx
+++ b/packages/studio-base/src/components/Events/EventsSyncAdapter.test.tsx
@@ -1,0 +1,221 @@
+/** @jest-environment jsdom */
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { create } from "@bufbuild/protobuf";
+import { DurationSchema, TimestampSchema } from "@bufbuild/protobuf/wkt";
+import { EventSchema } from "@coscene-io/cosceneapis-es-v2/coscene/dataplatform/v1alpha2/resources/event_pb";
+import { act, render, waitFor } from "@testing-library/react";
+import * as _ from "lodash-es";
+import type { AsyncState } from "react-use/lib/useAsyncFn";
+import { createStore } from "zustand";
+import type { StoreApi } from "zustand";
+
+import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
+import CoSceneConsoleApiContext from "@foxglove/studio-base/context/CoSceneConsoleApiContext";
+import {
+  EventsContext,
+  type EventsStore,
+  type TimelinePositionedEvent,
+  type TimelinePositionedEventMark,
+} from "@foxglove/studio-base/context/EventsContext";
+import {
+  TimelineInteractionStateContext,
+  type SyncBounds,
+  type TimelineInteractionStateStore,
+} from "@foxglove/studio-base/context/TimelineInteractionStateContext";
+import CoScenePlaylistProvider from "@foxglove/studio-base/providers/CoScenePlaylistProvider";
+import CoreDataProvider from "@foxglove/studio-base/providers/CoreDataProvider";
+
+import { EventsSyncAdapter } from "./EventsSyncAdapter";
+
+function makeEvent(name: string, startSec: number, durationSec: number): TimelinePositionedEvent {
+  return {
+    event: create(EventSchema, {
+      name,
+      displayName: name,
+      triggerTime: create(TimestampSchema, {
+        seconds: BigInt(startSec),
+        nanos: 0,
+      }),
+      duration: create(DurationSchema, {
+        seconds: BigInt(durationSec),
+        nanos: 0,
+      }),
+    }),
+    startTime: { sec: startSec, nsec: 0 },
+    endTime: { sec: startSec + durationSec, nsec: 0 },
+    color: "#00ADEF",
+    startPosition: startSec / 10,
+    endPosition: (startSec + durationSec) / 10,
+    secondsSinceStart: startSec,
+  };
+}
+
+function makeEventsStore({
+  events,
+  eventMarks,
+  setEventMarks,
+}: {
+  events: TimelinePositionedEvent[];
+  eventMarks?: TimelinePositionedEventMark[];
+  setEventMarks: jest.Mock<void, [TimelinePositionedEventMark[]]>;
+}): StoreApi<EventsStore> {
+  return createStore<EventsStore>((set) => ({
+    eventFetchCount: 0,
+    events: { loading: false, value: events },
+    filter: "",
+    selectedEventId: undefined,
+    deviceId: undefined,
+    eventMarks: eventMarks ?? [],
+    toModifyEvent: undefined,
+    customFieldSchema: undefined,
+
+    refreshEvents: () => {
+      set((old) => ({ eventFetchCount: old.eventFetchCount + 1 }));
+    },
+    selectEvent: (id: undefined | string) => {
+      set({ selectedEventId: id });
+    },
+    setEvents: (nextEvents: AsyncState<TimelinePositionedEvent[]>) => {
+      set({ events: nextEvents, selectedEventId: undefined });
+    },
+    setFilter: (filter: string) => {
+      set({ filter });
+    },
+    setDeviceId: (deviceId: string | undefined) => {
+      set({ deviceId });
+    },
+    setEventMarks: (marks: TimelinePositionedEventMark[]) => {
+      setEventMarks(marks);
+      set({ eventMarks: marks });
+    },
+    setToModifyEvent: (toModifyEvent) => {
+      set({ toModifyEvent });
+    },
+    setCustomFieldSchema: (customFieldSchema) => {
+      set({ customFieldSchema });
+    },
+  }));
+}
+
+function makeTimelineInteractionStore(): StoreApi<TimelineInteractionStateStore> {
+  return createStore<TimelineInteractionStateStore>((set) => ({
+    eventsAtHoverValue: {},
+    bagsAtHoverValue: {},
+    globalBounds: undefined,
+    hoveredEvent: undefined,
+    hoveredBag: undefined,
+    hoverValue: undefined,
+    loopedEvent: undefined,
+
+    clearHoverValue: (componentId: string) => {
+      set((store) => ({
+        hoverValue: store.hoverValue?.componentId === componentId ? undefined : store.hoverValue,
+      }));
+    },
+    setEventsAtHoverValue: (eventsAtHoverValue: TimelinePositionedEvent[]) => {
+      set({ eventsAtHoverValue: _.keyBy(eventsAtHoverValue, (event) => event.event.name) });
+    },
+    setBagsAtHoverValue: () => {
+      set({ bagsAtHoverValue: {} });
+    },
+    setGlobalBounds: (
+      newBounds:
+        | undefined
+        | SyncBounds
+        | ((oldValue: undefined | SyncBounds) => undefined | SyncBounds),
+    ) => {
+      set((store) => ({
+        globalBounds: typeof newBounds === "function" ? newBounds(store.globalBounds) : newBounds,
+      }));
+    },
+    setHoveredEvent: (hoveredEvent: undefined | TimelinePositionedEvent) => {
+      set({ hoveredEvent });
+    },
+    setHoveredBag: () => {
+      set({ hoveredBag: undefined });
+    },
+    setHoverValue: (hoverValue) => {
+      set({ hoverValue });
+    },
+    setLoopedEvent: (loopedEvent: undefined | TimelinePositionedEvent) => {
+      set({ loopedEvent });
+    },
+  }));
+}
+
+function Wrapper({
+  children,
+  currentTime,
+  eventsStore,
+  timelineInteractionStore,
+}: React.PropsWithChildren<{
+  currentTime: { sec: number; nsec: number };
+  eventsStore: StoreApi<EventsStore>;
+  timelineInteractionStore: StoreApi<TimelineInteractionStateStore>;
+}>): React.JSX.Element {
+  return (
+    <CoSceneConsoleApiContext.Provider value={{} as never}>
+      <CoreDataProvider>
+        <CoScenePlaylistProvider>
+          <MockMessagePipelineProvider
+            startTime={{ sec: 0, nsec: 0 }}
+            endTime={{ sec: 10, nsec: 0 }}
+            currentTime={currentTime}
+          >
+            <TimelineInteractionStateContext.Provider value={timelineInteractionStore}>
+              <EventsContext.Provider value={eventsStore}>{children}</EventsContext.Provider>
+            </TimelineInteractionStateContext.Provider>
+          </MockMessagePipelineProvider>
+        </CoScenePlaylistProvider>
+      </CoreDataProvider>
+    </CoSceneConsoleApiContext.Provider>
+  );
+}
+
+describe("<EventsSyncAdapter />", () => {
+  it("snaps shortcut-created marks to nearby event boundaries", async () => {
+    const setEventMarks = jest.fn<void, [TimelinePositionedEventMark[]]>();
+    const eventsStore = makeEventsStore({
+      events: [makeEvent("events/first", 1, 1)],
+      setEventMarks,
+    });
+    const timelineInteractionStore = makeTimelineInteractionStore();
+
+    render(
+      <Wrapper
+        currentTime={{ sec: 1, nsec: 990_000_000 }}
+        eventsStore={eventsStore}
+        timelineInteractionStore={timelineInteractionStore}
+      >
+        <EventsSyncAdapter />
+      </Wrapper>,
+    );
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "1",
+          code: "Digit1",
+          altKey: true,
+          bubbles: true,
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(setEventMarks).toHaveBeenCalledTimes(1);
+    });
+    expect(setEventMarks).toHaveBeenCalledWith([
+      expect.objectContaining({
+        position: 0.2,
+        time: { sec: 2, nsec: 0 },
+      }),
+    ]);
+  });
+});

--- a/packages/studio-base/src/components/Events/EventsSyncAdapter.tsx
+++ b/packages/studio-base/src/components/Events/EventsSyncAdapter.tsx
@@ -19,6 +19,7 @@ import {
   MessagePipelineContext,
   useMessagePipeline,
 } from "@foxglove/studio-base/components/MessagePipeline";
+import { getSnappedEventMark } from "@foxglove/studio-base/components/PlaybackControls/eventSnap";
 import { useConsoleApi } from "@foxglove/studio-base/context/CoSceneConsoleApiContext";
 import {
   CoScenePlaylistStore,
@@ -351,14 +352,21 @@ export function EventsSyncAdapter(): React.JSX.Element {
         pauseRef.current?.();
       }
 
-      const nextMarks = [
-        ...marks,
-        positionEventMark({ currentTime: current, startTime: start, endTime: end }),
-      ].sort((a, b) => a.position - b.position);
+      const mark = positionEventMark({ currentTime: current, startTime: start, endTime: end });
+      const snappedMark = getSnappedEventMark({ mark, events: events.value ?? [] });
+      const nextMarks = [...marks, snappedMark].sort((a, b) => a.position - b.position);
 
       setEventMarks(nextMarks);
     },
-    [currentTimeRef, endTimeRef, eventMarksRef, pauseRef, setEventMarks, startTimeRef],
+    [
+      currentTimeRef,
+      endTimeRef,
+      eventMarksRef,
+      events.value,
+      pauseRef,
+      setEventMarks,
+      startTimeRef,
+    ],
   );
 
   const keyDownHandlers = useMemo(

--- a/packages/studio-base/src/components/PlaybackControls/eventLanes.test.ts
+++ b/packages/studio-base/src/components/PlaybackControls/eventLanes.test.ts
@@ -107,9 +107,20 @@ describe("layoutEventLanes", () => {
     expect(getEventLaneByName(layout, "events/second")).toBe(0);
   });
 
+  it("keeps adjacent events on the same lane after millisecond timestamp drift", () => {
+    const layout = layoutEventLanes({
+      events: [makeEvent("events/first", 0, 2), makeEvent("events/second", 1.999, 2)],
+      viewport: makeTimelineViewport(0, 10),
+    });
+
+    expect(layout.laneCount).toBe(1);
+    expect(getEventLaneByName(layout, "events/first")).toBe(0);
+    expect(getEventLaneByName(layout, "events/second")).toBe(0);
+  });
+
   it("keeps non-exact near-touching events on separate lanes within overlap tolerance", () => {
     const layout = layoutEventLanes({
-      events: [makeEvent("events/first", 1, 2), makeEvent("events/second", 3.001, 2)],
+      events: [makeEvent("events/first", 1, 2), makeEvent("events/second", 3.01, 2)],
       viewport: makeTimelineViewport(0, 10),
     });
 

--- a/packages/studio-base/src/components/PlaybackControls/eventLanes.ts
+++ b/packages/studio-base/src/components/PlaybackControls/eventLanes.ts
@@ -19,7 +19,7 @@ export const EVENT_BAR_HEIGHT_PX: number = 24;
 export const EVENT_BAR_TOP_OFFSET_PX: number = 2;
 export const EVENT_MIN_WIDTH_PX: number = 4;
 
-const EVENT_LANE_ADJACENCY_EPSILON_SEC = 1e-6;
+const EVENT_LANE_ADJACENCY_EPSILON_SEC = 2e-3;
 
 export type EventLaneLayoutItem = {
   endPosition: number;


### PR DESCRIPTION
## Summary
- Snap shortcut-created moment marks to nearby event boundaries before saving
- Allow small millisecond-level boundary drift to stay on the same timeline lane
- Add tests for shortcut creation and lane placement around adjacent moments

## Testing
- `yarn test packages/studio-base/src/components/Events/EventsSyncAdapter.test.tsx packages/studio-base/src/components/PlaybackControls/eventSnap.test.ts packages/studio-base/src/components/PlaybackControls/eventLanes.test.ts --runInBand`
- Verified the local UI in the in-app browser after reload; both moments render on the same lane