### PR TITLE
[codex] fix portalled event control focus

### DIFF
--- a/packages/studio-base/src/components/PlaybackControls/Scrubber.test.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Scrubber.test.tsx
@@ -55,20 +55,32 @@ let mockSliderProps:
       onHoverOut?: () => void;
     }
   | undefined;
+let mockRenderPortalledEventsOverlay = false;
 let mockShortcutsHelpButtonRenderCount = 0;
 
-jest.mock("./EventsOverlay", () => ({
-  EventsOverlay: function MockEventsOverlay(): React.JSX.Element {
-    return (
-      <div
-        data-testid="events-overlay"
-        onPointerDown={(event) => {
-          event.stopPropagation();
-        }}
-      />
-    );
-  },
-}));
+jest.mock("./EventsOverlay", () => {
+  const { createPortal } = jest.requireActual<typeof import("react-dom")>("react-dom");
+
+  return {
+    EventsOverlay: function MockEventsOverlay(): React.JSX.Element {
+      if (mockRenderPortalledEventsOverlay) {
+        return createPortal(
+          <input aria-label="Portalled event form input" />,
+          globalThis.document.body,
+        ) as React.JSX.Element;
+      }
+
+      return (
+        <div
+          data-testid="events-overlay"
+          onPointerDown={(event) => {
+            event.stopPropagation();
+          }}
+        />
+      );
+    },
+  };
+});
 
 jest.mock("./PlaybackBarHoverTicks", () => ({
   PlaybackBarHoverTicks: function MockPlaybackBarHoverTicks(): React.JSX.Element {
@@ -211,6 +223,7 @@ function Wrapper({
 describe("<Scrubber />", () => {
   beforeEach(async () => {
     mockSliderProps = undefined;
+    mockRenderPortalledEventsOverlay = false;
     mockShortcutsHelpButtonRenderCount = 0;
     await i18n.changeLanguage("en");
   });
@@ -286,6 +299,36 @@ describe("<Scrubber />", () => {
     expect(screen.getByLabelText("Disable moment subtitles")).toBeTruthy();
     expect(within(subtitleButton).getByTestId("moment-subtitle-icon-active")).toBeTruthy();
     expect(within(subtitleButton).queryByTestId("moment-subtitle-icon-inactive")).toBeNull();
+  });
+
+  it("keeps focus inside portalled event controls when they are clicked", () => {
+    mockRenderPortalledEventsOverlay = true;
+    const requestAnimationFrame = jest
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => {
+        callback(0);
+        return 0;
+      });
+
+    try {
+      render(
+        <Wrapper eventEnabled>
+          <Scrubber onSeek={jest.fn()} />
+        </Wrapper>,
+      );
+
+      const input = screen.getByRole("textbox", { name: "Portalled event form input" });
+      input.focus();
+
+      fireEvent.pointerDown(input, {
+        clientX: 100,
+        clientY: 20,
+      });
+
+      expect(document.activeElement).toBe(input);
+    } finally {
+      requestAnimationFrame.mockRestore();
+    }
   });
 
   it("shows the moment subtitle toggle without event write permission", async () => {

--- a/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
@@ -704,6 +704,12 @@ export default function Scrubber(props: Props): React.JSX.Element {
 
   const onScrubberPointerDownCapture = useCallback(
     (event: React.PointerEvent<HTMLDivElement>): void => {
+      const scrubber = scrubberRef.current;
+      const target = event.target;
+      if (scrubber == undefined || !(target instanceof Node) || !scrubber.contains(target)) {
+        return;
+      }
+
       requestAnimationFrame(() => {
         scrubberRef.current?.focus({ preventScroll: true });
       });


### PR DESCRIPTION
## Summary
- Prevent Scrubber from stealing focus from controls rendered through React portals.
- Add a regression test covering portalled event controls keeping focus after pointer interaction.

## Root Cause
Scrubber focuses the timeline on pointer down during the capture phase so timeline keyboard shortcuts remain active. React portal events still bubble through the React tree even when the portal DOM is outside the Scrubber DOM. Because the handler did not verify that the native event target was actually inside the Scrubber element, clicking a portalled event form input refocused the timeline.

## Validation
- `yarn test packages/studio-base/src/components/PlaybackControls/Scrubber.test.tsx --runInBand`
- `yarn prettier --check packages/studio-base/src/components/PlaybackControls/Scrubber.tsx packages/studio-base/src/components/PlaybackControls/Scrubber.test.tsx`
- `yarn eslint packages/studio-base/src/components/PlaybackControls/Scrubber.tsx packages/studio-base/src/components/PlaybackControls/Scrubber.test.tsx`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784891756&installation_id=141984720&pr_number=1378&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1378&signature=891896df1d62758213fad768c379e4e13ad50eeba172339718ddfa60fc793141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->