### PR TITLE
[codex] Fix URDF mass value parsing

### DIFF
--- a/packages/den/urdf/parser.test.ts
+++ b/packages/den/urdf/parser.test.ts
@@ -9,6 +9,21 @@
 import { parseUrdf } from "./parser";
 
 describe("parseUrdf", () => {
+  it("parses inertial mass from the standard value attribute", () => {
+    const robot = parseUrdf(/* xml */ `<?xml version="1.0" ?>
+    <robot name="X">
+      <link name="base">
+        <inertial>
+          <mass value="3.813"/>
+          <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/>
+        </inertial>
+      </link>
+    </robot>
+`);
+
+    expect(robot.links.get("base")?.inertial?.mass).toBe(3.813);
+  });
+
   it("parses pose with arbitrary whitespace", () => {
     expect(
       parseUrdf(/* xml */ `<?xml version="1.0" ?>

--- a/packages/den/urdf/parser.ts
+++ b/packages/den/urdf/parser.ts
@@ -110,7 +110,7 @@ function parseInertial(xml: Element): UrdfInertial {
         origin = parsePose(child);
         break;
       case "mass":
-        mass = parseFloatContent(child);
+        mass = parseFloatAttributeOptional(child, "value") ?? parseFloatContent(child);
         break;
       case "inertia":
         inertia = parseInertia(child);


### PR DESCRIPTION
## Summary
- Support standard URDF `<mass value="..."/>` entries in the den URDF parser.
- Preserve existing support for text-content mass values.
- Add a regression test covering inertial mass parsed from the `value` attribute.

## Root Cause
The parser previously read `<mass>` using only `textContent`, so valid self-closing URDF mass tags like `<mass value="3.813"/>` produced an empty text node and failed with `expected float value in "[object Element]"`.

## Test Plan
- `yarn jest --runTestsByPath packages/den/urdf/parser.test.ts`
- `yarn tsc --build packages/den/tsconfig.json`