### PR TITLE
Replace the empty timeline hint icon with the inactive create asset

### DIFF
--- a/packages/studio-base/src/components/PlaybackControls/EventsOverlay.test.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/EventsOverlay.test.tsx
@@ -358,6 +358,7 @@ describe("<EventsOverlay />", () => {
       expect(screen.getByTestId("timeline-empty-event-hint").textContent).toBe(
         "使用快捷键 Alt+1 创建一刻，为数据打标注",
       );
+      expect(screen.getByTestId("timeline-empty-event-create-icon")).toBeTruthy();
     } finally {
       await act(async () => {
         await i18n.changeLanguage(originalLanguage || "en");

--- a/packages/studio-base/src/components/PlaybackControls/EventsOverlay.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/EventsOverlay.tsx
@@ -7,7 +7,6 @@
 
 import { create } from "@bufbuild/protobuf";
 import { EventSchema } from "@coscene-io/cosceneapis-es-v2/coscene/dataplatform/v1alpha2/resources/event_pb";
-import ShieldOutlinedIcon from "@mui/icons-material/ShieldOutlined";
 import { alpha, Menu, MenuItem, type PopoverPosition, Tooltip } from "@mui/material";
 import Fade from "@mui/material/Fade";
 import Popper from "@mui/material/Popper";
@@ -75,6 +74,7 @@ import {
   type TimelineViewport,
 } from "./timelineViewport";
 import EventMarkIcon from "../../assets/event-mark.svg";
+import EventCreateInactiveIcon from "../../assets/event-create-inactive.svg";
 
 const HOTSPOT_WIDTH_PER_CENT = 0.01;
 const EVENT_CLICK_DRAG_THRESHOLD_PX = 4;
@@ -153,6 +153,7 @@ const useStyles = makeStyles()(({ transitions, palette }) => ({
   },
   emptyEventHintIcon: {
     color: "currentColor",
+    display: "inline-flex",
     flex: "0 0 auto",
     fontSize: 16,
   },
@@ -1706,7 +1707,13 @@ function UnmemoizedEventsOverlay(props: Props): React.JSX.Element | ReactNull {
         ))}
         {showEmptyEventHint && (
           <div className={classes.emptyEventHint} data-testid="timeline-empty-event-hint">
-            <ShieldOutlinedIcon className={classes.emptyEventHintIcon} />
+            <span
+              aria-hidden="true"
+              className={classes.emptyEventHintIcon}
+              data-testid="timeline-empty-event-create-icon"
+            >
+              <EventCreateInactiveIcon focusable="false" />
+            </span>
             <span className={classes.emptyEventHintText}>{t("emptyTimelineHint")}</span>
           </div>
         )}

--- a/packages/studio-base/src/components/PlaybackControls/EventsOverlay.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/EventsOverlay.tsx
@@ -73,8 +73,8 @@ import {
   timelinePointToPercent,
   type TimelineViewport,
 } from "./timelineViewport";
-import EventMarkIcon from "../../assets/event-mark.svg";
 import EventCreateInactiveIcon from "../../assets/event-create-inactive.svg";
+import EventMarkIcon from "../../assets/event-mark.svg";
 
 const HOTSPOT_WIDTH_PER_CENT = 0.01;
 const EVENT_CLICK_DRAG_THRESHOLD_PX = 4;


### PR DESCRIPTION
## Summary
- Swap the empty-event hint icon to the inactive create SVG asset
- Keep the icon aligned with the hint text by rendering it inline-flex
- Extend the overlay test to verify the icon is present in the empty state

## Testing
- Unit tests updated for `EventsOverlay` empty-state rendering