### PR TITLE
[codex] Rearm H.264 playback stabilization after failed replay

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.test.ts
@@ -773,6 +773,105 @@ describe("CompressedVideoController", () => {
     ]);
   });
 
+  it("rearms playback stabilization after a failed post-seek replay", async () => {
+    const keyframe = makeVideoMessage(0n, "key");
+    const delta = makeVideoMessage(10_000_000n, "delta");
+    const firstPlaybackDelta = makeVideoMessage(20_000_000n, "delta");
+    const secondPlaybackDelta = makeVideoMessage(30_000_000n, "delta");
+    const displayFrames = jest.fn<
+      Promise<ImageSetImageResult>,
+      Parameters<CompressedVideoDisplayFrames>
+    >(async (frames, mode) => {
+      if (mode === "seek" && frameReceiveTimes(frames).at(-1) === 20_000_000n) {
+        return { ok: false };
+      }
+      return { ok: true };
+    });
+    const renderer = makeRenderer();
+    const controller = makeController({ renderer, displayFrames });
+
+    controller.processMessage(keyframe);
+    controller.processMessage(delta);
+    await flushAsyncWork();
+
+    renderer.currentTime = 10_000_000n;
+    controller.handleSeek();
+    await flushAsyncWork();
+    displayFrames.mockClear();
+
+    controller.processMessage(firstPlaybackDelta);
+    await flushAsyncWork();
+
+    expect(nonResetCalls(displayFrames).map(([frames]) => frameReceiveTimes(frames))).toEqual([
+      [0n, 10_000_000n, 20_000_000n],
+    ]);
+    expect(nonResetCalls(displayFrames).map((call) => call[1])).toEqual(["seek"]);
+
+    displayFrames.mockClear();
+    controller.processMessage(secondPlaybackDelta);
+    await flushAsyncWork();
+
+    expect(nonResetCalls(displayFrames).map(([frames]) => frameReceiveTimes(frames))).toEqual([
+      [0n, 10_000_000n, 20_000_000n, 30_000_000n],
+    ]);
+    expect(nonResetCalls(displayFrames).map((call) => call[1])).toEqual(["seek"]);
+    expect(
+      nonResetCalls(displayFrames).map((call) => call[2]?.allowIntermediateVideoFrame),
+    ).toEqual([false]);
+  });
+
+  it("retries the latest pending playback frame after a failed post-seek replay", async () => {
+    const keyframe = makeVideoMessage(0n, "key");
+    const delta = makeVideoMessage(10_000_000n, "delta");
+    const firstPlaybackDelta = makeVideoMessage(20_000_000n, "delta");
+    const secondPlaybackDelta = makeVideoMessage(30_000_000n, "delta");
+    let resolveStabilization!: (result: ImageSetImageResult) => void;
+    const stabilizationPromise = new Promise<ImageSetImageResult>((resolve) => {
+      resolveStabilization = resolve;
+    });
+    const displayFrames = jest.fn<
+      Promise<ImageSetImageResult>,
+      Parameters<CompressedVideoDisplayFrames>
+    >(async (frames, mode) => {
+      if (mode === "seek" && frameReceiveTimes(frames).at(-1) === 20_000_000n) {
+        return await stabilizationPromise;
+      }
+      return { ok: true };
+    });
+    const renderer = makeRenderer();
+    const controller = makeController({ renderer, displayFrames });
+
+    controller.processMessage(keyframe);
+    controller.processMessage(delta);
+    await flushAsyncWork();
+
+    renderer.currentTime = 10_000_000n;
+    controller.handleSeek();
+    await flushAsyncWork();
+    displayFrames.mockClear();
+
+    controller.processMessage(firstPlaybackDelta);
+    controller.processMessage(secondPlaybackDelta);
+    await flushAsyncWork();
+
+    expect(nonResetCalls(displayFrames).map(([frames]) => frameReceiveTimes(frames))).toEqual([
+      [0n, 10_000_000n, 20_000_000n],
+    ]);
+    expect(nonResetCalls(displayFrames).map((call) => call[1])).toEqual(["seek"]);
+
+    resolveStabilization({ ok: false });
+    await flushAsyncWork();
+
+    expect(nonResetCalls(displayFrames).map(([frames]) => frameReceiveTimes(frames))).toEqual([
+      [0n, 10_000_000n, 20_000_000n],
+      [0n, 10_000_000n, 20_000_000n, 30_000_000n],
+    ]);
+    expect(nonResetCalls(displayFrames).map((call) => call[1])).toEqual(["seek", "seek"]);
+    expect(
+      nonResetCalls(displayFrames).map((call) => call[2]?.allowIntermediateVideoFrame),
+    ).toEqual([false, false]);
+  });
+
   it("does not let stale lookback completion clear a newer keyframe search", async () => {
     const firstKeyframe = makeVideoMessage(0n, "key");
     const firstDelta = makeVideoMessage(10_000_000n, "delta");

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts
@@ -718,7 +718,7 @@ export class CompressedVideoController {
         return;
       }
 
-      this.#resetDecoderForReplay();
+      continuingStabilization = this.#recoverPlaybackStabilizationAfterFailure(generation, options);
     } finally {
       if (
         !continuingStabilization &&
@@ -727,6 +727,31 @@ export class CompressedVideoController {
         this.#state.playbackStabilizationInFlightGeneration = undefined;
       }
     }
+  }
+
+  #recoverPlaybackStabilizationAfterFailure(
+    generation: number,
+    options?: SetCompressedVideoFramesOptions,
+  ): boolean {
+    this.#resetDecoderForReplayableFrames();
+    this.#state.decoderResetGeneration = undefined;
+    this.#state.lastDisplayedPublishTimeNs = undefined;
+
+    const pendingReceiveTimeNs = this.#state.pendingPlaybackStabilizationReceiveTimeNs;
+    if (pendingReceiveTimeNs != undefined) {
+      this.#state.pendingPlaybackStabilizationReceiveTimeNs = undefined;
+      const pendingFrames = this.#cache.framesForReceiveTime(
+        this.#topic,
+        fromNanoSec(pendingReceiveTimeNs),
+      );
+      if (pendingFrames != undefined) {
+        void this.#displayStabilizedPlaybackFrames(pendingFrames, generation, options);
+        return true;
+      }
+    }
+
+    this.#state.playbackStabilizationGeneration = generation;
+    return false;
   }
 
   /** Smallest configured lookback window (seconds) that covers `spanNs`. */


### PR DESCRIPTION
## Summary
- Keep post-seek playback stabilization armed when a stabilization replay fails.
- Retry the latest pending playback frame through GOP replay when a newer frame arrived while the failed stabilization was in flight.
- Add regression coverage for both the re-arm and pending retry paths.

## Root cause
A failed post-seek stabilization replay called `resetDecoderForReplay()`, which cleared `playbackStabilizationGeneration` and pending stabilization state. The next playback delta frame could then go through normal single-frame playback immediately after the decoder reset, leaving H.264 without a stable reference chain.

## Test Plan
- `yarn test packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.test.ts packages/studio-base/src/providers/PlaybackInteractionStateProvider.test.ts packages/studio-base/src/components/PlaybackControls/index.test.tsx packages/studio-base/src/components/PlaybackControls/Scrubber.test.tsx packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.test.ts --runInBand`
- `yarn prettier --check packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784889816&installation_id=141984720&pr_number=1377&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1377&signature=f463fe89f2af71c11a03789736b61c25c8a67cf57bdb3c25ad2070aa1328aa9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->