### PR TITLE
[codex] Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# CODEOWNERS for honeybee.
+# Generated from recent module-level Git history; keep broad by design.
+
+* @Woodii1998
+
+/packages/ @Woodii1998
+/web/ @Woodii1998
+/desktop/ @Woodii1998
+/benchmark/ @Woodii1998
+/ci/ @Woodii1998
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 # CODEOWNERS for honeybee.
 # Generated from recent module-level Git history; keep broad by design.
+# More specific rules below override the broad defaults (last match wins).
 
 * @Woodii1998
 
@@ -9,3 +10,15 @@
 /benchmark/ @Woodii1998
 /ci/ @Woodii1998
 
+# Module ownership derived from recent contribution history.
+
+# Timeline & playback controls (PRs #1337, #1321)
+/packages/studio-base/src/components/PlaybackControls/ @Woodii1998 @zhigang1992
+/packages/studio-base/src/components/Events/ @Woodii1998 @zhigang1992
+
+# Image & compressed-video rendering (PR #1326)
+/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ @Woodii1998 @zhigang1992
+/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ @Woodii1998 @zhigang1992
+
+# Localization strings (PRs #1337, #1321)
+/packages/studio-base/src/i18n/ @Woodii1998 @zhigang1992


### PR DESCRIPTION
Adds a .github/CODEOWNERS file based on recent module-level ownership history. This gives GitHub a broad review-routing map without overfitting individual files. Validation: git diff --check.