### PR TITLE
Ignore stale auth status sign-out cookies

### DIFF
--- a/packages/studio-base/src/providers/CoSceneCookiesProvider/AuthSignOutListener.test.tsx
+++ b/packages/studio-base/src/providers/CoSceneCookiesProvider/AuthSignOutListener.test.tsx
@@ -1,0 +1,96 @@
+/** @jest-environment jsdom */
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { shouldRedirectForAuthStatusCookie } from "./AuthSignOutListener";
+import { AuthStatus } from "./constant";
+
+describe("shouldRedirectForAuthStatusCookie", () => {
+  const mountedAt = 1_000;
+
+  it("ignores stale SIGN_OUT cookies that predate listener mount", () => {
+    expect(
+      shouldRedirectForAuthStatusCookie({
+        cookie: { status: AuthStatus.SIGN_OUT, updatedAt: mountedAt - 1 },
+        mountedAt,
+        alreadyRedirected: false,
+        isDesktop: false,
+        isAuthless: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores SIGN_OUT cookies with missing or invalid updatedAt", () => {
+    expect(
+      shouldRedirectForAuthStatusCookie({
+        cookie: { status: AuthStatus.SIGN_OUT },
+        mountedAt,
+        alreadyRedirected: false,
+        isDesktop: false,
+        isAuthless: false,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldRedirectForAuthStatusCookie({
+        cookie: { status: AuthStatus.SIGN_OUT, updatedAt: "not-a-date" },
+        mountedAt,
+        alreadyRedirected: false,
+        isDesktop: false,
+        isAuthless: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("redirects for new SIGN_OUT cookies only once", () => {
+    const cookie = { status: AuthStatus.SIGN_OUT, updatedAt: mountedAt };
+
+    expect(
+      shouldRedirectForAuthStatusCookie({
+        cookie,
+        mountedAt,
+        alreadyRedirected: false,
+        isDesktop: false,
+        isAuthless: false,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldRedirectForAuthStatusCookie({
+        cookie,
+        mountedAt,
+        alreadyRedirected: true,
+        isDesktop: false,
+        isAuthless: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps the existing desktop and authless skip behavior", () => {
+    const cookie = { status: AuthStatus.SIGN_OUT, updatedAt: mountedAt };
+
+    expect(
+      shouldRedirectForAuthStatusCookie({
+        cookie,
+        mountedAt,
+        alreadyRedirected: false,
+        isDesktop: true,
+        isAuthless: false,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldRedirectForAuthStatusCookie({
+        cookie,
+        mountedAt,
+        alreadyRedirected: false,
+        isDesktop: false,
+        isAuthless: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/studio-base/src/providers/CoSceneCookiesProvider/AuthSignOutListener.tsx
+++ b/packages/studio-base/src/providers/CoSceneCookiesProvider/AuthSignOutListener.tsx
@@ -5,7 +5,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useCookies } from "react-cookie";
 
 import { getAuthStatusCookieName } from "@foxglove/studio-base/util/appConfig";
@@ -14,18 +14,90 @@ import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
 import { AuthStatus } from "./constant";
 
+type AuthStatusCookie = {
+  status?: unknown;
+  updatedAt?: unknown;
+};
+
+type ShouldRedirectForAuthStatusCookieArgs = {
+  cookie: unknown;
+  mountedAt: number;
+  alreadyRedirected: boolean;
+  isDesktop: boolean;
+  isAuthless: boolean;
+};
+
+function parseUpdatedAtMs(updatedAt: unknown): number | undefined {
+  if (typeof updatedAt === "number") {
+    return Number.isFinite(updatedAt) ? updatedAt : undefined;
+  }
+
+  if (typeof updatedAt !== "string") {
+    return undefined;
+  }
+
+  const trimmedUpdatedAt = updatedAt.trim();
+
+  if (trimmedUpdatedAt.length === 0) {
+    return undefined;
+  }
+
+  const timestamp = /^\d+$/.test(trimmedUpdatedAt)
+    ? Number(trimmedUpdatedAt)
+    : Date.parse(trimmedUpdatedAt);
+
+  return Number.isFinite(timestamp) ? timestamp : undefined;
+}
+
+function isAuthStatusCookie(cookie: unknown): cookie is AuthStatusCookie {
+  return cookie != undefined && typeof cookie === "object";
+}
+
+export function shouldRedirectForAuthStatusCookie({
+  cookie,
+  mountedAt,
+  alreadyRedirected,
+  isDesktop,
+  isAuthless,
+}: ShouldRedirectForAuthStatusCookieArgs): boolean {
+  if (alreadyRedirected || isDesktop || isAuthless || !isAuthStatusCookie(cookie)) {
+    return false;
+  }
+
+  if (cookie.status !== AuthStatus.SIGN_OUT) {
+    return false;
+  }
+
+  const updatedAt = parseUpdatedAtMs(cookie.updatedAt);
+
+  return updatedAt != undefined && updatedAt >= mountedAt;
+}
+
 function AuthSignOutListener(): React.JSX.Element {
   const authStatusCookieName = getAuthStatusCookieName();
   const [cookies] = useCookies([authStatusCookieName]);
-  const signOut = cookies[authStatusCookieName]?.status === AuthStatus.SIGN_OUT;
+  const authStatusCookie = cookies[authStatusCookieName];
+  const mountedAt = useRef(Date.now());
+  const redirected = useRef(false);
 
   useEffect(() => {
-    if (signOut && !isDesktopApp() && !isAuthlessDataSource()) {
-      window.location.href = `/login?redirectToPath=${encodeURIComponent(
-        window.location.pathname + window.location.search,
-      )}`;
+    if (
+      !shouldRedirectForAuthStatusCookie({
+        cookie: authStatusCookie,
+        mountedAt: mountedAt.current,
+        alreadyRedirected: redirected.current,
+        isDesktop: isDesktopApp(),
+        isAuthless: isAuthlessDataSource(),
+      })
+    ) {
+      return;
     }
-  }, [signOut]);
+
+    redirected.current = true;
+    window.location.href = `/login?redirectToPath=${encodeURIComponent(
+      window.location.pathname + window.location.search,
+    )}`;
+  }, [authStatusCookie]);
 
   return <></>;
 }

--- a/packages/studio-base/src/providers/CoSceneCookiesProvider/constant.test.ts
+++ b/packages/studio-base/src/providers/CoSceneCookiesProvider/constant.test.ts
@@ -1,0 +1,98 @@
+/** @jest-environment jsdom */
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import {
+  AUTH_STATUS_COOKIE_MAX_AGE_SECONDS,
+  getCookieSetOptions,
+  getLegacyAuthStatusCookieCleanupOptions,
+} from "./constant";
+
+const defaultDomainConfig = {
+  env: "saas",
+  logo: "coscene",
+  authStatusCookieName: "coSceneAuthStatus",
+  authStatusCookieDomain: "coscene.cn",
+  webDomain: "coscene.cn",
+  ssoDomain: "sso.coscene.cn",
+};
+
+const volcDomainConfig = {
+  env: "volc",
+  logo: "coscene",
+  authStatusCookieName: "coSceneVolcAuthStatus",
+  authStatusCookieDomain: "volc.coscene.cn",
+  webDomain: "volc.coscene.cn",
+  ssoDomain: "volc.sso.coscene.cn",
+};
+
+describe("CoScene auth status cookie options", () => {
+  afterEach(() => {
+    window.cosConfig = undefined;
+    window.cosConfigRemoteHostname = undefined;
+  });
+
+  it("uses the configured auth status cookie domain instead of the parent domain fallback", () => {
+    window.cosConfig = {
+      DOMAIN_CONFIG: {
+        default: defaultDomainConfig,
+        "volc.coscene.cn": volcDomainConfig,
+      },
+    };
+    window.cosConfigRemoteHostname = "volc.coscene.cn";
+
+    expect(getCookieSetOptions()).toEqual({
+      path: "/",
+      domain: "volc.coscene.cn",
+      secure: true,
+      sameSite: "none",
+      maxAge: AUTH_STATUS_COOKIE_MAX_AGE_SECONDS,
+    });
+  });
+
+  it("expires the legacy parent-domain auth status cookie when configured domain differs", () => {
+    window.cosConfig = {
+      DOMAIN_CONFIG: {
+        default: defaultDomainConfig,
+        "volc.coscene.cn": volcDomainConfig,
+      },
+    };
+    window.cosConfigRemoteHostname = "volc.coscene.cn";
+
+    expect(getLegacyAuthStatusCookieCleanupOptions("volc.coscene.cn")).toEqual({
+      name: "coSceneVolcAuthStatus",
+      path: "/",
+      domain: "coscene.cn",
+      secure: true,
+      sameSite: "none",
+      maxAge: 0,
+    });
+  });
+
+  it("does not expire a parent-domain cookie when it is also the configured domain", () => {
+    window.cosConfig = {
+      DOMAIN_CONFIG: {
+        default: defaultDomainConfig,
+      },
+    };
+
+    expect(getLegacyAuthStatusCookieCleanupOptions("www.coscene.cn")).toBeUndefined();
+  });
+
+  it("does not produce a legacy cleanup domain for local hostnames", () => {
+    window.cosConfig = {
+      DOMAIN_CONFIG: {
+        default: {
+          ...defaultDomainConfig,
+          authStatusCookieDomain: "localhost",
+        },
+      },
+    };
+
+    expect(getLegacyAuthStatusCookieCleanupOptions("127.0.0.1")).toBeUndefined();
+  });
+});

--- a/packages/studio-base/src/providers/CoSceneCookiesProvider/constant.ts
+++ b/packages/studio-base/src/providers/CoSceneCookiesProvider/constant.ts
@@ -80,7 +80,10 @@ export function getLegacyAuthStatusCookieCleanupOptions(
 
   const normalizedFallbackParentDomain = normalizeCookieDomain(fallbackParentDomain);
 
-  if (normalizedFallbackParentDomain.length === 0 || configuredDomain === normalizedFallbackParentDomain) {
+  if (
+    normalizedFallbackParentDomain.length === 0 ||
+    configuredDomain === normalizedFallbackParentDomain
+  ) {
     return undefined;
   }
 

--- a/packages/studio-base/src/providers/CoSceneCookiesProvider/constant.ts
+++ b/packages/studio-base/src/providers/CoSceneCookiesProvider/constant.ts
@@ -5,14 +5,114 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { getDomainConfig } from "@foxglove/studio-base/util/appConfig";
+
 export enum AuthStatus {
   LOGGED_IN = "LOGGED_IN",
   SIGN_OUT = "SIGN_OUT",
 }
 
-export const cookieSetOptions = {
-  path: "/",
-  domain: window.location.hostname.split(".").slice(-2).join("."),
-  secure: true,
-  sameSite: "none" as boolean | "none" | "lax" | "strict" | undefined,
+export const AUTH_STATUS_COOKIE_MAX_AGE_SECONDS = 1800;
+
+type AuthStatusCookieOptions = {
+  path: "/";
+  domain: string;
+  secure: true;
+  sameSite: "none";
+  maxAge: number;
 };
+
+type LegacyAuthStatusCookieCleanupOptions = AuthStatusCookieOptions & {
+  name: string;
+  maxAge: 0;
+};
+
+const sameSite = "none";
+
+function isLocalHostname(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+}
+
+export function getFallbackParentCookieDomain(hostname = getCurrentHostname()): string | undefined {
+  if (!hostname || isLocalHostname(hostname)) {
+    return undefined;
+  }
+
+  const parts = hostname.split(".");
+
+  if (parts.length < 2) {
+    return undefined;
+  }
+
+  return parts.slice(-2).join(".");
+}
+
+function getCurrentHostname(): string {
+  return typeof window !== "undefined" ? window.location.hostname : "";
+}
+
+function normalizeCookieDomain(domain: string): string {
+  return domain.trim().replace(/^\./, "").toLowerCase();
+}
+
+export function getCookieSetOptions(): AuthStatusCookieOptions {
+  const domainConfig = getDomainConfig();
+
+  return {
+    path: "/",
+    domain: normalizeCookieDomain(domainConfig.authStatusCookieDomain),
+    secure: true,
+    sameSite,
+    maxAge: AUTH_STATUS_COOKIE_MAX_AGE_SECONDS,
+  };
+}
+
+export function getLegacyAuthStatusCookieCleanupOptions(
+  hostname = getCurrentHostname(),
+): LegacyAuthStatusCookieCleanupOptions | undefined {
+  const domainConfig = getDomainConfig();
+  const configuredDomain = normalizeCookieDomain(domainConfig.authStatusCookieDomain);
+  const fallbackParentDomain = getFallbackParentCookieDomain(hostname);
+
+  if (configuredDomain.length === 0 || fallbackParentDomain == undefined) {
+    return undefined;
+  }
+
+  const normalizedFallbackParentDomain = normalizeCookieDomain(fallbackParentDomain);
+
+  if (normalizedFallbackParentDomain.length === 0 || configuredDomain === normalizedFallbackParentDomain) {
+    return undefined;
+  }
+
+  return {
+    name: domainConfig.authStatusCookieName,
+    path: "/",
+    domain: normalizedFallbackParentDomain,
+    secure: true,
+    sameSite,
+    maxAge: 0,
+  };
+}
+
+export function cleanupLegacyAuthStatusCookie(): void {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const cleanupOptions = getLegacyAuthStatusCookieCleanupOptions();
+
+  if (!cleanupOptions) {
+    return;
+  }
+
+  document.cookie = [
+    `${cleanupOptions.name}=`,
+    `Max-Age=${cleanupOptions.maxAge}`,
+    `path=${cleanupOptions.path}`,
+    `domain=${cleanupOptions.domain}`,
+    `SameSite=${cleanupOptions.sameSite}`,
+    "Secure",
+  ]
+    .filter(Boolean)
+    .join("; ");
+}

--- a/packages/studio-base/src/providers/CoSceneCookiesProvider/index.tsx
+++ b/packages/studio-base/src/providers/CoSceneCookiesProvider/index.tsx
@@ -5,19 +5,24 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { useEffect } from "react";
 import { CookiesProvider } from "react-cookie";
 
 import { AuthSignOutListener } from "@foxglove/studio-base/providers/CoSceneCookiesProvider/AuthSignOutListener";
 
-import { cookieSetOptions } from "./constant";
+import { cleanupLegacyAuthStatusCookie, getCookieSetOptions } from "./constant";
 
 export default function CoSceneCookiesProvider({
   children,
 }: {
   children?: React.PropsWithChildren;
 }): React.JSX.Element {
+  useEffect(() => {
+    cleanupLegacyAuthStatusCookie();
+  }, []);
+
   return (
-    <CookiesProvider defaultSetOptions={cookieSetOptions}>
+    <CookiesProvider defaultSetOptions={getCookieSetOptions()}>
       <AuthSignOutListener />
       {children}
     </CookiesProvider>


### PR DESCRIPTION
## Summary

- Use configured `authStatusCookieDomain` for honeybee auth status cookies and set `Max-Age=1800`.
- Expire legacy same-name parent-domain auth status cookies on provider mount.
- Ignore stale or malformed `SIGN_OUT` cookie values by requiring `updatedAt >= mountedAt` before redirecting.

## Root Cause

A parent-domain auth status cookie with the same name can coexist with the correct environment-domain cookie. If the parent-domain cookie contains an old `SIGN_OUT`, honeybee could previously redirect from `/viz` immediately because it only checked the cookie status.

## Validation

- `yarn jest --config packages/studio-base/jest.config.json src/providers/CoSceneCookiesProvider/constant.test.ts src/providers/CoSceneCookiesProvider/AuthSignOutListener.test.tsx --runInBand` (`2` suites / `8` tests passed)
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint packages/studio-base/src/providers/CoSceneCookiesProvider/constant.ts packages/studio-base/src/providers/CoSceneCookiesProvider/constant.test.ts packages/studio-base/src/providers/CoSceneCookiesProvider/index.tsx packages/studio-base/src/providers/CoSceneCookiesProvider/AuthSignOutListener.tsx packages/studio-base/src/providers/CoSceneCookiesProvider/AuthSignOutListener.test.tsx`
- `git diff --check`