### PR TITLE
Add playback interaction state and wait handling across Studio UI

### DIFF
--- a/packages/studio-base/src/StudioApp.tsx
+++ b/packages/studio-base/src/StudioApp.tsx
@@ -13,8 +13,8 @@ import { DialogsStore, useDialogs } from "@foxglove/studio-base/context/DialogsC
 import { useSharedRootContext } from "@foxglove/studio-base/context/SharedRootContext";
 import { UserScriptStateProvider } from "@foxglove/studio-base/context/UserScriptStateContext";
 import EventsProvider from "@foxglove/studio-base/providers/EventsProvider";
-import ProblemsContextProvider from "@foxglove/studio-base/providers/ProblemsContextProvider";
 import PlaybackInteractionStateProvider from "@foxglove/studio-base/providers/PlaybackInteractionStateProvider";
+import ProblemsContextProvider from "@foxglove/studio-base/providers/ProblemsContextProvider";
 import { StudioLogsSettingsProvider } from "@foxglove/studio-base/providers/StudioLogsSettingsProvider";
 import SubscriptionEntitlementProvider from "@foxglove/studio-base/providers/SubscriptionEntitlementProvider";
 import TasksProvider from "@foxglove/studio-base/providers/TasksProvider";

--- a/packages/studio-base/src/StudioApp.tsx
+++ b/packages/studio-base/src/StudioApp.tsx
@@ -14,6 +14,7 @@ import { useSharedRootContext } from "@foxglove/studio-base/context/SharedRootCo
 import { UserScriptStateProvider } from "@foxglove/studio-base/context/UserScriptStateContext";
 import EventsProvider from "@foxglove/studio-base/providers/EventsProvider";
 import ProblemsContextProvider from "@foxglove/studio-base/providers/ProblemsContextProvider";
+import PlaybackInteractionStateProvider from "@foxglove/studio-base/providers/PlaybackInteractionStateProvider";
 import { StudioLogsSettingsProvider } from "@foxglove/studio-base/providers/StudioLogsSettingsProvider";
 import SubscriptionEntitlementProvider from "@foxglove/studio-base/providers/SubscriptionEntitlementProvider";
 import TasksProvider from "@foxglove/studio-base/providers/TasksProvider";
@@ -62,6 +63,7 @@ export function StudioApp(): React.JSX.Element {
 
   const providers = [
     /* eslint-disable react/jsx-key */
+    <PlaybackInteractionStateProvider />,
     <TimelineInteractionStateProvider />,
     <UserScriptStateProvider />,
     <ExtensionMarketplaceProvider />,

--- a/packages/studio-base/src/components/AppBar/AppStateBar.tsx
+++ b/packages/studio-base/src/components/AppBar/AppStateBar.tsx
@@ -28,6 +28,10 @@ import {
   BagFileInfo,
 } from "@foxglove/studio-base/context/CoScenePlaylistContext";
 import { CoreDataStore, useCoreData } from "@foxglove/studio-base/context/CoreDataContext";
+import {
+  selectIsKeyframeSearchActive,
+  usePlaybackInteractionState,
+} from "@foxglove/studio-base/context/PlaybackInteractionStateContext";
 import { usePlayerSelection } from "@foxglove/studio-base/context/PlayerSelectionContext";
 import { useAppConfigurationValue } from "@foxglove/studio-base/hooks/useAppConfigurationValue";
 import { useConfirm } from "@foxglove/studio-base/hooks/useConfirm";
@@ -76,6 +80,7 @@ export function AppStateBar(): React.JSX.Element {
   const { classes, theme } = useStyles();
   const { t } = useTranslation("appBar");
   const presence = useMessagePipeline(selectPresence);
+  const isKeyframeSearchActive = usePlaybackInteractionState(selectIsKeyframeSearchActive);
   const confirm = useConfirm();
   const [timeoutMinutes] = useAppConfigurationValue<number>(AppSetting.TIMEOUT);
   const dataSource = useCoreData(selectDataSource);
@@ -143,7 +148,10 @@ export function AppStateBar(): React.JSX.Element {
     normalBagFileCount + generatedMediaCount + errorMediaCount === bagFileCount &&
     errorMediaCount > 0;
 
-  const loading = presence === PlayerPresence.INITIALIZING || presence === PlayerPresence.BUFFERING;
+  const loading =
+    presence === PlayerPresence.INITIALIZING ||
+    presence === PlayerPresence.BUFFERING ||
+    isKeyframeSearchActive;
 
   useEffect(() => {
     if (presence === PlayerPresence.INITIALIZING) {

--- a/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
@@ -44,6 +44,10 @@ import {
   useHoverValue,
   useSetHoverValue,
 } from "@foxglove/studio-base/context/TimelineInteractionStateContext";
+import {
+  PlaybackInteractionStateStore,
+  usePlaybackInteractionState,
+} from "@foxglove/studio-base/context/PlaybackInteractionStateContext";
 import useGlobalVariables from "@foxglove/studio-base/hooks/useGlobalVariables";
 import {
   AdvertiseOptions,
@@ -108,6 +112,9 @@ function selectContext(ctx: MessagePipelineContext) {
 function selectInstalledMessageConverters(state: ExtensionCatalog) {
   return state.installedMessageConverters;
 }
+
+const selectAcquireKeyframeSearchLock = (store: PlaybackInteractionStateStore) =>
+  store.acquireKeyframeSearchLock;
 
 type RenderFn = NonNullable<PanelExtensionContext["onRender"]>;
 /**
@@ -178,6 +185,7 @@ function PanelExtensionAdapter(
   //
   // This getter allows the extension context to remain stable through pipeline changes
   const getMessagePipelineContext = useMessagePipelineGetter();
+  const acquireKeyframeSearchLock = usePlaybackInteractionState(selectAcquireKeyframeSearchLock);
 
   // initRenderStateBuilder render produces a function which computes the latest render state from a set of inputs
   // Spiritually its like a reducer
@@ -396,6 +404,25 @@ function PanelExtensionAdapter(
           }
         : undefined,
 
+      unstable_getPlaybackIsPlaying: () =>
+        getMessagePipelineContext().playerState.activeData?.isPlaying === true,
+
+      unstable_acquireKeyframeSearchLock: acquireKeyframeSearchLock,
+
+      unstable_pausePlayback: () => {
+        if (!isMounted()) {
+          return;
+        }
+        getMessagePipelineContext().pausePlayback?.();
+      },
+
+      unstable_startPlayback: () => {
+        if (!isMounted()) {
+          return;
+        }
+        getMessagePipelineContext().startPlayback?.();
+      },
+
       dataSourceProfile,
 
       setParameter: (name: string, value: ParameterValue) => {
@@ -600,6 +627,7 @@ function PanelExtensionAdapter(
     saveConfig,
     stableSettingsActionHandler,
     getMessagePipelineContext,
+    acquireKeyframeSearchLock,
     setGlobalVariables,
     clearHoverValue,
     setHoverValue,

--- a/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/PanelExtensionAdapter.tsx
@@ -40,14 +40,14 @@ import {
   useExtensionCatalog,
 } from "@foxglove/studio-base/context/ExtensionCatalogContext";
 import {
+  PlaybackInteractionStateStore,
+  usePlaybackInteractionState,
+} from "@foxglove/studio-base/context/PlaybackInteractionStateContext";
+import {
   useClearHoverValue,
   useHoverValue,
   useSetHoverValue,
 } from "@foxglove/studio-base/context/TimelineInteractionStateContext";
-import {
-  PlaybackInteractionStateStore,
-  usePlaybackInteractionState,
-} from "@foxglove/studio-base/context/PlaybackInteractionStateContext";
 import useGlobalVariables from "@foxglove/studio-base/hooks/useGlobalVariables";
 import {
   AdvertiseOptions,

--- a/packages/studio-base/src/components/PanelExtensionAdapter/types.ts
+++ b/packages/studio-base/src/components/PanelExtensionAdapter/types.ts
@@ -6,6 +6,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { PanelExtensionContext } from "@foxglove/studio";
+import { AcquireKeyframeSearchLockArgs } from "@foxglove/studio-base/context/PlaybackInteractionStateContext";
 import { SubscribeMessageRange } from "@foxglove/studio-base/players/types";
 
 /**
@@ -83,6 +84,15 @@ export type BuiltinPanelExtensionContext = {
   ) => Promise<Asset>;
 
   unstable_subscribeMessageRange?: SubscribeMessageRange;
+
+  /**
+   * Built-in panels may need to coordinate async work with global playback controls.
+   * These remain internal because third-party panels should not control global playback directly.
+   */
+  unstable_acquireKeyframeSearchLock?: (args?: AcquireKeyframeSearchLockArgs) => () => void;
+  unstable_getPlaybackIsPlaying?: () => boolean;
+  unstable_pausePlayback?: () => void;
+  unstable_startPlayback?: () => void;
 
   /**
    * Updates the configuration for message path drag & drop support. A value of `undefined`

--- a/packages/studio-base/src/components/PlaybackControls/Scrubber.test.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Scrubber.test.tsx
@@ -14,10 +14,12 @@ import MockMessagePipelineProvider from "@foxglove/studio-base/components/Messag
 import AppConfigurationContext from "@foxglove/studio-base/context/AppConfigurationContext";
 import CoSceneConsoleApiContext from "@foxglove/studio-base/context/CoSceneConsoleApiContext";
 import { type CoreDataStore, useCoreData } from "@foxglove/studio-base/context/CoreDataContext";
+import { usePlaybackInteractionState } from "@foxglove/studio-base/context/PlaybackInteractionStateContext";
 import { useWorkspaceStore } from "@foxglove/studio-base/context/Workspace/WorkspaceContext";
 import CoScenePlaylistProvider from "@foxglove/studio-base/providers/CoScenePlaylistProvider";
 import CoreDataProvider from "@foxglove/studio-base/providers/CoreDataProvider";
 import EventsProvider from "@foxglove/studio-base/providers/EventsProvider";
+import PlaybackInteractionStateProvider from "@foxglove/studio-base/providers/PlaybackInteractionStateProvider";
 import TimelineInteractionStateProvider from "@foxglove/studio-base/providers/TimelineInteractionStateProvider";
 import WorkspaceContextProvider from "@foxglove/studio-base/providers/WorkspaceContextProvider";
 import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
@@ -38,15 +40,15 @@ jest.mock("./PlaybackBarHoverTicks", () => ({
 }));
 
 jest.mock("./ProgressPlot", () => ({
-  ProgressPlot: function MockProgressPlot(): React.JSX.Element {
-    return <div data-testid="progress-plot" />;
+  ProgressPlot: function MockProgressPlot({ loading }: { loading: boolean }): React.JSX.Element {
+    return <div data-testid={loading ? "timeline-progress-loading" : "progress-plot"} />;
   },
 }));
 
 jest.mock("./Slider", () => ({
   __esModule: true,
-  default: function MockSlider(): React.JSX.Element {
-    return <div data-testid="scrubber-slider" />;
+  default: function MockSlider({ disabled }: { disabled?: boolean }): React.JSX.Element {
+    return <div data-testid="scrubber-slider" data-disabled={String(disabled)} />;
   },
 }));
 
@@ -72,6 +74,18 @@ function MomentSubtitleStateProbe(): React.JSX.Element {
   return <div data-testid="moment-subtitle-enabled">{String(enabled)}</div>;
 }
 
+function KeyframeSearchLock(): ReactNull {
+  const acquireKeyframeSearchLock = usePlaybackInteractionState(
+    (store) => store.acquireKeyframeSearchLock,
+  );
+
+  useEffect(() => {
+    return acquireKeyframeSearchLock({ isPlaying: false });
+  }, [acquireKeyframeSearchLock]);
+
+  return ReactNull;
+}
+
 function Wrapper({
   children,
   eventEnabled = false,
@@ -94,15 +108,17 @@ function Wrapper({
                 endTime={{ sec: 10, nsec: 0 }}
                 currentTime={{ sec: 1, nsec: 0 }}
               >
-                <TimelineInteractionStateProvider>
-                  <CoScenePlaylistProvider>
-                    <EventsProvider>
-                      <SeedEventFeature enabled={eventEnabled} />
-                      {children}
-                      <MomentSubtitleStateProbe />
-                    </EventsProvider>
-                  </CoScenePlaylistProvider>
-                </TimelineInteractionStateProvider>
+                <PlaybackInteractionStateProvider>
+                  <TimelineInteractionStateProvider>
+                    <CoScenePlaylistProvider>
+                      <EventsProvider>
+                        <SeedEventFeature enabled={eventEnabled} />
+                        {children}
+                        <MomentSubtitleStateProbe />
+                      </EventsProvider>
+                    </CoScenePlaylistProvider>
+                  </TimelineInteractionStateProvider>
+                </PlaybackInteractionStateProvider>
               </MockMessagePipelineProvider>
             </WorkspaceContextProvider>
           </CoreDataProvider>
@@ -129,6 +145,28 @@ describe("<Scrubber />", () => {
     );
 
     expect(eventLaneLayerTop).toBeGreaterThanOrEqual(28);
+  });
+
+  it("shows timeline loading while keyframe search is active", () => {
+    render(
+      <Wrapper>
+        <KeyframeSearchLock />
+        <Scrubber onSeek={jest.fn()} />
+      </Wrapper>,
+    );
+
+    expect(screen.getByTestId("timeline-progress-loading")).toBeTruthy();
+  });
+
+  it("disables the timeline slider while keyframe search is active", () => {
+    render(
+      <Wrapper>
+        <KeyframeSearchLock />
+        <Scrubber onSeek={jest.fn()} />
+      </Wrapper>,
+    );
+
+    expect(screen.getByTestId("scrubber-slider").dataset.disabled).toBe("true");
   });
 
   it("renders and toggles the moment subtitle button when events are enabled", async () => {

--- a/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
@@ -37,6 +37,10 @@ import { useConsoleApi } from "@foxglove/studio-base/context/CoSceneConsoleApiCo
 import { CoreDataStore, useCoreData } from "@foxglove/studio-base/context/CoreDataContext";
 import { type EventsStore, useEvents } from "@foxglove/studio-base/context/EventsContext";
 import {
+  selectIsKeyframeSearchActive,
+  usePlaybackInteractionState,
+} from "@foxglove/studio-base/context/PlaybackInteractionStateContext";
+import {
   useClearHoverValue,
   useSetHoverValue,
 } from "@foxglove/studio-base/context/TimelineInteractionStateContext";
@@ -400,8 +404,12 @@ export default function Scrubber(props: Props): React.JSX.Element {
   const min = useMemo(() => startTime && toSec(startTime), [startTime]);
   const max = useMemo(() => endTime && toSec(endTime), [endTime]);
 
-  const loading = presence === PlayerPresence.INITIALIZING || presence === PlayerPresence.BUFFERING;
-  const disableControls = presence === PlayerPresence.ERROR;
+  const isKeyframeSearchActive = usePlaybackInteractionState(selectIsKeyframeSearchActive);
+  const loading =
+    presence === PlayerPresence.INITIALIZING ||
+    presence === PlayerPresence.BUFFERING ||
+    isKeyframeSearchActive;
+  const disableControls = presence === PlayerPresence.ERROR || isKeyframeSearchActive;
 
   const popperRef = React.useRef<Instance>(ReactNull);
 
@@ -746,7 +754,7 @@ export default function Scrubber(props: Props): React.JSX.Element {
             <Stack fullHeight fullWidth position="absolute" flex={1}>
               {resolvedViewport && (
                 <Slider
-                  disabled={min == undefined || max == undefined}
+                  disabled={disableControls || min == undefined || max == undefined}
                   onContextMenu={onContextMenu}
                   onHoverOver={onHoverOver}
                   onHoverOut={onHoverOut}

--- a/packages/studio-base/src/components/PlaybackControls/index.test.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.test.tsx
@@ -7,12 +7,15 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { act, fireEvent, render, screen } from "@testing-library/react";
+import { useEffect } from "react";
 
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
 import AppConfigurationContext from "@foxglove/studio-base/context/AppConfigurationContext";
 import CoSceneConsoleApiContext from "@foxglove/studio-base/context/CoSceneConsoleApiContext";
+import { usePlaybackInteractionState } from "@foxglove/studio-base/context/PlaybackInteractionStateContext";
 import { useWorkspaceStore } from "@foxglove/studio-base/context/Workspace/WorkspaceContext";
 import CoreDataProvider from "@foxglove/studio-base/providers/CoreDataProvider";
+import PlaybackInteractionStateProvider from "@foxglove/studio-base/providers/PlaybackInteractionStateProvider";
 import WorkspaceContextProvider from "@foxglove/studio-base/providers/WorkspaceContextProvider";
 import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
 import { makeMockAppConfiguration } from "@foxglove/studio-base/util/makeMockAppConfiguration";
@@ -50,6 +53,18 @@ function TimelineHeightObserver(): React.JSX.Element {
   return <div data-testid="timeline-height">{timelineHeight}</div>;
 }
 
+function KeyframeSearchLock(): ReactNull {
+  const acquireKeyframeSearchLock = usePlaybackInteractionState(
+    (store) => store.acquireKeyframeSearchLock,
+  );
+
+  useEffect(() => {
+    return acquireKeyframeSearchLock({ isPlaying: false });
+  }, [acquireKeyframeSearchLock]);
+
+  return ReactNull;
+}
+
 function Wrapper({ children }: React.PropsWithChildren): React.JSX.Element {
   return (
     <ThemeProvider isDark>
@@ -68,11 +83,13 @@ function Wrapper({ children }: React.PropsWithChildren): React.JSX.Element {
               disablePersistenceForStorybook
               initialState={{ playbackControls: { repeat: false, speed: 1 } }}
             >
-              <MockMessagePipelineProvider>
-                {children}
-                <SpeedObserver />
-                <TimelineHeightObserver />
-              </MockMessagePipelineProvider>
+              <PlaybackInteractionStateProvider>
+                <MockMessagePipelineProvider>
+                  {children}
+                  <SpeedObserver />
+                  <TimelineHeightObserver />
+                </MockMessagePipelineProvider>
+              </PlaybackInteractionStateProvider>
             </WorkspaceContextProvider>
           </CoreDataProvider>
         </CoSceneConsoleApiContext.Provider>
@@ -159,6 +176,90 @@ describe("<PlaybackControls />", () => {
       );
     });
 
+    expect(screen.getByTestId("playback-speed").textContent).toBe("1");
+  });
+
+  it("disables play controls and ignores spacebar playback while keyframe search is active", () => {
+    const play = jest.fn();
+    const { container } = render(
+      <Wrapper>
+        <KeyframeSearchLock />
+        <PlaybackControls
+          isPlaying={false}
+          repeatEnabled={false}
+          getTimeInfo={() => ({})}
+          play={play}
+          pause={jest.fn()}
+          seek={jest.fn()}
+          enableRepeatPlayback={jest.fn()}
+        />
+      </Wrapper>,
+    );
+
+    expect(container.querySelector<HTMLButtonElement>("#play-pause-button")?.disabled).toBe(true);
+    jest.mocked(console.warn).mockClear();
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          bubbles: true,
+          code: "Space",
+          key: " ",
+        }),
+      );
+    });
+
+    expect(play).not.toHaveBeenCalled();
+  });
+
+  it("ignores seek and speed keyboard shortcuts while keyframe search is active", () => {
+    const seek = jest.fn();
+    render(
+      <Wrapper>
+        <KeyframeSearchLock />
+        <PlaybackControls
+          isPlaying={false}
+          repeatEnabled={false}
+          getTimeInfo={() => ({
+            startTime: { sec: 0, nsec: 0 },
+            endTime: { sec: 10, nsec: 0 },
+            currentTime: { sec: 1, nsec: 0 },
+          })}
+          play={jest.fn()}
+          pause={jest.fn()}
+          seek={seek}
+          enableRepeatPlayback={jest.fn()}
+        />
+      </Wrapper>,
+    );
+    jest.mocked(console.warn).mockClear();
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          bubbles: true,
+          code: "ArrowRight",
+          key: "ArrowRight",
+        }),
+      );
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          bubbles: true,
+          code: "ArrowLeft",
+          key: "ArrowLeft",
+        }),
+      );
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          bubbles: true,
+          code: "Equal",
+          key: "+",
+          shiftKey: true,
+        }),
+      );
+    });
+
+    expect(seek).not.toHaveBeenCalled();
     expect(screen.getByTestId("playback-speed").textContent).toBe("1");
   });
 

--- a/packages/studio-base/src/components/PlaybackControls/index.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.tsx
@@ -45,6 +45,10 @@ import PlaybackSpeedControls from "@foxglove/studio-base/components/PlaybackSpee
 import Stack from "@foxglove/studio-base/components/Stack";
 import { stepPlaybackSpeed } from "@foxglove/studio-base/components/playbackSpeed";
 import { CoreDataStore, useCoreData } from "@foxglove/studio-base/context/CoreDataContext";
+import {
+  selectIsKeyframeSearchActive,
+  usePlaybackInteractionState,
+} from "@foxglove/studio-base/context/PlaybackInteractionStateContext";
 import { usePlayerSelection } from "@foxglove/studio-base/context/PlayerSelectionContext";
 import {
   WorkspaceContextStore,
@@ -165,6 +169,7 @@ export default function PlaybackControls(props: {
   } = props;
   const presence = useMessagePipeline(selectPresence);
   const urlState = useMessagePipeline(selectUrlState);
+  const isKeyframeSearchActive = usePlaybackInteractionState(selectIsKeyframeSearchActive);
 
   const dataSource = useCoreData(selectDataSource);
   const { selectRecent } = usePlayerSelection();
@@ -201,6 +206,10 @@ export default function PlaybackControls(props: {
   }, [repeat, repeatEnabled, enableRepeatPlayback]);
 
   const togglePlayPause = useCallback(() => {
+    if (isKeyframeSearchActive) {
+      return;
+    }
+
     if (isPlaying) {
       pause();
     } else {
@@ -211,7 +220,7 @@ export default function PlaybackControls(props: {
       }
       play();
     }
-  }, [isPlaying, pause, getTimeInfo, play, seek]);
+  }, [isKeyframeSearchActive, isPlaying, pause, getTimeInfo, play, seek]);
 
   // Track SeekStep editing state for KeyListener management
   const [seekStepEditing, setSeekStepEditing] = useState(false);
@@ -225,6 +234,10 @@ export default function PlaybackControls(props: {
 
   const seekForwardAction = useCallback(
     (ev?: KeyboardEvent) => {
+      if (isKeyframeSearchActive) {
+        return;
+      }
+
       const { currentTime, startTime: start, endTime: end } = getTimeInfo();
       if (!currentTime || !start || !end) {
         return;
@@ -252,25 +265,33 @@ export default function PlaybackControls(props: {
         seek(clampedTargetTime);
       }
     },
-    [getTimeInfo, playUntil, seek, effectiveSeekMs],
+    [isKeyframeSearchActive, getTimeInfo, playUntil, seek, effectiveSeekMs],
   );
 
   const seekBackwardAction = useCallback(
     (ev?: KeyboardEvent) => {
+      if (isKeyframeSearchActive) {
+        return;
+      }
+
       const { currentTime } = getTimeInfo();
       if (!currentTime) {
         return;
       }
       seek(jumpSeek(DIRECTION.BACKWARD, currentTime, ev, effectiveSeekMs));
     },
-    [getTimeInfo, seek, effectiveSeekMs],
+    [isKeyframeSearchActive, getTimeInfo, seek, effectiveSeekMs],
   );
 
   const adjustPlaybackSpeed = useCallback(
     (direction: "decrease" | "increase") => {
+      if (isKeyframeSearchActive) {
+        return;
+      }
+
       setSpeed(stepPlaybackSpeed(playbackSpeed, direction));
     },
-    [playbackSpeed, setSpeed],
+    [isKeyframeSearchActive, playbackSpeed, setSpeed],
   );
 
   const startTimelineResize = useCallback(
@@ -351,7 +372,7 @@ export default function PlaybackControls(props: {
     ],
   );
 
-  const disableControls = presence === PlayerPresence.ERROR;
+  const disableControls = presence === PlayerPresence.ERROR || isKeyframeSearchActive;
 
   return (
     <>

--- a/packages/studio-base/src/context/PlaybackInteractionStateContext.tsx
+++ b/packages/studio-base/src/context/PlaybackInteractionStateContext.tsx
@@ -36,6 +36,7 @@ export const selectIsKeyframeSearchActive = (store: PlaybackInteractionStateStor
 export function usePlaybackInteractionState<T>(
   selector: (store: PlaybackInteractionStateStore) => T,
 ): T {
-  const context = useContext(PlaybackInteractionStateContext) ?? defaultPlaybackInteractionStateStore;
+  const context =
+    useContext(PlaybackInteractionStateContext) ?? defaultPlaybackInteractionStateStore;
   return useStore(context, selector);
 }

--- a/packages/studio-base/src/context/PlaybackInteractionStateContext.tsx
+++ b/packages/studio-base/src/context/PlaybackInteractionStateContext.tsx
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { createContext, useContext } from "react";
+import { createStore, StoreApi, useStore } from "zustand";
+
+import { Immutable } from "@foxglove/studio";
+
+export type AcquireKeyframeSearchLockArgs = {
+  isPlaying?: boolean;
+  pausePlayback?: (() => void) | undefined;
+  startPlayback?: (() => void) | undefined;
+};
+
+export type PlaybackInteractionStateStore = Immutable<{
+  keyframeSearchLockCount: number;
+  acquireKeyframeSearchLock: (args?: AcquireKeyframeSearchLockArgs) => () => void;
+}>;
+
+export const PlaybackInteractionStateContext = createContext<
+  undefined | StoreApi<PlaybackInteractionStateStore>
+>(undefined);
+
+const defaultPlaybackInteractionStateStore = createStore<PlaybackInteractionStateStore>(() => ({
+  keyframeSearchLockCount: 0,
+  acquireKeyframeSearchLock: () => () => {},
+}));
+
+export const selectIsKeyframeSearchActive = (store: PlaybackInteractionStateStore): boolean =>
+  store.keyframeSearchLockCount > 0;
+
+export function usePlaybackInteractionState<T>(
+  selector: (store: PlaybackInteractionStateStore) => T,
+): T {
+  const context = useContext(PlaybackInteractionStateContext) ?? defaultPlaybackInteractionStateStore;
+  return useStore(context, selector);
+}

--- a/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/IRenderer.ts
@@ -190,6 +190,9 @@ export type RendererSubscription<T = unknown> = {
   filterQueue?: (queue: MessageEvent<T>[]) => MessageEvent<T>[];
 };
 
+export type ReleaseSeekKeyframeSearchPlaybackPause = () => void;
+export type AcquireSeekKeyframeSearchPlaybackPause = () => ReleaseSeekKeyframeSearchPlaybackPause;
+
 export type AnyRendererSubscription = Immutable<
   | {
       type: "schema";
@@ -260,6 +263,7 @@ export interface IRenderer extends EventEmitter<RendererEvents> {
   currentTime: bigint;
   startTime: bigint | undefined;
   subscribeMessageRange: SubscribeMessageRange | undefined;
+  acquireSeekKeyframeSearchPlaybackPause?: AcquireSeekKeyframeSearchPlaybackPause;
   /** Coordinate frame that transforms are applied through to the follow frame. Should be unchanging. */
   fixedFrameId: string | undefined;
   /**

--- a/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/Renderer.ts
@@ -237,6 +237,7 @@ export class Renderer extends EventEmitter<RendererEvents> implements IRenderer 
   public currentTime = 0n;
   public startTime: bigint | undefined;
   public subscribeMessageRange: SubscribeMessageRange | undefined;
+  public acquireSeekKeyframeSearchPlaybackPause?: IRenderer["acquireSeekKeyframeSearchPlaybackPause"];
   public fixedFrameId: string | undefined;
   public followFrameId: string | undefined;
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -542,6 +542,31 @@ export function ThreeDeeRender(props: {
     }
   }, [renderer, subscribeMessageRange]);
 
+  const acquireSeekKeyframeSearchPlaybackPause = useCallback(() => {
+    return (
+      context.unstable_acquireKeyframeSearchLock?.({
+        isPlaying: context.unstable_getPlaybackIsPlaying?.() ?? false,
+        pausePlayback: context.unstable_pausePlayback,
+        startPlayback: context.unstable_startPlayback,
+      }) ?? (() => {})
+    );
+  }, [context]);
+
+  useEffect(() => {
+    if (!renderer) {
+      return;
+    }
+
+    renderer.acquireSeekKeyframeSearchPlaybackPause = acquireSeekKeyframeSearchPlaybackPause;
+    return () => {
+      if (
+        renderer.acquireSeekKeyframeSearchPlaybackPause === acquireSeekKeyframeSearchPlaybackPause
+      ) {
+        renderer.acquireSeekKeyframeSearchPlaybackPause = undefined;
+      }
+    };
+  }, [acquireSeekKeyframeSearchPlaybackPause, renderer]);
+
   // Keep the renderer currentTime up to date and handle seeking
   useEffect(() => {
     const newTimeNs = currentTime ? toNanoSec(currentTime) : undefined;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.test.ts
@@ -61,12 +61,14 @@ function makeRenderer(
     currentTime?: bigint;
     startTime?: bigint;
     subscribeMessageRange?: SubscribeMessageRange;
+    acquireSeekKeyframeSearchPlaybackPause?: () => () => void;
   } = {},
 ) {
   return {
     currentTime: options.currentTime ?? 0n,
     startTime: options.startTime ?? 0n,
     subscribeMessageRange: options.subscribeMessageRange,
+    acquireSeekKeyframeSearchPlaybackPause: options.acquireSeekKeyframeSearchPlaybackPause,
     queueAnimationFrame: jest.fn(),
   };
 }
@@ -501,11 +503,46 @@ describe("CompressedVideoController", () => {
     ]);
   });
 
+  it("acquires a playback pause lock while a seek lookback is searching for a keyframe", async () => {
+    const keyframe = makeVideoMessage(0n, "key");
+    const delta = makeVideoMessage(10_000_000n, "delta");
+    const displayFrames = makeSuccessfulDisplayFrames();
+    const releasePlaybackPause = jest.fn();
+    const acquireSeekKeyframeSearchPlaybackPause = jest.fn(() => releasePlaybackPause);
+    const subscribeMessageRange = jest.fn<
+      ReturnType<SubscribeMessageRange>,
+      Parameters<SubscribeMessageRange>
+    >(({ onNewRangeIterator }) => {
+      void onNewRangeIterator(
+        (async function* () {
+          yield [keyframe, delta];
+        })(),
+      );
+      return jest.fn();
+    });
+    const renderer = makeRenderer({
+      currentTime: 10_000_000n,
+      subscribeMessageRange,
+      acquireSeekKeyframeSearchPlaybackPause,
+    });
+    const controller = makeController({ renderer, displayFrames });
+
+    controller.handleSeek();
+
+    expect(acquireSeekKeyframeSearchPlaybackPause).toHaveBeenCalledTimes(1);
+    expect(releasePlaybackPause).not.toHaveBeenCalled();
+
+    await flushAsyncWork();
+
+    expect(releasePlaybackPause).toHaveBeenCalledTimes(1);
+  });
+
   it("does not notify keyframe search for cached GOP seek replay", () => {
     const keyframe = makeVideoMessage(0n, "key");
     const delta = makeVideoMessage(10_000_000n, "delta");
     const onSeekKeyframeSearchChange = jest.fn();
-    const renderer = makeRenderer();
+    const acquireSeekKeyframeSearchPlaybackPause = jest.fn(() => jest.fn());
+    const renderer = makeRenderer({ acquireSeekKeyframeSearchPlaybackPause });
     const controller = makeController({ renderer, onSeekKeyframeSearchChange });
 
     controller.processMessage(keyframe);
@@ -515,6 +552,7 @@ describe("CompressedVideoController", () => {
     controller.handleSeek();
 
     expect(onSeekKeyframeSearchChange).not.toHaveBeenCalled();
+    expect(acquireSeekKeyframeSearchPlaybackPause).not.toHaveBeenCalled();
   });
 
   it("does not let stale lookback completion clear a newer keyframe search", async () => {
@@ -592,21 +630,35 @@ describe("CompressedVideoController", () => {
   it("cancels pending lookback when a newer seek starts", () => {
     const seekDelta = makeVideoMessage(20_000_000n, "delta");
     const cancel = jest.fn();
+    const firstReleasePlaybackPause = jest.fn();
+    const secondReleasePlaybackPause = jest.fn();
+    const acquireSeekKeyframeSearchPlaybackPause = jest
+      .fn()
+      .mockReturnValueOnce(firstReleasePlaybackPause)
+      .mockReturnValueOnce(secondReleasePlaybackPause);
     const subscribeMessageRange = jest.fn<
       ReturnType<SubscribeMessageRange>,
       Parameters<SubscribeMessageRange>
     >(() => cancel);
-    const renderer = makeRenderer({ currentTime: 20_000_000n, subscribeMessageRange });
+    const renderer = makeRenderer({
+      currentTime: 20_000_000n,
+      subscribeMessageRange,
+      acquireSeekKeyframeSearchPlaybackPause,
+    });
     const controller = makeController({ renderer });
 
     controller.handleSeek();
     controller.processMessage(seekDelta);
+    expect(acquireSeekKeyframeSearchPlaybackPause).toHaveBeenCalledTimes(1);
     expect(cancel).not.toHaveBeenCalled();
 
     renderer.currentTime = 30_000_000n;
     controller.handleSeek();
 
     expect(cancel).toHaveBeenCalledTimes(1);
+    expect(acquireSeekKeyframeSearchPlaybackPause).toHaveBeenCalledTimes(2);
+    expect(firstReleasePlaybackPause).toHaveBeenCalledTimes(1);
+    expect(secondReleasePlaybackPause).not.toHaveBeenCalled();
   });
 
   it("does not display or cache a seek delta when no range API is available", () => {
@@ -620,6 +672,59 @@ describe("CompressedVideoController", () => {
     controller.handleSeek();
 
     expect(nonResetCalls(displayFrames)).toHaveLength(0);
+  });
+
+  it("releases the playback pause lock when a lookback range read fails", async () => {
+    const displayFrames = makeSuccessfulDisplayFrames();
+    const releasePlaybackPause = jest.fn();
+    const acquireSeekKeyframeSearchPlaybackPause = jest.fn(() => releasePlaybackPause);
+    const subscribeMessageRange = jest.fn<
+      ReturnType<SubscribeMessageRange>,
+      Parameters<SubscribeMessageRange>
+    >(({ onNewRangeIterator }) => {
+      void onNewRangeIterator(
+        (async function* () {
+          throw new Error("range read failed");
+        })(),
+      );
+      return jest.fn();
+    });
+    const renderer = makeRenderer({
+      currentTime: 20_000_000n,
+      subscribeMessageRange,
+      acquireSeekKeyframeSearchPlaybackPause,
+    });
+    const controller = makeController({ renderer, displayFrames });
+
+    controller.handleSeek();
+    await flushAsyncWork();
+
+    expect(acquireSeekKeyframeSearchPlaybackPause).toHaveBeenCalledTimes(1);
+    expect(releasePlaybackPause).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases the playback pause lock once when disposed during keyframe search", () => {
+    const releasePlaybackPause = jest.fn();
+    const acquireSeekKeyframeSearchPlaybackPause = jest.fn(() => releasePlaybackPause);
+    const cancel = jest.fn();
+    const subscribeMessageRange = jest.fn<
+      ReturnType<SubscribeMessageRange>,
+      Parameters<SubscribeMessageRange>
+    >(() => cancel);
+    const renderer = makeRenderer({
+      currentTime: 20_000_000n,
+      subscribeMessageRange,
+      acquireSeekKeyframeSearchPlaybackPause,
+    });
+    const controller = makeController({ renderer });
+
+    controller.handleSeek();
+    controller.dispose();
+    controller.dispose();
+
+    expect(acquireSeekKeyframeSearchPlaybackPause).toHaveBeenCalledTimes(1);
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(releasePlaybackPause).toHaveBeenCalledTimes(1);
   });
 
   it("falls back to lookback when cached replay fails to decode", async () => {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.test.ts
@@ -682,11 +682,15 @@ describe("CompressedVideoController", () => {
       ReturnType<SubscribeMessageRange>,
       Parameters<SubscribeMessageRange>
     >(({ onNewRangeIterator }) => {
-      void onNewRangeIterator(
-        (async function* () {
-          throw new Error("range read failed");
-        })(),
-      );
+      void onNewRangeIterator({
+        [Symbol.asyncIterator]() {
+          return {
+            async next(): Promise<IteratorResult<readonly MessageEvent[]>> {
+              throw new Error("range read failed");
+            },
+          };
+        },
+      });
       return jest.fn();
     });
     const renderer = makeRenderer({

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts
@@ -66,7 +66,11 @@ type ControllerState = {
 
 type ControllerRenderer = Pick<
   IRenderer,
-  "currentTime" | "startTime" | "subscribeMessageRange" | "queueAnimationFrame"
+  | "currentTime"
+  | "startTime"
+  | "subscribeMessageRange"
+  | "acquireSeekKeyframeSearchPlaybackPause"
+  | "queueAnimationFrame"
 >;
 
 export class CompressedVideoController {
@@ -83,6 +87,7 @@ export class CompressedVideoController {
   #seekTargetNs: bigint | undefined;
   #seekKeyframeSearchActive = false;
   #seekKeyframeSearchGeneration: number | undefined;
+  #releaseSeekKeyframeSearchPlaybackPause: (() => void) | undefined;
 
   public constructor(args: {
     topic: string;
@@ -650,6 +655,8 @@ export class CompressedVideoController {
       return;
     }
     this.#seekKeyframeSearchActive = true;
+    this.#releaseSeekKeyframeSearchPlaybackPause =
+      this.#renderer.acquireSeekKeyframeSearchPlaybackPause?.();
     this.#onSeekKeyframeSearchChange?.({ active: true });
   }
 
@@ -666,6 +673,9 @@ export class CompressedVideoController {
       return;
     }
     this.#seekKeyframeSearchActive = false;
+    const releaseSeekKeyframeSearchPlaybackPause = this.#releaseSeekKeyframeSearchPlaybackPause;
+    this.#releaseSeekKeyframeSearchPlaybackPause = undefined;
+    releaseSeekKeyframeSearchPlaybackPause?.();
     this.#onSeekKeyframeSearchChange?.({ active: false });
   }
 

--- a/packages/studio-base/src/providers/PlaybackInteractionStateProvider.test.ts
+++ b/packages/studio-base/src/providers/PlaybackInteractionStateProvider.test.ts
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { selectIsKeyframeSearchActive } from "@foxglove/studio-base/context/PlaybackInteractionStateContext";
+
+import { createPlaybackInteractionStateStore } from "./PlaybackInteractionStateProvider";
+
+describe("PlaybackInteractionStateProvider", () => {
+  it("pauses playback once and resumes after the final keyframe search lock releases", () => {
+    const store = createPlaybackInteractionStateStore();
+    const pausePlayback = jest.fn();
+    const startPlayback = jest.fn();
+
+    const releaseFirst = store.getState().acquireKeyframeSearchLock({
+      isPlaying: true,
+      pausePlayback,
+      startPlayback,
+    });
+    const releaseSecond = store.getState().acquireKeyframeSearchLock({
+      isPlaying: true,
+      pausePlayback,
+      startPlayback,
+    });
+
+    expect(selectIsKeyframeSearchActive(store.getState())).toBe(true);
+    expect(store.getState().keyframeSearchLockCount).toBe(2);
+    expect(pausePlayback).toHaveBeenCalledTimes(1);
+    expect(startPlayback).not.toHaveBeenCalled();
+
+    releaseFirst();
+
+    expect(selectIsKeyframeSearchActive(store.getState())).toBe(true);
+    expect(store.getState().keyframeSearchLockCount).toBe(1);
+    expect(startPlayback).not.toHaveBeenCalled();
+
+    releaseSecond();
+
+    expect(selectIsKeyframeSearchActive(store.getState())).toBe(false);
+    expect(store.getState().keyframeSearchLockCount).toBe(0);
+    expect(pausePlayback).toHaveBeenCalledTimes(1);
+    expect(startPlayback).toHaveBeenCalledTimes(1);
+
+    releaseSecond();
+
+    expect(store.getState().keyframeSearchLockCount).toBe(0);
+    expect(startPlayback).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not pause or resume when the keyframe search starts while playback is paused", () => {
+    const store = createPlaybackInteractionStateStore();
+    const pausePlayback = jest.fn();
+    const startPlayback = jest.fn();
+
+    const release = store.getState().acquireKeyframeSearchLock({
+      isPlaying: false,
+      pausePlayback,
+      startPlayback,
+    });
+
+    expect(selectIsKeyframeSearchActive(store.getState())).toBe(true);
+    expect(pausePlayback).not.toHaveBeenCalled();
+
+    release();
+
+    expect(selectIsKeyframeSearchActive(store.getState())).toBe(false);
+    expect(startPlayback).not.toHaveBeenCalled();
+  });
+});

--- a/packages/studio-base/src/providers/PlaybackInteractionStateProvider.tsx
+++ b/packages/studio-base/src/providers/PlaybackInteractionStateProvider.tsx
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { ReactNode, useState } from "react";
+import { createStore, StoreApi } from "zustand";
+
+import {
+  AcquireKeyframeSearchLockArgs,
+  PlaybackInteractionStateContext,
+  PlaybackInteractionStateStore,
+} from "@foxglove/studio-base/context/PlaybackInteractionStateContext";
+
+export function createPlaybackInteractionStateStore(): StoreApi<PlaybackInteractionStateStore> {
+  return createStore((set, get) => {
+    let resumePlaybackAfterKeyframeSearch: (() => void) | undefined;
+
+    return {
+      keyframeSearchLockCount: 0,
+
+      acquireKeyframeSearchLock: (args?: AcquireKeyframeSearchLockArgs) => {
+        const wasInactive = get().keyframeSearchLockCount === 0;
+        set((store) => ({ keyframeSearchLockCount: store.keyframeSearchLockCount + 1 }));
+
+        if (wasInactive && args?.isPlaying === true && args.pausePlayback != undefined) {
+          args.pausePlayback();
+          resumePlaybackAfterKeyframeSearch = args.startPlayback;
+        }
+
+        let released = false;
+        return () => {
+          if (released) {
+            return;
+          }
+          released = true;
+
+          let resumePlayback: (() => void) | undefined;
+          set((store) => {
+            const nextCount = Math.max(0, store.keyframeSearchLockCount - 1);
+            if (store.keyframeSearchLockCount > 0 && nextCount === 0) {
+              resumePlayback = resumePlaybackAfterKeyframeSearch;
+              resumePlaybackAfterKeyframeSearch = undefined;
+            }
+            return { keyframeSearchLockCount: nextCount };
+          });
+
+          resumePlayback?.();
+        };
+      },
+    };
+  });
+}
+
+export default function PlaybackInteractionStateProvider({
+  children,
+}: {
+  children?: ReactNode;
+}): React.JSX.Element {
+  const [store] = useState(() => createPlaybackInteractionStateStore());
+
+  return (
+    <PlaybackInteractionStateContext.Provider value={store}>
+      {children}
+    </PlaybackInteractionStateContext.Provider>
+  );
+}


### PR DESCRIPTION
## Summary
- Introduce a shared playback interaction state context/provider to track when the app should wait for playback-related work
- Thread the state through the studio shell, app bar, panel extension adapter, playback controls, and 3D render path
- Update scrubber behavior and compressed video handling to respect the new interaction state
- Add and adjust tests covering playback controls and provider behavior

## Testing
- Added/updated unit tests for scrubber, playback controls index, compressed video controller, and playback interaction provider
- Local validation focused on state propagation and UI behavior under waiting conditions