### PR TITLE
Stabilize playback while keyframe search is active

### DIFF
--- a/packages/studio-base/src/components/PlaybackControls/Scrubber.test.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Scrubber.test.tsx
@@ -50,6 +50,7 @@ function dispatchMockPipelineProps(store: MockPipelineStore, mockProps: MockPipe
 let mockSliderProps:
   | {
       disabled?: boolean;
+      onChange?: (playbackSeconds: number) => void;
       onHoverOver?: (event: HoverOverEvent) => void;
       onHoverOut?: () => void;
     }
@@ -85,6 +86,7 @@ jest.mock("./Slider", () => ({
   __esModule: true,
   default: function MockSlider(props: {
     disabled?: boolean;
+    onChange?: (playbackSeconds: number) => void;
     onHoverOver?: (event: HoverOverEvent) => void;
     onHoverOut?: () => void;
   }): React.JSX.Element {
@@ -247,6 +249,22 @@ describe("<Scrubber />", () => {
     );
 
     expect(screen.getByTestId("scrubber-slider").dataset.disabled).toBe("true");
+  });
+
+  it("ignores timeline seek changes while keyframe search is active", () => {
+    const onSeek = jest.fn();
+    render(
+      <Wrapper>
+        <KeyframeSearchLock />
+        <Scrubber onSeek={onSeek} />
+      </Wrapper>,
+    );
+
+    act(() => {
+      mockSliderProps?.onChange?.(5);
+    });
+
+    expect(onSeek).not.toHaveBeenCalled();
   });
 
   it("renders and toggles the moment subtitle button when events are enabled", async () => {

--- a/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
@@ -454,6 +454,13 @@ export default function Scrubber(props: Props): React.JSX.Element {
   const latestStartTime = useLatest(startTime);
   const latestEndTime = useLatest(endTime);
 
+  const isKeyframeSearchActive = usePlaybackInteractionState(selectIsKeyframeSearchActive);
+  const loading =
+    presence === PlayerPresence.INITIALIZING ||
+    presence === PlayerPresence.BUFFERING ||
+    isKeyframeSearchActive;
+  const disableControls = presence === PlayerPresence.ERROR || isKeyframeSearchActive;
+
   const defaultViewport = useMemo<TimelineViewport | undefined>(() => {
     if (startTime == undefined || endTime == undefined) {
       return undefined;
@@ -518,12 +525,12 @@ export default function Scrubber(props: Props): React.JSX.Element {
 
   const onChange = useCallback(
     (playbackSeconds: number) => {
-      if (!latestStartTime.current || !latestEndTime.current) {
+      if (disableControls || !latestStartTime.current || !latestEndTime.current) {
         return;
       }
       onSeek(addTimes(latestStartTime.current, fromSec(playbackSeconds)));
     },
-    [onSeek, latestEndTime, latestStartTime],
+    [disableControls, onSeek, latestEndTime, latestStartTime],
   );
 
   const onHoverOver = useCallback(
@@ -562,13 +569,6 @@ export default function Scrubber(props: Props): React.JSX.Element {
 
   const min = useMemo(() => startTime && toSec(startTime), [startTime]);
   const max = useMemo(() => endTime && toSec(endTime), [endTime]);
-
-  const isKeyframeSearchActive = usePlaybackInteractionState(selectIsKeyframeSearchActive);
-  const loading =
-    presence === PlayerPresence.INITIALIZING ||
-    presence === PlayerPresence.BUFFERING ||
-    isKeyframeSearchActive;
-  const disableControls = presence === PlayerPresence.ERROR || isKeyframeSearchActive;
 
   const [isDragging, setIsDragging] = useState(false);
 

--- a/packages/studio-base/src/components/PlaybackControls/index.test.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.test.tsx
@@ -27,7 +27,12 @@ jest.mock("./PlaybackTimeDisplay", () => ({
   __esModule: true,
   default: function MockPlaybackTimeDisplay({ onSeek }: { onSeek: (seekTo: Time) => void }) {
     return (
-      <button data-testid="playback-time-display" onClick={() => onSeek({ sec: 3, nsec: 0 })}>
+      <button
+        data-testid="playback-time-display"
+        onClick={() => {
+          onSeek({ sec: 3, nsec: 0 });
+        }}
+      >
         time
       </button>
     );
@@ -37,7 +42,12 @@ jest.mock("./Scrubber", () => ({
   __esModule: true,
   default: function MockScrubber({ onSeek }: { onSeek: (seekTo: Time) => void }) {
     return (
-      <button data-testid="scrubber" onClick={() => onSeek({ sec: 2, nsec: 0 })}>
+      <button
+        data-testid="scrubber"
+        onClick={() => {
+          onSeek({ sec: 2, nsec: 0 });
+        }}
+      >
         scrubber
       </button>
     );
@@ -249,7 +259,7 @@ describe("<PlaybackControls />", () => {
   it("does not own playback resume after keyframe search ends", () => {
     const play = jest.fn();
     const pause = jest.fn();
-    const renderControls = (active: boolean, isPlaying: boolean) => (
+    const renderControls = ({ active, isPlaying }: { active: boolean; isPlaying: boolean }) => (
       <Wrapper>
         <KeyframeSearchLock active={active} />
         <PlaybackControls
@@ -264,17 +274,17 @@ describe("<PlaybackControls />", () => {
       </Wrapper>
     );
 
-    const { rerender } = render(renderControls(true, true));
+    const { rerender } = render(renderControls({ active: true, isPlaying: true }));
     jest.mocked(console.warn).mockClear();
 
     expect(pause).not.toHaveBeenCalled();
     expect(play).not.toHaveBeenCalled();
 
-    rerender(renderControls(true, false));
+    rerender(renderControls({ active: true, isPlaying: false }));
     jest.mocked(console.warn).mockClear();
     expect(play).not.toHaveBeenCalled();
 
-    rerender(renderControls(false, false));
+    rerender(renderControls({ active: false, isPlaying: false }));
     jest.mocked(console.warn).mockClear();
     expect(play).not.toHaveBeenCalled();
   });

--- a/packages/studio-base/src/components/PlaybackControls/index.test.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.test.tsx
@@ -9,6 +9,7 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { useEffect } from "react";
 
+import type { Time } from "@foxglove/rostime";
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
 import AppConfigurationContext from "@foxglove/studio-base/context/AppConfigurationContext";
 import CoSceneConsoleApiContext from "@foxglove/studio-base/context/CoSceneConsoleApiContext";
@@ -24,14 +25,22 @@ import PlaybackControls from ".";
 
 jest.mock("./PlaybackTimeDisplay", () => ({
   __esModule: true,
-  default: function MockPlaybackTimeDisplay() {
-    return <div data-testid="playback-time-display" />;
+  default: function MockPlaybackTimeDisplay({ onSeek }: { onSeek: (seekTo: Time) => void }) {
+    return (
+      <button data-testid="playback-time-display" onClick={() => onSeek({ sec: 3, nsec: 0 })}>
+        time
+      </button>
+    );
   },
 }));
 jest.mock("./Scrubber", () => ({
   __esModule: true,
-  default: function MockScrubber() {
-    return <div data-testid="scrubber" />;
+  default: function MockScrubber({ onSeek }: { onSeek: (seekTo: Time) => void }) {
+    return (
+      <button data-testid="scrubber" onClick={() => onSeek({ sec: 2, nsec: 0 })}>
+        scrubber
+      </button>
+    );
   },
 }));
 jest.mock("./SeekStepControls", () => ({
@@ -53,14 +62,17 @@ function TimelineHeightObserver(): React.JSX.Element {
   return <div data-testid="timeline-height">{timelineHeight}</div>;
 }
 
-function KeyframeSearchLock(): ReactNull {
+function KeyframeSearchLock({ active = true }: { active?: boolean }): ReactNull {
   const acquireKeyframeSearchLock = usePlaybackInteractionState(
     (store) => store.acquireKeyframeSearchLock,
   );
 
   useEffect(() => {
+    if (!active) {
+      return;
+    }
     return acquireKeyframeSearchLock({ isPlaying: false });
-  }, [acquireKeyframeSearchLock]);
+  }, [acquireKeyframeSearchLock, active]);
 
   return ReactNull;
 }
@@ -212,6 +224,61 @@ describe("<PlaybackControls />", () => {
     expect(play).not.toHaveBeenCalled();
   });
 
+  it("does not own playback pause while keyframe search is active", () => {
+    const pause = jest.fn();
+
+    render(
+      <Wrapper>
+        <KeyframeSearchLock />
+        <PlaybackControls
+          isPlaying
+          repeatEnabled={false}
+          getTimeInfo={() => ({})}
+          play={jest.fn()}
+          pause={pause}
+          seek={jest.fn()}
+          enableRepeatPlayback={jest.fn()}
+        />
+      </Wrapper>,
+    );
+    jest.mocked(console.warn).mockClear();
+
+    expect(pause).not.toHaveBeenCalled();
+  });
+
+  it("does not own playback resume after keyframe search ends", () => {
+    const play = jest.fn();
+    const pause = jest.fn();
+    const renderControls = (active: boolean, isPlaying: boolean) => (
+      <Wrapper>
+        <KeyframeSearchLock active={active} />
+        <PlaybackControls
+          isPlaying={isPlaying}
+          repeatEnabled={false}
+          getTimeInfo={() => ({})}
+          play={play}
+          pause={pause}
+          seek={jest.fn()}
+          enableRepeatPlayback={jest.fn()}
+        />
+      </Wrapper>
+    );
+
+    const { rerender } = render(renderControls(true, true));
+    jest.mocked(console.warn).mockClear();
+
+    expect(pause).not.toHaveBeenCalled();
+    expect(play).not.toHaveBeenCalled();
+
+    rerender(renderControls(true, false));
+    jest.mocked(console.warn).mockClear();
+    expect(play).not.toHaveBeenCalled();
+
+    rerender(renderControls(false, false));
+    jest.mocked(console.warn).mockClear();
+    expect(play).not.toHaveBeenCalled();
+  });
+
   it("ignores seek and speed keyboard shortcuts while keyframe search is active", () => {
     const seek = jest.fn();
     render(
@@ -261,6 +328,34 @@ describe("<PlaybackControls />", () => {
 
     expect(seek).not.toHaveBeenCalled();
     expect(screen.getByTestId("playback-speed").textContent).toBe("1");
+  });
+
+  it("blocks child seek callbacks while keyframe search is active", () => {
+    const seek = jest.fn();
+    render(
+      <Wrapper>
+        <KeyframeSearchLock />
+        <PlaybackControls
+          isPlaying={false}
+          repeatEnabled={false}
+          getTimeInfo={() => ({
+            startTime: { sec: 0, nsec: 0 },
+            endTime: { sec: 10, nsec: 0 },
+            currentTime: { sec: 1, nsec: 0 },
+          })}
+          play={jest.fn()}
+          pause={jest.fn()}
+          seek={seek}
+          enableRepeatPlayback={jest.fn()}
+        />
+      </Wrapper>,
+    );
+    jest.mocked(console.warn).mockClear();
+
+    fireEvent.click(screen.getByTestId("scrubber"));
+    fireEvent.click(screen.getByTestId("playback-time-display"));
+
+    expect(seek).not.toHaveBeenCalled();
   });
 
   it("resizes the timeline and stores the height in the workspace", () => {

--- a/packages/studio-base/src/components/PlaybackControls/index.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.tsx
@@ -205,6 +205,16 @@ export default function PlaybackControls(props: {
     }
   }, [repeat, repeatEnabled, enableRepeatPlayback]);
 
+  const seekIfAllowed = useCallback(
+    (seekTo: Time) => {
+      if (isKeyframeSearchActive) {
+        return;
+      }
+      seek(seekTo);
+    },
+    [isKeyframeSearchActive, seek],
+  );
+
   const togglePlayPause = useCallback(() => {
     if (isKeyframeSearchActive) {
       return;
@@ -216,11 +226,11 @@ export default function PlaybackControls(props: {
       const { startTime: start, endTime: end, currentTime: current } = getTimeInfo();
       // if we are at the end, we need to go back to start
       if (current && end && start && compare(current, end) >= 0) {
-        seek(start);
+        seekIfAllowed(start);
       }
       play();
     }
-  }, [isKeyframeSearchActive, isPlaying, pause, getTimeInfo, play, seek]);
+  }, [isKeyframeSearchActive, isPlaying, pause, getTimeInfo, seekIfAllowed, play]);
 
   // Track SeekStep editing state for KeyListener management
   const [seekStepEditing, setSeekStepEditing] = useState(false);
@@ -262,10 +272,10 @@ export default function PlaybackControls(props: {
       if (playUntil) {
         playUntil(clampedTargetTime);
       } else {
-        seek(clampedTargetTime);
+        seekIfAllowed(clampedTargetTime);
       }
     },
-    [isKeyframeSearchActive, getTimeInfo, playUntil, seek, effectiveSeekMs],
+    [isKeyframeSearchActive, getTimeInfo, playUntil, seekIfAllowed, effectiveSeekMs],
   );
 
   const seekBackwardAction = useCallback(
@@ -278,9 +288,9 @@ export default function PlaybackControls(props: {
       if (!currentTime) {
         return;
       }
-      seek(jumpSeek(DIRECTION.BACKWARD, currentTime, ev, effectiveSeekMs));
+      seekIfAllowed(jumpSeek(DIRECTION.BACKWARD, currentTime, ev, effectiveSeekMs));
     },
-    [isKeyframeSearchActive, getTimeInfo, seek, effectiveSeekMs],
+    [isKeyframeSearchActive, getTimeInfo, seekIfAllowed, effectiveSeekMs],
   );
 
   const adjustPlaybackSpeed = useCallback(
@@ -389,7 +399,7 @@ export default function PlaybackControls(props: {
           data-testid="playback-controls-resize-handle"
           onPointerDown={startTimelineResize}
         />
-        <Scrubber onSeek={seek} />
+        <Scrubber onSeek={seekIfAllowed} />
         <Stack className={classes.controlsRow} direction="row" alignItems="center" gap={1}>
           <Stack direction="row" flex={1} gap={0.5}>
             <Tooltip
@@ -415,7 +425,7 @@ export default function PlaybackControls(props: {
                 icon={<Info20Regular />}
               />
             </Tooltip>
-            <PlaybackTimeDisplay onSeek={seek} onPause={pause} />
+            <PlaybackTimeDisplay onSeek={seekIfAllowed} onPause={pause} />
             {dataSource?.type === "persistent-cache" &&
               dataSource.previousRecentId != undefined && (
                 <Tooltip title={t("switchToRealTimeFromPlayback", { ns: "websocket" })}>

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.test.ts
@@ -132,6 +132,8 @@ class PlaybackCompressedVideoMessageHandler extends FakeMessageHandler {
 class TestImageRenderable extends ImageRenderable {
   public readonly setImageCalls: AnyImage[] = [];
   public readonly setCompressedVideoFrameBatches: AnyImage[][] = [];
+  public readonly setCompressedVideoFrameOptions: (SetCompressedVideoFramesOptions | undefined)[] =
+    [];
   public resetForSeekCalls = 0;
   public disposed = false;
 
@@ -156,6 +158,7 @@ class TestImageRenderable extends ImageRenderable {
 
     this.userData.image = targetFrame.message;
     this.setCompressedVideoFrameBatches.push(frames.map((frame) => frame.message));
+    this.setCompressedVideoFrameOptions.push(options);
     options?.onDecoded?.();
     options?.updateImageState?.(targetFrame);
     return { ok: true };
@@ -313,6 +316,11 @@ describe("ImageMode compressed video seek replay", () => {
         batch.map(timestampFromImage),
       ),
     ).toEqual([[keyframe.message.timestamp, delta.message.timestamp]]);
+    expect(
+      imageMode.createdRenderables[0]!.setCompressedVideoFrameOptions.map(
+        (options) => options?.allowIntermediateVideoFrame,
+      ),
+    ).toEqual([false]);
     expect(imageMode.createdRenderables[0]!.setImageCalls).toEqual([]);
   });
 
@@ -362,6 +370,11 @@ describe("ImageMode compressed video seek replay", () => {
         batch.map(timestampFromImage),
       ),
     ).toEqual([[keyframe.message.timestamp, middle.message.timestamp, delta.message.timestamp]]);
+    expect(
+      imageMode.createdRenderables[0]!.setCompressedVideoFrameOptions.map(
+        (options) => options?.allowIntermediateVideoFrame,
+      ),
+    ).toEqual([false]);
     expect(messageHandler.updateImageState).not.toHaveBeenCalled();
   });
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -856,6 +856,7 @@ export class ImageMode
     renderable.userData.receiveTime = receiveTime;
     return await renderable.setCompressedVideoFrames(frames, {
       ...options,
+      allowIntermediateVideoFrame: false,
       onDecoded: () => {
         options?.onDecoded?.();
         if (this.#fallbackCameraModelActive()) {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.test.ts
@@ -606,13 +606,14 @@ describe("CompressedVideoController", () => {
     const delta = makeVideoMessage(10_000_000n, "delta");
     const nextDelta = makeVideoMessage(20_000_000n, "delta");
     const displayFrames = makeSuccessfulDisplayFrames();
-    let controller: CompressedVideoController | undefined;
+    const controllerRef: { current?: CompressedVideoController } = {};
     const releasePlaybackPause = jest.fn(() => {
-      controller?.processMessage(nextDelta);
+      controllerRef.current?.processMessage(nextDelta);
     });
     const acquireSeekKeyframeSearchPlaybackPause = jest.fn(() => releasePlaybackPause);
     const renderer = makeRenderer({ acquireSeekKeyframeSearchPlaybackPause });
-    controller = makeController({ renderer, displayFrames });
+    const controller = makeController({ renderer, displayFrames });
+    controllerRef.current = controller;
 
     controller.processMessage(keyframe);
     controller.processMessage(delta);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.test.ts
@@ -129,6 +129,10 @@ describe("CompressedVideoController", () => {
   });
 
   afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  afterEach(() => {
     jest.restoreAllMocks();
   });
 
@@ -164,6 +168,9 @@ describe("CompressedVideoController", () => {
       [0n, 10_000_000n],
     ]);
     expect(nonResetCalls(displayFrames).map((call) => call[1])).toEqual(["seek"]);
+    expect(
+      nonResetCalls(displayFrames).map((call) => call[2]?.allowIntermediateVideoFrame),
+    ).toEqual([false]);
   });
 
   it("replays from the cached keyframe to a publish-time target", async () => {
@@ -184,6 +191,9 @@ describe("CompressedVideoController", () => {
       [0n, 10_000_000n, 20_000_000n],
     ]);
     expect(nonResetCalls(displayFrames).map((call) => call[1])).toEqual(["direct"]);
+    expect(
+      nonResetCalls(displayFrames).map((call) => call[2]?.allowIntermediateVideoFrame),
+    ).toEqual([false]);
     expect(renderer.queueAnimationFrame).toHaveBeenCalledTimes(1);
   });
 
@@ -245,6 +255,9 @@ describe("CompressedVideoController", () => {
       [0n, 10_000_000n, 20_000_000n],
     ]);
     expect(nonResetCalls(displayFrames).map((call) => call[1])).toEqual(["seek"]);
+    expect(
+      nonResetCalls(displayFrames).map((call) => call[2]?.allowIntermediateVideoFrame),
+    ).toEqual([false]);
     expect(renderer.queueAnimationFrame).toHaveBeenCalledTimes(1);
     expect(unsubscribe).toHaveBeenCalledTimes(1);
   });
@@ -541,18 +554,171 @@ describe("CompressedVideoController", () => {
     const keyframe = makeVideoMessage(0n, "key");
     const delta = makeVideoMessage(10_000_000n, "delta");
     const onSeekKeyframeSearchChange = jest.fn();
-    const acquireSeekKeyframeSearchPlaybackPause = jest.fn(() => jest.fn());
-    const renderer = makeRenderer({ acquireSeekKeyframeSearchPlaybackPause });
+    const renderer = makeRenderer({ currentTime: 10_000_000n });
     const controller = makeController({ renderer, onSeekKeyframeSearchChange });
 
     controller.processMessage(keyframe);
     controller.processMessage(delta);
 
-    renderer.currentTime = 10_000_000n;
     controller.handleSeek();
 
     expect(onSeekKeyframeSearchChange).not.toHaveBeenCalled();
-    expect(acquireSeekKeyframeSearchPlaybackPause).not.toHaveBeenCalled();
+  });
+
+  it("holds a playback pause lock while cached GOP seek replay is pending", async () => {
+    const keyframe = makeVideoMessage(0n, "key");
+    const delta = makeVideoMessage(10_000_000n, "delta");
+    let resolveSeekDisplay!: (result: ImageSetImageResult) => void;
+    const seekDisplayPromise = new Promise<ImageSetImageResult>((resolve) => {
+      resolveSeekDisplay = resolve;
+    });
+    const displayFrames = jest.fn<
+      Promise<ImageSetImageResult>,
+      Parameters<CompressedVideoDisplayFrames>
+    >(async (_frames, mode) => {
+      return mode === "seek" ? await seekDisplayPromise : { ok: true };
+    });
+    const releasePlaybackPause = jest.fn();
+    const acquireSeekKeyframeSearchPlaybackPause = jest.fn(() => releasePlaybackPause);
+    const renderer = makeRenderer({ acquireSeekKeyframeSearchPlaybackPause });
+    const controller = makeController({ renderer, displayFrames });
+
+    controller.processMessage(keyframe);
+    controller.processMessage(delta);
+    await flushAsyncWork();
+    displayFrames.mockClear();
+
+    renderer.currentTime = 10_000_000n;
+    controller.handleSeek();
+
+    expect(acquireSeekKeyframeSearchPlaybackPause).toHaveBeenCalledTimes(1);
+    expect(releasePlaybackPause).not.toHaveBeenCalled();
+
+    resolveSeekDisplay({ ok: true });
+    await flushAsyncWork();
+
+    expect(nonResetCalls(displayFrames).map((call) => call[1])).toEqual(["seek"]);
+    expect(releasePlaybackPause).toHaveBeenCalledTimes(1);
+  });
+
+  it("stabilizes the first playback frame that arrives as cached seek replay resumes", async () => {
+    const keyframe = makeVideoMessage(0n, "key");
+    const delta = makeVideoMessage(10_000_000n, "delta");
+    const nextDelta = makeVideoMessage(20_000_000n, "delta");
+    const displayFrames = makeSuccessfulDisplayFrames();
+    let controller: CompressedVideoController | undefined;
+    const releasePlaybackPause = jest.fn(() => {
+      controller?.processMessage(nextDelta);
+    });
+    const acquireSeekKeyframeSearchPlaybackPause = jest.fn(() => releasePlaybackPause);
+    const renderer = makeRenderer({ acquireSeekKeyframeSearchPlaybackPause });
+    controller = makeController({ renderer, displayFrames });
+
+    controller.processMessage(keyframe);
+    controller.processMessage(delta);
+    await flushAsyncWork();
+    displayFrames.mockClear();
+
+    renderer.currentTime = 10_000_000n;
+    controller.handleSeek();
+    await flushAsyncWork();
+
+    expect(nonResetCalls(displayFrames).map(([frames]) => frameReceiveTimes(frames))).toEqual([
+      [0n, 10_000_000n],
+      [0n, 10_000_000n, 20_000_000n],
+    ]);
+    expect(nonResetCalls(displayFrames).map((call) => call[1])).toEqual(["seek", "seek"]);
+    expect(
+      nonResetCalls(displayFrames).map((call) => call[2]?.allowIntermediateVideoFrame),
+    ).toEqual([false, false]);
+  });
+
+  it("stabilizes the first playback keyframe after seek instead of using normal playback", async () => {
+    const keyframe = makeVideoMessage(0n, "key");
+    const delta = makeVideoMessage(10_000_000n, "delta");
+    const nextKeyframe = makeVideoMessage(20_000_000n, "key");
+    const displayFrames = makeSuccessfulDisplayFrames();
+    const renderer = makeRenderer();
+    const controller = makeController({ renderer, displayFrames });
+
+    controller.processMessage(keyframe);
+    controller.processMessage(delta);
+    await flushAsyncWork();
+    displayFrames.mockClear();
+
+    renderer.currentTime = 10_000_000n;
+    controller.handleSeek();
+    await flushAsyncWork();
+    displayFrames.mockClear();
+
+    controller.processMessage(nextKeyframe);
+    await flushAsyncWork();
+
+    expect(nonResetCalls(displayFrames).map(([frames]) => frameReceiveTimes(frames))).toEqual([
+      [20_000_000n],
+    ]);
+    expect(nonResetCalls(displayFrames).map((call) => call[1])).toEqual(["seek"]);
+    expect(
+      nonResetCalls(displayFrames).map((call) => call[2]?.allowIntermediateVideoFrame),
+    ).toEqual([false]);
+  });
+
+  it("suppresses playback frames while post-seek playback stabilization is pending", async () => {
+    const keyframe = makeVideoMessage(0n, "key");
+    const delta = makeVideoMessage(10_000_000n, "delta");
+    const firstPlaybackDelta = makeVideoMessage(20_000_000n, "delta");
+    const secondPlaybackDelta = makeVideoMessage(30_000_000n, "delta");
+    const thirdPlaybackDelta = makeVideoMessage(40_000_000n, "delta");
+    let resolveStabilization!: (result: ImageSetImageResult) => void;
+    const stabilizationPromise = new Promise<ImageSetImageResult>((resolve) => {
+      resolveStabilization = resolve;
+    });
+    const displayFrames = jest.fn<
+      Promise<ImageSetImageResult>,
+      Parameters<CompressedVideoDisplayFrames>
+    >(async (frames, mode) => {
+      if (mode === "seek" && frameReceiveTimes(frames).at(-1) === 20_000_000n) {
+        return await stabilizationPromise;
+      }
+      return { ok: true };
+    });
+    const renderer = makeRenderer();
+    const controller = makeController({ renderer, displayFrames });
+
+    controller.processMessage(keyframe);
+    controller.processMessage(delta);
+    await flushAsyncWork();
+
+    renderer.currentTime = 10_000_000n;
+    controller.handleSeek();
+    await flushAsyncWork();
+    displayFrames.mockClear();
+
+    controller.processMessage(firstPlaybackDelta);
+    controller.processMessage(secondPlaybackDelta);
+    await flushAsyncWork();
+
+    expect(nonResetCalls(displayFrames).map(([frames]) => frameReceiveTimes(frames))).toEqual([
+      [0n, 10_000_000n, 20_000_000n],
+    ]);
+    expect(nonResetCalls(displayFrames).map((call) => call[1])).toEqual(["seek"]);
+
+    resolveStabilization({ ok: true });
+    await flushAsyncWork();
+
+    controller.processMessage(thirdPlaybackDelta);
+    await flushAsyncWork();
+
+    expect(nonResetCalls(displayFrames).map(([frames]) => frameReceiveTimes(frames))).toEqual([
+      [0n, 10_000_000n, 20_000_000n],
+      [0n, 10_000_000n, 20_000_000n, 30_000_000n],
+      [40_000_000n],
+    ]);
+    expect(nonResetCalls(displayFrames).map((call) => call[1])).toEqual([
+      "seek",
+      "seek",
+      "playback",
+    ]);
   });
 
   it("does not let stale lookback completion clear a newer keyframe search", async () => {
@@ -705,6 +871,43 @@ describe("CompressedVideoController", () => {
 
     expect(acquireSeekKeyframeSearchPlaybackPause).toHaveBeenCalledTimes(1);
     expect(releasePlaybackPause).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases the playback pause lock when a lookback range read never resolves", async () => {
+    jest.useFakeTimers();
+
+    const releasePlaybackPause = jest.fn();
+    const acquireSeekKeyframeSearchPlaybackPause = jest.fn(() => releasePlaybackPause);
+    const onSeekKeyframeSearchChange = jest.fn();
+    const unsubscribe = jest.fn();
+    const subscribeMessageRange = jest.fn<
+      ReturnType<SubscribeMessageRange>,
+      Parameters<SubscribeMessageRange>
+    >(() => unsubscribe);
+    const renderer = makeRenderer({
+      currentTime: 20_000_000n,
+      subscribeMessageRange,
+      acquireSeekKeyframeSearchPlaybackPause,
+    });
+    const controller = makeController({
+      renderer,
+      onSeekKeyframeSearchChange,
+    });
+
+    controller.handleSeek();
+
+    expect(acquireSeekKeyframeSearchPlaybackPause).toHaveBeenCalledTimes(1);
+    expect(onSeekKeyframeSearchChange).toHaveBeenCalledWith({ active: true });
+    expect(releasePlaybackPause).not.toHaveBeenCalled();
+
+    await jest.advanceTimersByTimeAsync(30_000);
+
+    expect(unsubscribe).toHaveBeenCalled();
+    expect(releasePlaybackPause).toHaveBeenCalledTimes(1);
+    expect(onSeekKeyframeSearchChange.mock.calls).toEqual([
+      [{ active: true }],
+      [{ active: false }],
+    ]);
   });
 
   it("releases the playback pause lock once when disposed during keyframe search", () => {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.test.ts
@@ -601,6 +601,57 @@ describe("CompressedVideoController", () => {
     expect(releasePlaybackPause).toHaveBeenCalledTimes(1);
   });
 
+  it("suppresses playback frames while cached seek replay is waiting for the target frame", async () => {
+    const keyframe = makeVideoMessage(0n, "key");
+    const delta = makeVideoMessage(10_000_000n, "delta");
+    const firstPlaybackDelta = makeVideoMessage(20_000_000n, "delta");
+    const secondPlaybackDelta = makeVideoMessage(30_000_000n, "delta");
+    let resolveSeekDisplay!: (result: ImageSetImageResult) => void;
+    const seekDisplayPromise = new Promise<ImageSetImageResult>((resolve) => {
+      resolveSeekDisplay = resolve;
+    });
+    const displayFrames = jest.fn<
+      Promise<ImageSetImageResult>,
+      Parameters<CompressedVideoDisplayFrames>
+    >(async (frames, mode) => {
+      if (mode === "seek" && frameReceiveTimes(frames).at(-1) === 10_000_000n) {
+        return await seekDisplayPromise;
+      }
+      return { ok: true };
+    });
+    const renderer = makeRenderer();
+    const controller = makeController({ renderer, displayFrames });
+
+    controller.processMessage(keyframe);
+    controller.processMessage(delta);
+    await flushAsyncWork();
+    displayFrames.mockClear();
+
+    renderer.currentTime = 10_000_000n;
+    controller.handleSeek();
+
+    controller.processMessage(firstPlaybackDelta);
+    controller.processMessage(secondPlaybackDelta);
+    await flushAsyncWork();
+
+    expect(nonResetCalls(displayFrames).map(([frames]) => frameReceiveTimes(frames))).toEqual([
+      [0n, 10_000_000n],
+    ]);
+    expect(nonResetCalls(displayFrames).map((call) => call[1])).toEqual(["seek"]);
+
+    resolveSeekDisplay({ ok: true });
+    await flushAsyncWork();
+
+    expect(nonResetCalls(displayFrames).map(([frames]) => frameReceiveTimes(frames))).toEqual([
+      [0n, 10_000_000n],
+      [0n, 10_000_000n, 20_000_000n, 30_000_000n],
+    ]);
+    expect(nonResetCalls(displayFrames).map((call) => call[1])).toEqual(["seek", "seek"]);
+    expect(
+      nonResetCalls(displayFrames).map((call) => call[2]?.allowIntermediateVideoFrame),
+    ).toEqual([false, false]);
+  });
+
   it("stabilizes the first playback frame that arrives as cached seek replay resumes", async () => {
     const keyframe = makeVideoMessage(0n, "key");
     const delta = makeVideoMessage(10_000_000n, "delta");

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts
@@ -188,6 +188,9 @@ export class CompressedVideoController {
     }
 
     this.#cache.addFrame(normalizedEvent);
+    if (this.#suppressPlaybackDuringPendingSeekReplay(receiveTimeNs)) {
+      return;
+    }
     if (this.#displayStabilizedPlaybackAfterSeek(normalizedEvent, receiveTimeNs, options)) {
       return;
     }
@@ -424,7 +427,7 @@ export class CompressedVideoController {
 
       this.#state.replayGeneration = undefined;
       if (ok) {
-        this.#markSeekReplayComplete(generation, frames);
+        this.#markSeekReplayComplete(generation, frames, options);
         return;
       }
 
@@ -563,7 +566,7 @@ export class CompressedVideoController {
 
         this.#state.successfulWindowSeconds =
           windowSec ?? this.#windowSecondsForSpan(lookbackTargetNs - windowStartNs);
-        this.#markSeekReplayComplete(generation, replayFrames);
+        this.#markSeekReplayComplete(generation, replayFrames, options);
         this.#state.lookbackCancel = undefined;
         this.#state.lookbackGeneration = undefined;
         return true;
@@ -577,11 +580,55 @@ export class CompressedVideoController {
     }
   }
 
-  #markSeekReplayComplete(generation: number, frames: readonly MessageEvent[]): void {
+  #markSeekReplayComplete(
+    generation: number,
+    frames: readonly MessageEvent[],
+    options?: SetCompressedVideoFramesOptions,
+  ): void {
     this.#state.completedSeekGeneration = generation;
     this.#state.playbackStabilizationGeneration = generation;
     this.#recordLastDisplayedPublishTime(frames);
     this.#renderer.queueAnimationFrame();
+    this.#startPendingPlaybackStabilizationAfterSeekReplay(generation, frames, options);
+  }
+
+  #suppressPlaybackDuringPendingSeekReplay(receiveTimeNs: bigint): boolean {
+    if (
+      this.#state.replayGeneration !== this.#generation &&
+      this.#state.lookbackGeneration !== this.#generation
+    ) {
+      return false;
+    }
+
+    this.#recordPendingPlaybackStabilizationReceiveTime(receiveTimeNs);
+    return true;
+  }
+
+  #startPendingPlaybackStabilizationAfterSeekReplay(
+    generation: number,
+    frames: readonly MessageEvent[],
+    options?: SetCompressedVideoFramesOptions,
+  ): void {
+    const targetFrame = frames[frames.length - 1];
+    const targetReceiveTimeNs =
+      targetFrame != undefined ? toNanoSec(targetFrame.receiveTime) : undefined;
+    const pendingReceiveTimeNs = this.#state.pendingPlaybackStabilizationReceiveTimeNs;
+    if (pendingReceiveTimeNs == undefined || targetReceiveTimeNs == undefined) {
+      return;
+    }
+
+    this.#state.pendingPlaybackStabilizationReceiveTimeNs = undefined;
+    if (pendingReceiveTimeNs <= targetReceiveTimeNs) {
+      return;
+    }
+
+    const pendingFrames = this.#cache.framesForReceiveTime(
+      this.#topic,
+      fromNanoSec(pendingReceiveTimeNs),
+    );
+    if (pendingFrames != undefined) {
+      this.#startPlaybackStabilization(pendingFrames, generation, options);
+    }
   }
 
   #displayStabilizedPlaybackAfterSeek(

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts
@@ -32,6 +32,7 @@ import { PartialMessageEvent } from "../../SceneExtension";
 // range first and only walk outward for sparser-keyframe streams (one extra range read each step).
 const LOOKBACK_WINDOWS_SEC = [1, 2, 5, 10, 20, 40, 60] as const;
 const LOOKBACK_RANGE_RETRY_DELAYS_MS = [50, 250, 1000] as const;
+const LOOKBACK_RANGE_READ_TIMEOUT_MS = 5_000;
 
 export type VideoDisplayMode = "playback" | "seek" | "direct";
 
@@ -62,6 +63,9 @@ type ControllerState = {
   completedSeekGeneration?: number;
   decoderResetGeneration?: number;
   lastDisplayedPublishTimeNs?: bigint;
+  playbackStabilizationGeneration?: number;
+  playbackStabilizationInFlightGeneration?: number;
+  pendingPlaybackStabilizationReceiveTimeNs?: bigint;
 };
 
 type ControllerRenderer = Pick<
@@ -88,6 +92,8 @@ export class CompressedVideoController {
   #seekKeyframeSearchActive = false;
   #seekKeyframeSearchGeneration: number | undefined;
   #releaseSeekKeyframeSearchPlaybackPause: (() => void) | undefined;
+  #seekReplayPlaybackPauseGeneration: number | undefined;
+  #releaseSeekReplayPlaybackPause: (() => void) | undefined;
 
   public constructor(args: {
     topic: string;
@@ -182,6 +188,9 @@ export class CompressedVideoController {
     }
 
     this.#cache.addFrame(normalizedEvent);
+    if (this.#displayStabilizedPlaybackAfterSeek(normalizedEvent, receiveTimeNs, options)) {
+      return;
+    }
     void this.#displayReplayFrames([normalizedEvent], this.#generation, "playback", options);
   }
 
@@ -275,6 +284,7 @@ export class CompressedVideoController {
     this.#generation++;
     this.#seekTargetNs = undefined;
     this.#cancelLookback();
+    this.#endSeekReplayPlaybackPause();
     this.#state.replayGeneration = undefined;
     this.#state.completedSeekGeneration = undefined;
     this.#state.decoderResetGeneration = this.#generation;
@@ -285,6 +295,7 @@ export class CompressedVideoController {
   public clear(): void {
     this.#generation++;
     this.#cancelLookback();
+    this.#endSeekReplayPlaybackPause();
     this.#cache.clearTopic(this.#topic);
     this.#endSeekKeyframeSearch();
   }
@@ -330,6 +341,9 @@ export class CompressedVideoController {
     this.#cancelLookback();
     this.#state.replayGeneration = undefined;
     this.#state.completedSeekGeneration = undefined;
+    this.#state.playbackStabilizationGeneration = undefined;
+    this.#state.playbackStabilizationInFlightGeneration = undefined;
+    this.#state.pendingPlaybackStabilizationReceiveTimeNs = undefined;
     return generation;
   }
 
@@ -340,12 +354,18 @@ export class CompressedVideoController {
     this.#resetDecoderForReplayableFrames();
     this.#state.decoderResetGeneration = generation;
     this.#state.lastDisplayedPublishTimeNs = undefined;
+    this.#state.playbackStabilizationGeneration = undefined;
+    this.#state.playbackStabilizationInFlightGeneration = undefined;
+    this.#state.pendingPlaybackStabilizationReceiveTimeNs = undefined;
   }
 
   #resetDecoderForReplay(): void {
     this.#resetDecoderForReplayableFrames();
     this.#state.decoderResetGeneration = undefined;
     this.#state.lastDisplayedPublishTimeNs = undefined;
+    this.#state.playbackStabilizationGeneration = undefined;
+    this.#state.playbackStabilizationInFlightGeneration = undefined;
+    this.#state.pendingPlaybackStabilizationReceiveTimeNs = undefined;
   }
 
   #resetDecoderForReplayableFrames(): void {
@@ -394,21 +414,25 @@ export class CompressedVideoController {
     frames: readonly MessageEvent[],
     options?: SetCompressedVideoFramesOptions,
   ): Promise<void> {
-    const ok = await this.#displayReplayFrames(frames, generation, "seek", options);
-    if (!this.#isCurrentGeneration(generation)) {
-      return;
-    }
+    this.#beginSeekReplayPlaybackPause(generation);
+    let ok = false;
+    try {
+      ok = await this.#displayReplayFrames(frames, generation, "seek", options);
+      if (!this.#isCurrentGeneration(generation)) {
+        return;
+      }
 
-    this.#state.replayGeneration = undefined;
-    if (ok) {
-      this.#state.completedSeekGeneration = generation;
-      this.#recordLastDisplayedPublishTime(frames);
-      this.#renderer.queueAnimationFrame();
-      return;
-    }
+      this.#state.replayGeneration = undefined;
+      if (ok) {
+        this.#markSeekReplayComplete(generation, frames);
+        return;
+      }
 
-    this.#resetDecoderForReplay();
-    this.#startLookback(generation, replayTarget, options);
+      this.#resetDecoderForReplay();
+      this.#startLookback(generation, replayTarget, options);
+    } finally {
+      this.#endSeekReplayPlaybackPause(generation);
+    }
   }
 
   async #lookBackPublishTimeTarget(
@@ -539,11 +563,9 @@ export class CompressedVideoController {
 
         this.#state.successfulWindowSeconds =
           windowSec ?? this.#windowSecondsForSpan(lookbackTargetNs - windowStartNs);
-        this.#state.completedSeekGeneration = generation;
-        this.#recordLastDisplayedPublishTime(replayFrames);
+        this.#markSeekReplayComplete(generation, replayFrames);
         this.#state.lookbackCancel = undefined;
         this.#state.lookbackGeneration = undefined;
-        this.#renderer.queueAnimationFrame();
         return true;
       }
 
@@ -552,6 +574,111 @@ export class CompressedVideoController {
       return false;
     } finally {
       this.#endSeekKeyframeSearch(generation);
+    }
+  }
+
+  #markSeekReplayComplete(generation: number, frames: readonly MessageEvent[]): void {
+    this.#state.completedSeekGeneration = generation;
+    this.#state.playbackStabilizationGeneration = generation;
+    this.#recordLastDisplayedPublishTime(frames);
+    this.#renderer.queueAnimationFrame();
+  }
+
+  #displayStabilizedPlaybackAfterSeek(
+    messageEvent: MessageEvent<CompressedVideo>,
+    receiveTimeNs: bigint,
+    options?: SetCompressedVideoFramesOptions,
+  ): boolean {
+    if (this.#state.playbackStabilizationInFlightGeneration === this.#generation) {
+      this.#recordPendingPlaybackStabilizationReceiveTime(receiveTimeNs);
+      return true;
+    }
+
+    if (this.#state.playbackStabilizationGeneration !== this.#generation) {
+      return false;
+    }
+
+    if (this.#seekTargetNs != undefined && receiveTimeNs <= this.#seekTargetNs) {
+      return true;
+    }
+
+    const replayFrames = this.#cache.framesForReceiveTime(this.#topic, messageEvent.receiveTime);
+    if (replayFrames == undefined) {
+      return true;
+    }
+
+    this.#startPlaybackStabilization(replayFrames, this.#generation, options);
+    return true;
+  }
+
+  #recordPendingPlaybackStabilizationReceiveTime(receiveTimeNs: bigint): void {
+    const pendingReceiveTimeNs = this.#state.pendingPlaybackStabilizationReceiveTimeNs;
+    if (pendingReceiveTimeNs == undefined || receiveTimeNs > pendingReceiveTimeNs) {
+      this.#state.pendingPlaybackStabilizationReceiveTimeNs = receiveTimeNs;
+    }
+  }
+
+  #startPlaybackStabilization(
+    frames: readonly MessageEvent[],
+    generation: number,
+    options?: SetCompressedVideoFramesOptions,
+  ): void {
+    this.#state.playbackStabilizationGeneration = undefined;
+    this.#state.playbackStabilizationInFlightGeneration = generation;
+    this.#state.pendingPlaybackStabilizationReceiveTimeNs = undefined;
+    void this.#displayStabilizedPlaybackFrames(frames, generation, options);
+  }
+
+  async #displayStabilizedPlaybackFrames(
+    frames: readonly MessageEvent[],
+    generation: number,
+    options?: SetCompressedVideoFramesOptions,
+  ): Promise<void> {
+    let continuingStabilization = false;
+    try {
+      const ok = await this.#displayReplayFrames(frames, generation, "seek", {
+        ...options,
+        allowIntermediateVideoFrame: false,
+      });
+      if (!this.#isCurrentGeneration(generation)) {
+        return;
+      }
+
+      if (ok) {
+        this.#recordLastDisplayedPublishTime(frames);
+        this.#renderer.queueAnimationFrame();
+        const targetFrame = frames[frames.length - 1];
+        const targetReceiveTimeNs =
+          targetFrame != undefined ? toNanoSec(targetFrame.receiveTime) : undefined;
+        const pendingReceiveTimeNs = this.#state.pendingPlaybackStabilizationReceiveTimeNs;
+        if (
+          targetReceiveTimeNs != undefined &&
+          pendingReceiveTimeNs != undefined &&
+          pendingReceiveTimeNs > targetReceiveTimeNs
+        ) {
+          const pendingFrames = this.#cache.framesForReceiveTime(
+            this.#topic,
+            fromNanoSec(pendingReceiveTimeNs),
+          );
+          this.#state.pendingPlaybackStabilizationReceiveTimeNs = undefined;
+          if (pendingFrames != undefined) {
+            continuingStabilization = true;
+            void this.#displayStabilizedPlaybackFrames(pendingFrames, generation, options);
+            return;
+          }
+          this.#state.playbackStabilizationGeneration = generation;
+        }
+        return;
+      }
+
+      this.#resetDecoderForReplay();
+    } finally {
+      if (
+        !continuingStabilization &&
+        this.#state.playbackStabilizationInFlightGeneration === generation
+      ) {
+        this.#state.playbackStabilizationInFlightGeneration = undefined;
+      }
     }
   }
 
@@ -597,6 +724,7 @@ export class CompressedVideoController {
 
     return await new Promise<MessageEvent[] | undefined>((resolve) => {
       let finished = false;
+      let timeout: ReturnType<typeof setTimeout> | undefined;
       let unsubscribe: (() => void) | undefined;
       const currentCancel = () => {
         finish([]);
@@ -606,6 +734,10 @@ export class CompressedVideoController {
           return;
         }
         finished = true;
+        if (timeout != undefined) {
+          clearTimeout(timeout);
+          timeout = undefined;
+        }
         unsubscribe?.();
         unsubscribe = undefined;
         if (this.#state.lookbackCancel === currentCancel) {
@@ -635,6 +767,9 @@ export class CompressedVideoController {
         finish(undefined);
         return;
       }
+      timeout = setTimeout(() => {
+        finish(undefined);
+      }, LOOKBACK_RANGE_READ_TIMEOUT_MS);
     });
   }
 
@@ -658,6 +793,33 @@ export class CompressedVideoController {
     this.#releaseSeekKeyframeSearchPlaybackPause =
       this.#renderer.acquireSeekKeyframeSearchPlaybackPause?.();
     this.#onSeekKeyframeSearchChange?.({ active: true });
+  }
+
+  #beginSeekReplayPlaybackPause(generation: number): void {
+    if (!this.#isCurrentGeneration(generation)) {
+      return;
+    }
+    if (this.#seekReplayPlaybackPauseGeneration === generation) {
+      return;
+    }
+    this.#endSeekReplayPlaybackPause();
+    this.#seekReplayPlaybackPauseGeneration = generation;
+    this.#releaseSeekReplayPlaybackPause =
+      this.#renderer.acquireSeekKeyframeSearchPlaybackPause?.();
+  }
+
+  #endSeekReplayPlaybackPause(generation?: number): void {
+    if (
+      generation != undefined &&
+      this.#seekReplayPlaybackPauseGeneration != undefined &&
+      generation !== this.#seekReplayPlaybackPauseGeneration
+    ) {
+      return;
+    }
+    this.#seekReplayPlaybackPauseGeneration = undefined;
+    const releaseSeekReplayPlaybackPause = this.#releaseSeekReplayPlaybackPause;
+    this.#releaseSeekReplayPlaybackPause = undefined;
+    releaseSeekReplayPlaybackPause?.();
   }
 
   #endSeekKeyframeSearch(generation?: number): void {
@@ -701,7 +863,11 @@ export class CompressedVideoController {
       const normalizedFrames = frames.map((frame) =>
         normalizeVideoMessageEvent(frame as MessageEvent<CompressedVideo>),
       );
-      const result = await this.#displayFrames(normalizedFrames, mode, options);
+      const result = await this.#displayFrames(
+        normalizedFrames,
+        mode,
+        displayOptionsForMode(mode, options),
+      );
       return this.#isCurrentGeneration(generation) && result.ok;
     } catch {
       return false;
@@ -745,6 +911,16 @@ export class CompressedVideoController {
       this.#state.lastDisplayedPublishTimeNs = toNanoSec(frameInfo.frame.timestamp);
     }
   }
+}
+
+function displayOptionsForMode(
+  mode: VideoDisplayMode,
+  options?: SetCompressedVideoFramesOptions,
+): SetCompressedVideoFramesOptions | undefined {
+  if (mode === "playback") {
+    return options;
+  }
+  return { ...options, allowIntermediateVideoFrame: false };
 }
 
 /** Collect every video frame on `topic` with a receive time within `[startTime, endTime]`. */

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts
@@ -832,6 +832,163 @@ describe("ImageRenderable", () => {
     }
   });
 
+  it("keeps the current video frame during seek replay until the target frame arrives", async () => {
+    const time = mockDateNow();
+    try {
+      const currentFrame = new MockVideoFrame() as unknown as VideoFrame;
+      const intermediateFrame = new MockVideoFrame() as unknown as VideoFrame;
+      const targetFrame = new MockVideoFrame() as unknown as VideoFrame;
+      let resolveTarget!: (result: AwaitTargetFrameResult) => void;
+      const targetPromise = new Promise<AwaitTargetFrameResult>((resolve) => {
+        resolveTarget = resolve;
+      });
+      const decodeVideoFrames = jest
+        .fn<Promise<DecodeVideoFramesResult>, [DecodeVideoFramesArgs]>()
+        .mockResolvedValueOnce({
+          type: "TargetFrame",
+          requestId: 1,
+          frame: currentFrame,
+          originalTimestamp: 1n,
+          receiveTime: 10n,
+        })
+        .mockResolvedValueOnce({
+          type: "IntermediateFrame",
+          requestId: 2,
+          frame: intermediateFrame,
+          originalTimestamp: 1n,
+          receiveTime: 10n,
+        });
+      const decoder = {
+        decodeVideoFrames,
+        awaitTargetFrame: jest.fn(async () => await targetPromise),
+        resetVideoDecoder: jest.fn(),
+        terminate: jest.fn(),
+      } as unknown as WorkerImageDecoder;
+      const renderable = new TestVideoBatchRenderable(decoder);
+
+      await expect(
+        renderable.setCompressedVideoFrames([videoFrameEvent(10n, 1, "key")]),
+      ).resolves.toEqual<ImageSetImageResult>({ ok: true });
+      expect(renderable.getDecodedImage()).toBe(currentFrame);
+      expect(renderable.userData.texture?.image).toBe(currentFrame);
+
+      time.advance(20);
+      const replayResult = renderable.setCompressedVideoFrames(
+        [videoFrameEvent(10n, 1, "key"), videoFrameEvent(20n, 2, "delta")],
+        { allowIntermediateVideoFrame: false },
+      );
+      await flushPromises();
+      await flushPromises();
+
+      expect(renderable.getDecodedImage()).toBe(currentFrame);
+      expect(renderable.userData.texture?.image).toBe(currentFrame);
+      expect((intermediateFrame as unknown as MockVideoFrame).close).toHaveBeenCalledTimes(1);
+
+      time.advance(20);
+      resolveTarget({
+        type: "TargetFrame",
+        requestId: 2,
+        frame: targetFrame,
+        originalTimestamp: 2n,
+        receiveTime: 20n,
+      });
+
+      await expect(replayResult).resolves.toEqual<ImageSetImageResult>({ ok: true });
+      expect(renderable.getDecodedImage()).toBe(targetFrame);
+      expect((currentFrame as unknown as MockVideoFrame).close).toHaveBeenCalledTimes(1);
+      expect((targetFrame as unknown as MockVideoFrame).close).not.toHaveBeenCalled();
+    } finally {
+      time.restore();
+    }
+  });
+
+  it("resolves failed seek replay when the awaited target video frame is aborted", async () => {
+    const intermediateFrame = new MockVideoFrame() as unknown as VideoFrame;
+    const decoder = {
+      decodeVideoFrames: jest.fn<Promise<DecodeVideoFramesResult>, [DecodeVideoFramesArgs]>(
+        async ({ requestId }) => ({
+          type: "IntermediateFrame",
+          requestId,
+          frame: intermediateFrame,
+          originalTimestamp: 1n,
+          receiveTime: 10n,
+        }),
+      ),
+      awaitTargetFrame: jest.fn(
+        async ({ requestId }): Promise<AwaitTargetFrameResult> => ({ type: "Aborted", requestId }),
+      ),
+      resetVideoDecoder: jest.fn(),
+      terminate: jest.fn(),
+    } as unknown as WorkerImageDecoder;
+    const renderable = new TestVideoBatchRenderable(decoder);
+
+    await expect(
+      renderable.setCompressedVideoFrames(
+        [videoFrameEvent(10n, 1, "key"), videoFrameEvent(20n, 2, "delta")],
+        { allowIntermediateVideoFrame: false },
+      ),
+    ).resolves.toEqual<ImageSetImageResult>({ ok: false });
+    expect(renderable.getDecodedImage()).toBeUndefined();
+    expect((intermediateFrame as unknown as MockVideoFrame).close).toHaveBeenCalledTimes(1);
+  });
+
+  it("times out no-intermediate seek replay when the awaited target video frame never arrives", async () => {
+    jest.useFakeTimers();
+    try {
+      const currentFrame = new MockVideoFrame() as unknown as VideoFrame;
+      const intermediateFrame = new MockVideoFrame() as unknown as VideoFrame;
+      const targetPromise = new Promise<AwaitTargetFrameResult>(() => {});
+      const decodeVideoFrames = jest
+        .fn<Promise<DecodeVideoFramesResult>, [DecodeVideoFramesArgs]>()
+        .mockResolvedValueOnce({
+          type: "TargetFrame",
+          requestId: 1,
+          frame: currentFrame,
+          originalTimestamp: 1n,
+          receiveTime: 10n,
+        })
+        .mockResolvedValueOnce({
+          type: "IntermediateFrame",
+          requestId: 2,
+          frame: intermediateFrame,
+          originalTimestamp: 1n,
+          receiveTime: 10n,
+        });
+      const decoder = {
+        decodeVideoFrames,
+        awaitTargetFrame: jest.fn(async () => await targetPromise),
+        resetVideoDecoder: jest.fn(),
+        terminate: jest.fn(),
+      } as unknown as WorkerImageDecoder;
+      const renderable = new TestVideoBatchRenderable(decoder);
+
+      await expect(
+        renderable.setCompressedVideoFrames([videoFrameEvent(10n, 1, "key")]),
+      ).resolves.toEqual<ImageSetImageResult>({ ok: true });
+
+      const replayResult = renderable.setCompressedVideoFrames(
+        [videoFrameEvent(10n, 1, "key"), videoFrameEvent(20n, 2, "delta")],
+        { allowIntermediateVideoFrame: false, targetFrameTimeoutMs: 25 },
+      );
+      await flushPromises();
+      await flushPromises();
+
+      expect(renderable.getDecodedImage()).toBe(currentFrame);
+      expect((intermediateFrame as unknown as MockVideoFrame).close).toHaveBeenCalledTimes(1);
+
+      await jest.advanceTimersByTimeAsync(25);
+      await flushPromises();
+
+      await expect(Promise.race([replayResult, Promise.resolve("pending")])).resolves.toEqual<
+        ImageSetImageResult
+      >({ ok: false });
+      expect(renderable.getDecodedImage()).toBe(currentFrame);
+      expect(decoder.resetVideoDecoder).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it("closes a late target frame when a newer image has already been requested", async () => {
     const time = mockDateNow();
     try {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts
@@ -6,6 +6,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import race from "race-as-promised";
 import * as THREE from "three";
 
 import { PinholeCameraModel } from "@foxglove/den/image";
@@ -954,10 +955,11 @@ describe("ImageRenderable", () => {
           originalTimestamp: 1n,
           receiveTime: 10n,
         });
+      const resetVideoDecoder = jest.fn();
       const decoder = {
         decodeVideoFrames,
         awaitTargetFrame: jest.fn(async () => await targetPromise),
-        resetVideoDecoder: jest.fn(),
+        resetVideoDecoder,
         terminate: jest.fn(),
       } as unknown as WorkerImageDecoder;
       const renderable = new TestVideoBatchRenderable(decoder);
@@ -979,11 +981,11 @@ describe("ImageRenderable", () => {
       await jest.advanceTimersByTimeAsync(25);
       await flushPromises();
 
-      await expect(Promise.race([replayResult, Promise.resolve("pending")])).resolves.toEqual<
-        ImageSetImageResult
-      >({ ok: false });
+      await expect(
+        race([replayResult, Promise.resolve("pending")]),
+      ).resolves.toEqual<ImageSetImageResult>({ ok: false });
       expect(renderable.getDecodedImage()).toBe(currentFrame);
-      expect(decoder.resetVideoDecoder).toHaveBeenCalledTimes(1);
+      expect(resetVideoDecoder).toHaveBeenCalledTimes(1);
     } finally {
       jest.useRealTimers();
     }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -6,6 +6,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import * as _ from "lodash-es";
+import race from "race-as-promised";
 import * as THREE from "three";
 import { assert } from "ts-essentials";
 
@@ -1151,7 +1152,7 @@ async function awaitTargetFrameWithTimeout(
 ): Promise<Awaited<ReturnType<WorkerImageDecoder["awaitTargetFrame"]>> | undefined> {
   let timeout: ReturnType<typeof setTimeout> | undefined;
   try {
-    return await Promise.race([
+    return await race([
       decoder.awaitTargetFrame({ requestId }),
       new Promise<undefined>((resolve) => {
         timeout = setTimeout(() => {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -67,6 +67,7 @@ export const IMAGE_RENDERABLE_DEFAULT_SETTINGS: ImageRenderableSettings = {
 
 const VIDEO_FORMATS = new Set(["h264", "h265"]);
 const MIN_IMAGE_RENDER_INTERVAL_MS = 16;
+const DEFAULT_TARGET_FRAME_TIMEOUT_MS = 1000;
 
 type DecodedImageResource = ImageBitmap | ImageData | VideoFrame;
 type DecodedImageResult = {
@@ -86,6 +87,7 @@ export type SetCompressedVideoFramesOptions = {
   updateImageState?: (event: CompressedVideoFrameEvent) => void;
   targetFrameTimeoutMs?: number;
   anyFrameTimeoutMs?: number;
+  allowIntermediateVideoFrame?: boolean;
 };
 
 type PendingDecodedImage = {
@@ -631,7 +633,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     entries: PendingVideoDecode[],
     options: Pick<
       SetCompressedVideoFramesOptions,
-      "targetFrameTimeoutMs" | "anyFrameTimeoutMs"
+      "targetFrameTimeoutMs" | "anyFrameTimeoutMs" | "allowIntermediateVideoFrame"
     > = {},
   ): Promise<void> {
     const requestId = ++this.#videoDecodeRequestId;
@@ -669,6 +671,21 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     }
 
     const targetEntry = entries[entries.length - 1]!;
+    if (result.type === "IntermediateFrame" && options.allowIntermediateVideoFrame === false) {
+      result.frame.close();
+      for (const entry of entries) {
+        if (entry === targetEntry) {
+          continue;
+        }
+        this.#settleVideoDecode(entry, this.#failedVideoFrameResult());
+      }
+      void this.#awaitTargetVideoFrame(decoder, requestId, targetEntry, {
+        settleTargetEntry: true,
+        targetFrameTimeoutMs: options.targetFrameTimeoutMs,
+      });
+      return;
+    }
+
     const resultEntry =
       result.type === "IntermediateFrame"
         ? targetEntry
@@ -694,14 +711,35 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     decoder: WorkerImageDecoder,
     requestId: number,
     targetEntry: PendingVideoDecode,
+    options: { settleTargetEntry?: boolean; targetFrameTimeoutMs?: number } = {},
   ): Promise<void> {
-    let result: Awaited<ReturnType<WorkerImageDecoder["awaitTargetFrame"]>>;
+    let result: Awaited<ReturnType<WorkerImageDecoder["awaitTargetFrame"]>> | undefined;
+    const timeoutMs =
+      options.settleTargetEntry === true
+        ? (options.targetFrameTimeoutMs ?? DEFAULT_TARGET_FRAME_TIMEOUT_MS)
+        : undefined;
     try {
-      result = await decoder.awaitTargetFrame({ requestId });
+      result =
+        timeoutMs != undefined
+          ? await awaitTargetFrameWithTimeout(decoder, requestId, timeoutMs)
+          : await decoder.awaitTargetFrame({ requestId });
     } catch {
+      if (options.settleTargetEntry === true) {
+        this.#settleVideoDecode(targetEntry, this.#failedVideoFrameResult());
+      }
+      return;
+    }
+    if (result == undefined) {
+      void Promise.resolve(decoder.resetVideoDecoder()).catch(() => {});
+      if (options.settleTargetEntry === true) {
+        this.#settleVideoDecode(targetEntry, this.#failedVideoFrameResult());
+      }
       return;
     }
     if (result.type !== "TargetFrame") {
+      if (options.settleTargetEntry === true) {
+        this.#settleVideoDecode(targetEntry, this.#failedVideoFrameResult());
+      }
       return;
     }
     if (
@@ -710,6 +748,14 @@ export class ImageRenderable extends Renderable<ImageUserData> {
       targetEntry.seq !== this.#receivedImageSequenceNumber
     ) {
       result.frame.close();
+      if (options.settleTargetEntry === true) {
+        this.#settleVideoDecode(targetEntry, this.#failedVideoFrameResult());
+      }
+      return;
+    }
+
+    if (options.settleTargetEntry === true) {
+      this.#settleVideoDecode(targetEntry, { image: result.frame, ok: true });
       return;
     }
 
@@ -1095,6 +1141,28 @@ function closeDecodedImageResource(resource: unknown): void {
 function closeDecodeResultFrame(result: DecodeVideoFramesResult): void {
   if (result.type === "TargetFrame" || result.type === "IntermediateFrame") {
     result.frame.close();
+  }
+}
+
+async function awaitTargetFrameWithTimeout(
+  decoder: WorkerImageDecoder,
+  requestId: number,
+  timeoutMs: number,
+): Promise<Awaited<ReturnType<WorkerImageDecoder["awaitTargetFrame"]>> | undefined> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      decoder.awaitTargetFrame({ requestId }),
+      new Promise<undefined>((resolve) => {
+        timeout = setTimeout(() => {
+          resolve(undefined);
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout != undefined) {
+      clearTimeout(timeout);
+    }
   }
 }
 

--- a/packages/studio-base/src/providers/PlaybackInteractionStateProvider.test.ts
+++ b/packages/studio-base/src/providers/PlaybackInteractionStateProvider.test.ts
@@ -10,7 +10,7 @@ import { selectIsKeyframeSearchActive } from "@foxglove/studio-base/context/Play
 import { createPlaybackInteractionStateStore } from "./PlaybackInteractionStateProvider";
 
 describe("PlaybackInteractionStateProvider", () => {
-  it("pauses playback once and resumes after the final keyframe search lock releases", () => {
+  it("pauses playback while keyframe search locks are acquired and resumes after the final release", () => {
     const store = createPlaybackInteractionStateStore();
     const pausePlayback = jest.fn();
     const startPlayback = jest.fn();
@@ -28,7 +28,7 @@ describe("PlaybackInteractionStateProvider", () => {
 
     expect(selectIsKeyframeSearchActive(store.getState())).toBe(true);
     expect(store.getState().keyframeSearchLockCount).toBe(2);
-    expect(pausePlayback).toHaveBeenCalledTimes(1);
+    expect(pausePlayback).toHaveBeenCalledTimes(2);
     expect(startPlayback).not.toHaveBeenCalled();
 
     releaseFirst();
@@ -41,7 +41,7 @@ describe("PlaybackInteractionStateProvider", () => {
 
     expect(selectIsKeyframeSearchActive(store.getState())).toBe(false);
     expect(store.getState().keyframeSearchLockCount).toBe(0);
-    expect(pausePlayback).toHaveBeenCalledTimes(1);
+    expect(pausePlayback).toHaveBeenCalledTimes(2);
     expect(startPlayback).toHaveBeenCalledTimes(1);
 
     releaseSecond();
@@ -50,7 +50,7 @@ describe("PlaybackInteractionStateProvider", () => {
     expect(startPlayback).toHaveBeenCalledTimes(1);
   });
 
-  it("does not pause or resume when the keyframe search starts while playback is paused", () => {
+  it("does not resume when the keyframe search starts while playback is paused", () => {
     const store = createPlaybackInteractionStateStore();
     const pausePlayback = jest.fn();
     const startPlayback = jest.fn();
@@ -62,11 +62,37 @@ describe("PlaybackInteractionStateProvider", () => {
     });
 
     expect(selectIsKeyframeSearchActive(store.getState())).toBe(true);
-    expect(pausePlayback).not.toHaveBeenCalled();
+    expect(pausePlayback).toHaveBeenCalledTimes(1);
 
     release();
 
     expect(selectIsKeyframeSearchActive(store.getState())).toBe(false);
     expect(startPlayback).not.toHaveBeenCalled();
+  });
+
+  it("pauses again if a later keyframe search lock observes playback active", () => {
+    const store = createPlaybackInteractionStateStore();
+    const pausePlayback = jest.fn();
+    const startPlayback = jest.fn();
+
+    const releaseFirst = store.getState().acquireKeyframeSearchLock({
+      isPlaying: false,
+      pausePlayback,
+      startPlayback,
+    });
+    const releaseSecond = store.getState().acquireKeyframeSearchLock({
+      isPlaying: true,
+      pausePlayback,
+      startPlayback,
+    });
+
+    expect(store.getState().keyframeSearchLockCount).toBe(2);
+    expect(pausePlayback).toHaveBeenCalledTimes(2);
+
+    releaseFirst();
+    releaseSecond();
+
+    expect(store.getState().keyframeSearchLockCount).toBe(0);
+    expect(startPlayback).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/studio-base/src/providers/PlaybackInteractionStateProvider.tsx
+++ b/packages/studio-base/src/providers/PlaybackInteractionStateProvider.tsx
@@ -25,9 +25,11 @@ export function createPlaybackInteractionStateStore(): StoreApi<PlaybackInteract
         const wasInactive = get().keyframeSearchLockCount === 0;
         set((store) => ({ keyframeSearchLockCount: store.keyframeSearchLockCount + 1 }));
 
-        if (wasInactive && args?.isPlaying === true && args.pausePlayback != undefined) {
+        if (args?.pausePlayback != undefined && (wasInactive || args.isPlaying === true)) {
           args.pausePlayback();
-          resumePlaybackAfterKeyframeSearch = args.startPlayback;
+        }
+        if (args?.isPlaying === true) {
+          resumePlaybackAfterKeyframeSearch ??= args.startPlayback;
         }
 
         let released = false;


### PR DESCRIPTION
## Summary
- block scrubber, time display, and child seek callbacks while keyframe search is active
- hold and release playback pause locks around seek replay and timeout-based lookback reads
- keep compressed video playback on the current frame until the seek target is reached
- add coverage for seek replay stabilization and paused playback behavior

## Testing
- Added and updated unit tests for Scrubber, PlaybackControls, CompressedVideoController, ImageMode, and ImageRenderable
- Not run (not requested)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784887696&installation_id=141984720&pr_number=1376&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1376&signature=04f1d0a99bd7f35ca1d191b3c0c97054a98072623225c2cb9c745252a9ce74e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->