### PR TITLE
[codex] Implement share manifest playback

### DIFF
--- a/packages/studio-base/src/components/AppBar/index.test.tsx
+++ b/packages/studio-base/src/components/AppBar/index.test.tsx
@@ -6,7 +6,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { render } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
+import { useEffect } from "react";
 
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
 import MultiProvider from "@foxglove/studio-base/components/MultiProvider";
@@ -14,6 +15,7 @@ import StudioToastProvider from "@foxglove/studio-base/components/StudioToastPro
 import AppConfigurationContext from "@foxglove/studio-base/context/AppConfigurationContext";
 import CoSceneConsoleApiContext from "@foxglove/studio-base/context/CoSceneConsoleApiContext";
 import CoSceneLayoutManagerContext from "@foxglove/studio-base/context/CoSceneLayoutManagerContext";
+import { useCoreData } from "@foxglove/studio-base/context/CoreDataContext";
 import CoScenePlaylistProvider from "@foxglove/studio-base/providers/CoScenePlaylistProvider";
 import CoreDataProvider from "@foxglove/studio-base/providers/CoreDataProvider";
 import MockCurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider/MockCurrentLayoutProvider";
@@ -28,6 +30,7 @@ import type ConsoleApi from "@foxglove/studio-base/services/api/CoSceneConsoleAp
 import { setupTestAppConfig } from "@foxglove/studio-base/test/mocks/setupTestAppConfig";
 import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
 import { makeMockAppConfiguration } from "@foxglove/studio-base/util/makeMockAppConfiguration";
+import { SHARE_MANIFEST_DATA_SOURCE_ID } from "@foxglove/studio-base/util/shareManifest";
 // MockCoSceneLayoutManager
 
 import { AppBar } from ".";
@@ -63,6 +66,16 @@ function Wrapper({ children }: React.PropsWithChildren): React.JSX.Element {
     /* eslint-enable react/jsx-key */
   ];
   return <MultiProvider providers={providers}>{children}</MultiProvider>;
+}
+
+function SelectShareManifestSource(): ReactNull {
+  const setDataSource = useCoreData((state) => state.setDataSource);
+
+  useEffect(() => {
+    setDataSource({ id: SHARE_MANIFEST_DATA_SOURCE_ID, type: "connection" });
+  }, [setDataSource]);
+
+  return ReactNull;
 }
 
 describe("<AppBar />", () => {
@@ -117,5 +130,31 @@ describe("<AppBar />", () => {
     expect(mockClose).toHaveBeenCalled();
 
     root.unmount();
+  });
+
+  it("hides the open in CoStudio button for share manifest playback", async () => {
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn().mockResolvedValue({
+      text: async () => "version: 1.0.0",
+    } as Response);
+    window.cosConfig = {
+      ...window.cosConfig,
+      COSTUDIO_DOWNLOAD_URL: "https://download.example.com",
+    };
+
+    try {
+      const root = render(
+        <Wrapper>
+          <SelectShareManifestSource />
+          <AppBar />
+        </Wrapper>,
+      );
+
+      await waitFor(() => {
+        expect(root.container.querySelector('[data-tourid="open-in-coStudio"]')).toBeNull();
+      });
+    } finally {
+      global.fetch = originalFetch;
+    }
   });
 });

--- a/packages/studio-base/src/components/AppBar/index.tsx
+++ b/packages/studio-base/src/components/AppBar/index.tsx
@@ -350,7 +350,7 @@ export function AppBar(props: AppBarProps): React.JSX.Element {
                 >
                   <SlideAdd24Regular color={theme.palette.appBar.icon} />
                 </AppBarIconButton>
-                {checkSupportCoStudioDownload() && (
+                {!isShareManifestSource && checkSupportCoStudioDownload() && (
                   <AppBarIconButton
                     title={t("openInCoStudio")}
                     aria-label={t("openInCoStudio")}

--- a/packages/studio-base/src/components/AppBar/index.tsx
+++ b/packages/studio-base/src/components/AppBar/index.tsx
@@ -31,6 +31,7 @@ import {
   useCurrentUser as useCoSceneCurrentUser,
   UserStore,
 } from "@foxglove/studio-base/context/CoSceneCurrentUserContext";
+import { CoreDataStore, useCoreData } from "@foxglove/studio-base/context/CoreDataContext";
 import {
   LayoutState,
   useCurrentLayoutSelector,
@@ -48,6 +49,7 @@ import {
 } from "@foxglove/studio-base/util/download";
 import { getDocsLink } from "@foxglove/studio-base/util/getDocsLink";
 import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
+import { SHARE_MANIFEST_DATA_SOURCE_ID } from "@foxglove/studio-base/util/shareManifest";
 
 import { AddPanelMenu } from "./AddPanelMenu";
 import { AppBarContainer } from "./AppBarContainer";
@@ -175,6 +177,7 @@ const selectRightSidebarOpen = (store: WorkspaceContextStore) => store.sidebars.
 
 const selectUser = (store: UserStore) => store.user;
 const selectLoginStatus = (state: UserStore) => state.loginStatus;
+const selectDataSource = (state: CoreDataStore) => state.dataSource;
 
 export function AppBar(props: AppBarProps): React.JSX.Element {
   const {
@@ -195,6 +198,8 @@ export function AppBar(props: AppBarProps): React.JSX.Element {
   const loginStatus = useCoSceneCurrentUser(selectLoginStatus);
 
   const { appBarLayoutButton } = useAppContext();
+  const dataSource = useCoreData(selectDataSource);
+  const isShareManifestSource = dataSource?.id === SHARE_MANIFEST_DATA_SOURCE_ID;
 
   const hasCurrentLayout = useCurrentLayoutSelector(selectHasCurrentLayout);
 
@@ -323,10 +328,10 @@ export function AppBar(props: AppBarProps): React.JSX.Element {
 
           <div className={classes.end}>
             <div className={classes.endInner} onDoubleClick={handleStopDoubleClick}>
-              {appBarLayoutButton}
+              {!isShareManifestSource && appBarLayoutButton}
               <ShardProfileSelector />
               {/* <CoSceneLayoutButtonOld /> */}
-              <CoSceneLayoutButton />
+              {!isShareManifestSource && <CoSceneLayoutButton />}
               <Stack direction="row" alignItems="center" data-tourid="sidebar-button-group">
                 <AppBarIconButton
                   className={cx({ "Mui-selected": panelMenuOpen })}

--- a/packages/studio-base/src/components/AuthlessDataSourceSyncAdapter.test.tsx
+++ b/packages/studio-base/src/components/AuthlessDataSourceSyncAdapter.test.tsx
@@ -1,0 +1,81 @@
+/** @jest-environment jsdom */
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { render, waitFor } from "@testing-library/react";
+import { useEffect } from "react";
+
+import { AuthlessDataSourceSyncAdapter } from "@foxglove/studio-base/components/AuthlessDataSourceSyncAdapter";
+import { CoreDataStore, useCoreData } from "@foxglove/studio-base/context/CoreDataContext";
+import CoreDataProvider from "@foxglove/studio-base/providers/CoreDataProvider";
+import { isAuthlessDataSource } from "@foxglove/studio-base/util/coscene";
+import { SHARE_MANIFEST_DATA_SOURCE_ID } from "@foxglove/studio-base/util/shareManifest";
+
+const selectSetDataSource = (state: CoreDataStore) => state.setDataSource;
+
+function encodeBase64Url(value: unknown): string {
+  const json = JSON.stringify(value);
+  if (json == undefined) {
+    throw new Error("Unable to encode share manifest");
+  }
+  return Buffer.from(json, "utf8").toString("base64url");
+}
+
+function SetDataSource({ sourceId }: { sourceId: string | undefined }): ReactNull {
+  const setDataSource = useCoreData(selectSetDataSource);
+  useEffect(() => {
+    setDataSource(sourceId == undefined ? undefined : { id: sourceId, type: "connection" });
+  }, [setDataSource, sourceId]);
+
+  return ReactNull;
+}
+
+function renderWithSource(sourceId: string | undefined): ReturnType<typeof render> {
+  return render(
+    <CoreDataProvider>
+      <AuthlessDataSourceSyncAdapter />
+      <SetDataSource sourceId={sourceId} />
+    </CoreDataProvider>,
+  );
+}
+
+describe("<AuthlessDataSourceSyncAdapter />", () => {
+  beforeEach(() => {
+    const manifest = encodeBase64Url({
+      version: 1,
+      expireTime: "2026-06-30T10:00:00Z",
+      links: {
+        mini_mcap: "https://mock-storage.example.com/artifacts/process.mini.mcap",
+        layout: "https://mock-storage.example.com/shares/layout.json",
+      },
+    });
+    window.history.replaceState(
+      undefined,
+      "",
+      `${window.location.origin}/viz#manifest=${manifest}`,
+    );
+  });
+
+  it("uses the current data source instead of the URL hash", async () => {
+    const { rerender } = renderWithSource("coscene-data-platform");
+
+    await waitFor(() => {
+      expect(isAuthlessDataSource()).toBe(false);
+    });
+
+    rerender(
+      <CoreDataProvider>
+        <AuthlessDataSourceSyncAdapter />
+        <SetDataSource sourceId={SHARE_MANIFEST_DATA_SOURCE_ID} />
+      </CoreDataProvider>,
+    );
+
+    await waitFor(() => {
+      expect(isAuthlessDataSource()).toBe(true);
+    });
+  });
+});

--- a/packages/studio-base/src/components/AuthlessDataSourceSyncAdapter.tsx
+++ b/packages/studio-base/src/components/AuthlessDataSourceSyncAdapter.tsx
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { useEffect } from "react";
+
+import { CoreDataStore, useCoreData } from "@foxglove/studio-base/context/CoreDataContext";
+import { setAuthlessDataSource } from "@foxglove/studio-base/util/coscene";
+import { SHARE_MANIFEST_DATA_SOURCE_ID } from "@foxglove/studio-base/util/shareManifest";
+
+const selectIsAuthlessDataSource = (state: CoreDataStore) =>
+  state.dataSource?.id === SHARE_MANIFEST_DATA_SOURCE_ID;
+
+export function AuthlessDataSourceSyncAdapter(): ReactNull {
+  const isAuthless = useCoreData(selectIsAuthlessDataSource);
+
+  useEffect(() => {
+    setAuthlessDataSource({ authless: isAuthless });
+
+    return () => {
+      setAuthlessDataSource({ authless: false });
+    };
+  }, [isAuthless]);
+
+  return ReactNull;
+}

--- a/packages/studio-base/src/components/BagView.test.tsx
+++ b/packages/studio-base/src/components/BagView.test.tsx
@@ -22,7 +22,7 @@ import {
   useCoreData,
 } from "@foxglove/studio-base/context/CoreDataContext";
 import PlayerSelectionContext from "@foxglove/studio-base/context/PlayerSelectionContext";
-import type { confirmTypes } from "@foxglove/studio-base/hooks/useConfirm";
+import type { ConfirmOptions, confirmTypes } from "@foxglove/studio-base/hooks/useConfirm";
 import CoScenePlaylistProvider from "@foxglove/studio-base/providers/CoScenePlaylistProvider";
 import CoreDataProvider from "@foxglove/studio-base/providers/CoreDataProvider";
 import MockCoSceneCurrentUserProvider from "@foxglove/studio-base/providers/MockCoSceneCurrentUserProvider";
@@ -80,7 +80,9 @@ function renderBagView({
   setExternalInitConfig: jest.Mock;
   updateUrl: jest.Mock;
 } {
-  const confirm = jest.fn(async () => confirmResult) as jest.MockedFunction<confirmTypes>;
+  const confirm: jest.MockedFunction<confirmTypes> = jest.fn(
+    async (_options: ConfirmOptions) => confirmResult,
+  );
   const selectSource = jest.fn();
   const setExternalInitConfig = jest.fn(async () => "new-key");
   const updateUrl = jest.fn();

--- a/packages/studio-base/src/components/CoSceneCurrentLayoutSyncAdapter.tsx
+++ b/packages/studio-base/src/components/CoSceneCurrentLayoutSyncAdapter.tsx
@@ -45,7 +45,7 @@ export function CurrentLayoutSyncAdapter(): ReactNull {
   const isMounted = useMountedState();
 
   useEffect(() => {
-    if (selectedLayout?.edited === true) {
+    if (selectedLayout?.edited === true && selectedLayout.transient !== true) {
       setUnsavedLayouts((old) => ({
         ...old,
         [selectedLayout.id]: selectedLayout,

--- a/packages/studio-base/src/components/DeepLinksSyncAdapter.test.tsx
+++ b/packages/studio-base/src/components/DeepLinksSyncAdapter.test.tsx
@@ -86,7 +86,7 @@ function encodeBase64Url(value: unknown): string {
 function shareUrl(expiresAt: string): { url: string; encodedManifest: string } {
   const encodedManifest = encodeBase64Url({
     version: 1,
-    expires_at: expiresAt,
+    expireTime: expiresAt,
     links: {
       mini_mcap: "https://mock-storage.example.com/artifacts/process.mini.mcap?sig=playback",
       layout: "https://mock-storage.example.com/shares/layout.json?sig=layout",

--- a/packages/studio-base/src/components/DeepLinksSyncAdapter.test.tsx
+++ b/packages/studio-base/src/components/DeepLinksSyncAdapter.test.tsx
@@ -1,0 +1,140 @@
+/** @jest-environment jsdom */
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { render, screen, waitFor } from "@testing-library/react";
+
+import { DeepLinksSyncAdapter } from "@foxglove/studio-base/components/DeepLinksSyncAdapter";
+import { SHARE_MANIFEST_DATA_SOURCE_ID } from "@foxglove/studio-base/util/shareManifest";
+
+const mockSelectSource = jest.fn();
+const mockSelectEvent = jest.fn();
+const mockSetIsReadyForSyncLayout = jest.fn();
+const mockSetLastExternalInitConfig = jest.fn();
+const mockDataSourceClose = jest.fn();
+
+jest.mock("@foxglove/studio-base/context/PlayerSelectionContext", () => ({
+  usePlayerSelection: () => ({ selectSource: mockSelectSource }),
+}));
+
+jest.mock("@foxglove/studio-base/context/CoSceneCurrentUserContext", () => ({
+  useCurrentUser: (selector: (store: unknown) => unknown) =>
+    selector({ user: undefined, loginStatus: "notLogin" }),
+}));
+
+jest.mock("@foxglove/studio-base/context/Workspace/WorkspaceContext", () => ({
+  useWorkspaceStore: (selector: (store: unknown) => unknown) =>
+    selector({ dialogs: { dataSource: { open: true } } }),
+}));
+
+jest.mock("@foxglove/studio-base/context/Workspace/useWorkspaceActions", () => ({
+  useWorkspaceActions: () => ({
+    dialogActions: { dataSource: { close: mockDataSourceClose } },
+  }),
+}));
+
+jest.mock("@foxglove/studio-base/context/EventsContext", () => ({
+  useEvents: () => mockSelectEvent,
+}));
+
+jest.mock("@foxglove/studio-base/context/CoreDataContext", () => ({
+  useCoreData: (selector: (store: unknown) => unknown) =>
+    selector({ setIsReadyForSyncLayout: mockSetIsReadyForSyncLayout }),
+}));
+
+jest.mock("@foxglove/studio-base/hooks", () => ({
+  useAppConfigurationValue: () => [undefined, mockSetLastExternalInitConfig],
+}));
+
+jest.mock("@foxglove/studio-base/components/CoreDataSyncAdapter", () => ({
+  useSetExternalInitConfig: () => jest.fn(),
+}));
+
+jest.mock("@foxglove/studio-base/context/CoSceneConsoleApiContext", () => ({
+  useConsoleApi: () => ({ getProject: jest.fn() }),
+}));
+
+jest.mock("@foxglove/studio-base/hooks/useSyncLayoutFromUrl", () => ({
+  useSyncLayoutFromUrl: jest.fn(),
+}));
+
+jest.mock("@foxglove/studio-base/hooks/useSyncTimeFromUrl", () => ({
+  useSyncTimeFromUrl: jest.fn(),
+}));
+
+jest.mock("@foxglove/studio-base/util/appConfig", () => ({
+  getDomainConfig: () => ({ webDomain: "dev.coscene.cn" }),
+}));
+
+jest.mock("@foxglove/studio-base/util/isDesktopApp", () => ({
+  __esModule: true,
+  default: () => false,
+}));
+
+function encodeBase64Url(value: unknown): string {
+  const json = JSON.stringify(value);
+  if (json == undefined) {
+    throw new Error("Unable to encode share manifest");
+  }
+  return Buffer.from(json, "utf8").toString("base64url");
+}
+
+function shareUrl(expiresAt: string): { url: string; encodedManifest: string } {
+  const encodedManifest = encodeBase64Url({
+    version: 1,
+    expires_at: expiresAt,
+    links: {
+      mini_mcap: "https://mock-storage.example.com/artifacts/process.mini.mcap?sig=playback",
+      layout: "https://mock-storage.example.com/shares/layout.json?sig=layout",
+    },
+  });
+  return {
+    url: `${window.location.origin}/viz#manifest=${encodedManifest}`,
+    encodedManifest,
+  };
+}
+
+describe("<DeepLinksSyncAdapter /> share manifest handling", () => {
+  beforeEach(() => {
+    jest.useFakeTimers({ now: new Date("2026-06-25T00:00:00Z") });
+    mockSelectSource.mockClear();
+    mockSelectEvent.mockClear();
+    mockSetIsReadyForSyncLayout.mockClear();
+    mockSetLastExternalInitConfig.mockClear();
+    mockDataSourceClose.mockClear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("initializes the hidden share manifest data source without login", async () => {
+    const { url, encodedManifest } = shareUrl("2026-06-30T10:00:00Z");
+    window.history.replaceState(undefined, "", url);
+
+    render(<DeepLinksSyncAdapter deepLinks={[url]} />);
+
+    await waitFor(() => {
+      expect(mockSelectSource).toHaveBeenCalledWith(SHARE_MANIFEST_DATA_SOURCE_ID, {
+        type: "connection",
+        params: { manifest: encodedManifest },
+      });
+    });
+    expect(mockDataSourceClose).toHaveBeenCalled();
+  });
+
+  it("shows a non-dismissible expired dialog and does not initialize playback", async () => {
+    const { url } = shareUrl("2026-06-20T10:00:00Z");
+    window.history.replaceState(undefined, "", url);
+
+    render(<DeepLinksSyncAdapter deepLinks={[url]} />);
+
+    await screen.findByText("分享链接已过期");
+    expect(mockSelectSource).not.toHaveBeenCalled();
+    expect(mockSetIsReadyForSyncLayout).not.toHaveBeenCalled();
+  });
+});

--- a/packages/studio-base/src/components/DeepLinksSyncAdapter.tsx
+++ b/packages/studio-base/src/components/DeepLinksSyncAdapter.tsx
@@ -5,6 +5,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { Dialog, DialogContent, DialogTitle, Typography } from "@mui/material";
 import * as _ from "lodash-es";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import toast from "react-hot-toast";
@@ -38,6 +39,11 @@ import { getDomainConfig } from "@foxglove/studio-base/util/appConfig";
 import { parseAppURLState } from "@foxglove/studio-base/util/appURLState";
 import { isAuthlessDataSource } from "@foxglove/studio-base/util/coscene";
 import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
+import {
+  SHARE_MANIFEST_DATA_SOURCE_ID,
+  SHARE_MANIFEST_HASH_PARAM,
+  parseShareManifestFromUrl,
+} from "@foxglove/studio-base/util/shareManifest";
 
 const log = Logger.getLogger(__filename);
 
@@ -48,6 +54,17 @@ const selectSelectEvent = (store: EventsStore) => store.selectEvent;
 const selectSetIsReadyForSyncLayout = (state: CoreDataStore) => state.setIsReadyForSyncLayout;
 
 const DEFAULT_DEEPLINKS = Object.freeze([]);
+
+function ExpiredShareManifestDialog(): React.JSX.Element {
+  return (
+    <Dialog open disableEscapeKeyDown>
+      <DialogTitle>分享链接已过期</DialogTitle>
+      <DialogContent>
+        <Typography>该分享链接已过期，请联系分享者获取新的链接。</Typography>
+      </DialogContent>
+    </Dialog>
+  );
+}
 
 /**
  * DeepLinksSyncAdapter
@@ -61,7 +78,7 @@ export function DeepLinksSyncAdapter({
   deepLinks = DEFAULT_DEEPLINKS,
 }: {
   deepLinks?: readonly string[];
-}): ReactNull {
+}): React.JSX.Element | ReactNull {
   // ========== 依赖和状态 ==========
   const { t } = useTranslation("workspace");
   const domainConfig = getDomainConfig();
@@ -83,10 +100,35 @@ export function DeepLinksSyncAdapter({
     }
 
     const url = new URL(deepLinks[0]);
+    const shareManifest = parseShareManifestFromUrl(url);
+    if (shareManifest.status === "valid") {
+      return {
+        ds: SHARE_MANIFEST_DATA_SOURCE_ID,
+        dsParams: { [SHARE_MANIFEST_HASH_PARAM]: shareManifest.encodedManifest },
+      };
+    }
+    if (shareManifest.status === "expired") {
+      return undefined;
+    }
+
     const parsedUrl = parseAppURLState(url);
 
     return parsedUrl;
   }, [deepLinks]);
+
+  const targetShareManifest = useMemo(() => {
+    if (deepLinks[0] == undefined) {
+      return undefined;
+    }
+    try {
+      const result = parseShareManifestFromUrl(new URL(deepLinks[0]));
+      return result.status === "missing" || result.status === "invalid" ? undefined : result;
+    } catch {
+      return undefined;
+    }
+  }, [deepLinks]);
+
+  const shareManifestExpired = targetShareManifest?.status === "expired";
 
   // ========== 状态管理 ==========
   // 待应用的数据源参数（只在组件挂载时从 URL 初始化一次）
@@ -249,8 +291,17 @@ export function DeepLinksSyncAdapter({
       return;
     }
 
+    if (shareManifestExpired) {
+      isSourceProcessed.current = true;
+      if (dataSourceDialog.open) {
+        dialogActions.dataSource.close();
+      }
+      setUnappliedSourceArgs(undefined);
+      return;
+    }
+
     // Authless data sources bypass the login gate.
-    const authless = isAuthlessDataSource();
+    const authless = targetShareManifest?.status === "valid" || isAuthlessDataSource();
 
     // 特殊情况：用户未登录但试图访问需要登录的数据源
     if (loginStatus === "notLogin" && unappliedSourceArgs?.ds && !authless) {
@@ -318,6 +369,8 @@ export function DeepLinksSyncAdapter({
     debouncedPleaseLoginFirstToast,
     loadLastExternalInitConfig,
     setIsReadyForSyncLayout,
+    shareManifestExpired,
+    targetShareManifest?.status,
   ]);
 
   /**
@@ -333,8 +386,8 @@ export function DeepLinksSyncAdapter({
    * 同步 layout 和播放时间
    * 这些 hooks 会等待 isReadyForSyncLayout 标志后再执行
    */
-  useSyncLayoutFromUrl(targetUrlState);
-  useSyncTimeFromUrl(targetUrlState);
+  useSyncLayoutFromUrl(shareManifestExpired ? undefined : targetUrlState);
+  useSyncTimeFromUrl(shareManifestExpired ? undefined : targetUrlState);
 
-  return ReactNull;
+  return shareManifestExpired ? <ExpiredShareManifestDialog /> : ReactNull;
 }

--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -68,6 +68,7 @@ import {
 import UserScriptPlayer from "@foxglove/studio-base/players/UserScriptPlayer";
 import { Player } from "@foxglove/studio-base/players/types";
 import { UserScripts } from "@foxglove/studio-base/types/panels";
+import { SHARE_MANIFEST_DATA_SOURCE_ID } from "@foxglove/studio-base/util/shareManifest";
 
 const log = Logger.getLogger(__filename);
 
@@ -424,13 +425,16 @@ export default function PlayerManager(
 
             constructPlayers(newPlayer);
 
-            const recentId = addRecent({
-              type: "connection",
-              sourceId: foundSource.id,
-              title: args.params?.url ?? t("onlineData"),
-              label: foundSource.displayName,
-              extra: args.params,
-            });
+            const recentId =
+              sourceId === SHARE_MANIFEST_DATA_SOURCE_ID
+                ? undefined
+                : addRecent({
+                    type: "connection",
+                    sourceId: foundSource.id,
+                    title: args.params?.url ?? t("onlineData"),
+                    label: foundSource.displayName,
+                    extra: args.params,
+                  });
 
             setDataSource({
               id: sourceId,

--- a/packages/studio-base/src/components/ShareManifestLayoutSyncAdapter.test.tsx
+++ b/packages/studio-base/src/components/ShareManifestLayoutSyncAdapter.test.tsx
@@ -1,0 +1,94 @@
+/** @jest-environment jsdom */
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { render, waitFor } from "@testing-library/react";
+
+import { ShareManifestLayoutSyncAdapter } from "@foxglove/studio-base/components/ShareManifestLayoutSyncAdapter";
+import { SHARE_MANIFEST_DATA_SOURCE_ID } from "@foxglove/studio-base/util/shareManifest";
+
+const mockSetCurrentLayout = jest.fn();
+const mockEnqueueSnackbar = jest.fn();
+
+jest.mock("@foxglove/studio-base/context/CoreDataContext", () => ({
+  useCoreData: (selector: (store: unknown) => unknown) =>
+    selector({ dataSource: { id: "coscene-share-manifest", type: "connection" } }),
+}));
+
+jest.mock("@foxglove/studio-base/context/CurrentLayoutContext", () => ({
+  useCurrentLayoutActions: () => ({ setCurrentLayout: mockSetCurrentLayout }),
+}));
+
+jest.mock("notistack", () => ({
+  useSnackbar: () => ({ enqueueSnackbar: mockEnqueueSnackbar }),
+}));
+
+function encodeBase64Url(value: unknown): string {
+  const json = JSON.stringify(value);
+  if (json == undefined) {
+    throw new Error("Unable to encode share manifest");
+  }
+  return Buffer.from(json, "utf8").toString("base64url");
+}
+
+describe("<ShareManifestLayoutSyncAdapter />", () => {
+  const layoutUrl = "https://mock-storage.example.com/shares/layout.json?sig=layout";
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.useFakeTimers({ now: new Date("2026-06-25T00:00:00Z") });
+    mockSetCurrentLayout.mockClear();
+    mockEnqueueSnackbar.mockClear();
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        layout: "RawMessages!1",
+        savedProps: { "RawMessages!1": { diffEnabled: true } },
+        globalVariables: {},
+        userNodes: {},
+      }),
+    } as Response);
+    const manifest = encodeBase64Url({
+      version: 1,
+      expires_at: "2026-06-30T10:00:00Z",
+      links: {
+        mini_mcap: "https://mock-storage.example.com/artifacts/process.mini.mcap?sig=playback",
+        layout: layoutUrl,
+      },
+    });
+    window.history.replaceState(
+      undefined,
+      "",
+      `${window.location.origin}/viz#manifest=${manifest}`,
+    );
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.useRealTimers();
+  });
+
+  it("loads the manifest layout as a transient in-memory layout", async () => {
+    render(<ShareManifestLayoutSyncAdapter />);
+
+    await waitFor(() => {
+      expect(mockSetCurrentLayout).toHaveBeenCalledWith({
+        id: "share-manifest-layout",
+        name: "Shared layout",
+        transient: true,
+        data: {
+          layout: "RawMessages!1",
+          configById: { "RawMessages!1": { diffEnabled: true } },
+          globalVariables: {},
+          userNodes: {},
+        },
+      });
+    });
+    expect(global.fetch).toHaveBeenCalledWith(layoutUrl, { signal: expect.any(AbortSignal) });
+    expect(SHARE_MANIFEST_DATA_SOURCE_ID).toBe("coscene-share-manifest");
+  });
+});

--- a/packages/studio-base/src/components/ShareManifestLayoutSyncAdapter.test.tsx
+++ b/packages/studio-base/src/components/ShareManifestLayoutSyncAdapter.test.tsx
@@ -54,7 +54,7 @@ describe("<ShareManifestLayoutSyncAdapter />", () => {
     } as Response);
     const manifest = encodeBase64Url({
       version: 1,
-      expires_at: "2026-06-30T10:00:00Z",
+      expireTime: "2026-06-30T10:00:00Z",
       links: {
         mini_mcap: "https://mock-storage.example.com/artifacts/process.mini.mcap?sig=playback",
         layout: layoutUrl,

--- a/packages/studio-base/src/components/ShareManifestLayoutSyncAdapter.tsx
+++ b/packages/studio-base/src/components/ShareManifestLayoutSyncAdapter.tsx
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { useSnackbar } from "notistack";
+import { useEffect } from "react";
+import type { MarkOptional } from "ts-essentials";
+
+import { CoreDataStore, useCoreData } from "@foxglove/studio-base/context/CoreDataContext";
+import {
+  LayoutID,
+  useCurrentLayoutActions,
+} from "@foxglove/studio-base/context/CurrentLayoutContext";
+import { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
+import { migratePanelsState } from "@foxglove/studio-base/services/migrateLayout";
+import { replaceNullWithUndefined } from "@foxglove/studio-base/util/coscene";
+import {
+  SHARE_MANIFEST_DATA_SOURCE_ID,
+  windowShareManifestParseResult,
+} from "@foxglove/studio-base/util/shareManifest";
+
+const selectDataSource = (state: CoreDataStore) => state.dataSource;
+const SHARE_LAYOUT_ID = "share-manifest-layout" as LayoutID;
+
+export function ShareManifestLayoutSyncAdapter(): ReactNull {
+  const dataSource = useCoreData(selectDataSource);
+  const { setCurrentLayout } = useCurrentLayoutActions();
+  const { enqueueSnackbar } = useSnackbar();
+
+  useEffect(() => {
+    if (dataSource?.id !== SHARE_MANIFEST_DATA_SOURCE_ID) {
+      return;
+    }
+
+    const controller = new AbortController();
+    void (async () => {
+      const manifestResult = windowShareManifestParseResult();
+      if (manifestResult.status !== "valid") {
+        return;
+      }
+
+      try {
+        const response = await fetch(manifestResult.manifest.links.layout, {
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        const rawLayout = replaceNullWithUndefined(await response.json());
+        const data = migratePanelsState(rawLayout as MarkOptional<LayoutData, "configById">);
+        setCurrentLayout({
+          id: SHARE_LAYOUT_ID,
+          name: "Shared layout",
+          data,
+          transient: true,
+        });
+      } catch (error) {
+        if (controller.signal.aborted) {
+          return;
+        }
+        enqueueSnackbar(`Shared layout could not be loaded. ${(error as Error).message}`, {
+          variant: "error",
+        });
+      }
+    })();
+
+    return () => {
+      controller.abort();
+    };
+  }, [dataSource?.id, enqueueSnackbar, setCurrentLayout]);
+
+  return ReactNull;
+}

--- a/packages/studio-base/src/components/SyncAdapters.tsx
+++ b/packages/studio-base/src/components/SyncAdapters.tsx
@@ -12,6 +12,7 @@ import { CoSceneCurrentUserSyncAdapter } from "@foxglove/studio-base/components/
 import { PlaylistSyncAdapter } from "@foxglove/studio-base/components/CoScenePlaylistSyncAdapter";
 import { CoreDataSyncAdapter } from "@foxglove/studio-base/components/CoreDataSyncAdapter";
 import { EventsSyncAdapter } from "@foxglove/studio-base/components/Events/EventsSyncAdapter";
+import { ShareManifestLayoutSyncAdapter } from "@foxglove/studio-base/components/ShareManifestLayoutSyncAdapter";
 import { SubscriptionEntitlementSyncAdapter } from "@foxglove/studio-base/components/SubscriptionEntitlementSyncAdapter";
 import { TasksSyncAdapter } from "@foxglove/studio-base/components/Tasks/TasksSyncAdapter";
 import { URLStateSyncAdapter } from "@foxglove/studio-base/components/URLStateSyncAdapter";
@@ -34,6 +35,7 @@ export function SyncAdapters(): React.JSX.Element {
         <TasksSyncAdapter />
         <PlaylistSyncAdapter />
         <URLStateSyncAdapter />
+        <ShareManifestLayoutSyncAdapter />
         <CurrentLayoutSyncAdapter />
         <CoreDataSyncAdapter />
         <SubscriptionEntitlementSyncAdapter />

--- a/packages/studio-base/src/components/SyncAdapters.tsx
+++ b/packages/studio-base/src/components/SyncAdapters.tsx
@@ -7,6 +7,7 @@
 
 import { useMemo } from "react";
 
+import { AuthlessDataSourceSyncAdapter } from "@foxglove/studio-base/components/AuthlessDataSourceSyncAdapter";
 import { CurrentLayoutSyncAdapter } from "@foxglove/studio-base/components/CoSceneCurrentLayoutSyncAdapter";
 import { CoSceneCurrentUserSyncAdapter } from "@foxglove/studio-base/components/CoSceneCurrentUserSyncAdapter";
 import { PlaylistSyncAdapter } from "@foxglove/studio-base/components/CoScenePlaylistSyncAdapter";
@@ -30,6 +31,7 @@ export function SyncAdapters(): React.JSX.Element {
 
     return (
       <>
+        <AuthlessDataSourceSyncAdapter />
         <CoSceneCurrentUserSyncAdapter />
         <EventsSyncAdapter />
         <TasksSyncAdapter />

--- a/packages/studio-base/src/context/CurrentLayoutContext/index.ts
+++ b/packages/studio-base/src/context/CurrentLayoutContext/index.ts
@@ -43,9 +43,11 @@ export type SharedPanelState = RenderState["sharedPanelState"];
 export type UpdatePanelState = (type: PanelType, data: SharedPanelState) => void;
 
 export type SelectedLayout = {
+  id?: LayoutID;
   data: LayoutData | undefined;
   name?: string;
   edited?: boolean;
+  transient?: boolean;
 };
 export type LayoutID = string & { __brand: "LayoutID" };
 
@@ -62,6 +64,7 @@ export type LayoutState = Readonly<{
         data: LayoutData | undefined;
         name?: string;
         edited?: boolean;
+        transient?: boolean;
       }
     | undefined;
 }>;

--- a/packages/studio-base/src/dataSources/CoSceneShareManifestDataSourceFactory.test.ts
+++ b/packages/studio-base/src/dataSources/CoSceneShareManifestDataSourceFactory.test.ts
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import {
+  IterablePlayer,
+  WorkerSerializedIterableSource,
+} from "@foxglove/studio-base/players/IterablePlayer";
+import { SHARE_MANIFEST_DATA_SOURCE_ID } from "@foxglove/studio-base/util/shareManifest";
+import type { ShareManifest } from "@foxglove/studio-base/util/shareManifest";
+
+import CoSceneShareManifestDataSourceFactory from "./CoSceneShareManifestDataSourceFactory";
+
+jest.mock("@foxglove/studio-base/players/IterablePlayer", () => ({
+  IterablePlayer: jest.fn().mockImplementation((options: unknown) => ({ options })),
+  WorkerSerializedIterableSource: jest.fn().mockImplementation((options: unknown) => ({
+    options,
+  })),
+}));
+
+const mockIterablePlayer = IterablePlayer as unknown as jest.Mock;
+const mockWorkerSerializedIterableSource = WorkerSerializedIterableSource as unknown as jest.Mock;
+
+function encodeBase64Url(value: unknown): string {
+  const json = JSON.stringify(value);
+  if (json == undefined) {
+    throw new Error("Unable to encode share manifest");
+  }
+  return Buffer.from(json, "utf8").toString("base64url");
+}
+
+describe("CoSceneShareManifestDataSourceFactory", () => {
+  const manifest: ShareManifest = {
+    version: 1,
+    expires_at: "2026-06-30T10:00:00Z",
+    links: {
+      mini_mcap: "https://mock-storage.example.com/artifacts/process.mini.mcap?sig=playback",
+      layout: "https://mock-storage.example.com/shares/layout.json?sig=layout",
+    },
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers({ now: new Date("2026-06-25T00:00:00Z") });
+    mockIterablePlayer.mockClear();
+    mockWorkerSerializedIterableSource.mockClear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("is a hidden authless connection source", () => {
+    const factory = new CoSceneShareManifestDataSourceFactory();
+
+    expect(factory.id).toBe(SHARE_MANIFEST_DATA_SOURCE_ID);
+    expect(factory.type).toBe("connection");
+    expect(factory.hidden).toBe(true);
+    expect((factory as { needLogin?: unknown }).needLogin).toBeUndefined();
+  });
+
+  it("uses the manifest mini_mcap URL as the remote MCAP source", () => {
+    const encodedManifest = encodeBase64Url(manifest);
+    const factory = new CoSceneShareManifestDataSourceFactory();
+
+    factory.initialize({
+      metricsCollector: undefined as never,
+      params: { manifest: encodedManifest },
+    });
+
+    expect(mockWorkerSerializedIterableSource).toHaveBeenCalledTimes(1);
+    expect(mockWorkerSerializedIterableSource.mock.calls[0]?.[0]).toMatchObject({
+      initArgs: { url: manifest.links.mini_mcap },
+    });
+    expect(mockIterablePlayer).toHaveBeenCalledTimes(1);
+    expect(mockIterablePlayer.mock.calls[0]?.[0]).toMatchObject({
+      sourceId: SHARE_MANIFEST_DATA_SOURCE_ID,
+      urlParams: { manifest: encodedManifest },
+      name: "Shared MCAP",
+    });
+    expect(mockIterablePlayer.mock.calls[0]?.[0]).not.toHaveProperty("enablePlaybackSpillCache");
+    expect(mockIterablePlayer.mock.calls[0]?.[0]).not.toHaveProperty("playbackSpillCacheSourceKey");
+  });
+
+  it("rejects expired manifests before constructing a player", () => {
+    const encodedManifest = encodeBase64Url({
+      ...manifest,
+      expires_at: "2026-06-20T10:00:00Z",
+    });
+    const factory = new CoSceneShareManifestDataSourceFactory();
+
+    expect(() =>
+      factory.initialize({
+        metricsCollector: undefined as never,
+        params: { manifest: encodedManifest },
+      }),
+    ).toThrow("Share manifest has expired");
+    expect(mockWorkerSerializedIterableSource).not.toHaveBeenCalled();
+    expect(mockIterablePlayer).not.toHaveBeenCalled();
+  });
+});

--- a/packages/studio-base/src/dataSources/CoSceneShareManifestDataSourceFactory.test.ts
+++ b/packages/studio-base/src/dataSources/CoSceneShareManifestDataSourceFactory.test.ts
@@ -79,9 +79,12 @@ describe("CoSceneShareManifestDataSourceFactory", () => {
       sourceId: SHARE_MANIFEST_DATA_SOURCE_ID,
       urlParams: { manifest: encodedManifest },
       name: "Shared MCAP",
+      enablePlaybackSpillCache: true,
+      playbackSpillCacheSourceKey: JSON.stringify({
+        sourceId: SHARE_MANIFEST_DATA_SOURCE_ID,
+        url: manifest.links.mini_mcap,
+      }),
     });
-    expect(mockIterablePlayer.mock.calls[0]?.[0]).not.toHaveProperty("enablePlaybackSpillCache");
-    expect(mockIterablePlayer.mock.calls[0]?.[0]).not.toHaveProperty("playbackSpillCacheSourceKey");
   });
 
   it("rejects expired manifests before constructing a player", () => {

--- a/packages/studio-base/src/dataSources/CoSceneShareManifestDataSourceFactory.test.ts
+++ b/packages/studio-base/src/dataSources/CoSceneShareManifestDataSourceFactory.test.ts
@@ -35,7 +35,7 @@ function encodeBase64Url(value: unknown): string {
 describe("CoSceneShareManifestDataSourceFactory", () => {
   const manifest: ShareManifest = {
     version: 1,
-    expires_at: "2026-06-30T10:00:00Z",
+    expireTime: "2026-06-30T10:00:00Z",
     links: {
       mini_mcap: "https://mock-storage.example.com/artifacts/process.mini.mcap?sig=playback",
       layout: "https://mock-storage.example.com/shares/layout.json?sig=layout",
@@ -87,7 +87,7 @@ describe("CoSceneShareManifestDataSourceFactory", () => {
   it("rejects expired manifests before constructing a player", () => {
     const encodedManifest = encodeBase64Url({
       ...manifest,
-      expires_at: "2026-06-20T10:00:00Z",
+      expireTime: "2026-06-20T10:00:00Z",
     });
     const factory = new CoSceneShareManifestDataSourceFactory();
 

--- a/packages/studio-base/src/dataSources/CoSceneShareManifestDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/CoSceneShareManifestDataSourceFactory.ts
@@ -41,6 +41,7 @@ class CoSceneShareManifestDataSourceFactory implements IDataSourceFactory {
       throw result.error;
     }
 
+    const miniMcapUrl = result.manifest.links.mini_mcap;
     const source = new WorkerSerializedIterableSource({
       initWorker: () => {
         return new Worker(
@@ -51,7 +52,7 @@ class CoSceneShareManifestDataSourceFactory implements IDataSourceFactory {
           ),
         );
       },
-      initArgs: { url: result.manifest.links.mini_mcap },
+      initArgs: { url: miniMcapUrl },
     });
 
     return new IterablePlayer({
@@ -61,6 +62,8 @@ class CoSceneShareManifestDataSourceFactory implements IDataSourceFactory {
       name: "Shared MCAP",
       urlParams: { [SHARE_MANIFEST_HASH_PARAM]: encodedManifest },
       readAheadDuration: { sec: 10, nsec: 0 },
+      enablePlaybackSpillCache: true,
+      playbackSpillCacheSourceKey: JSON.stringify({ sourceId: this.id, url: miniMcapUrl }),
     });
   }
 }

--- a/packages/studio-base/src/dataSources/CoSceneShareManifestDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/CoSceneShareManifestDataSourceFactory.ts
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import {
+  DataSourceFactoryInitializeArgs,
+  IDataSourceFactory,
+} from "@foxglove/studio-base/context/PlayerSelectionContext";
+import {
+  IterablePlayer,
+  WorkerSerializedIterableSource,
+} from "@foxglove/studio-base/players/IterablePlayer";
+import { Player } from "@foxglove/studio-base/players/types";
+import {
+  SHARE_MANIFEST_DATA_SOURCE_ID,
+  SHARE_MANIFEST_HASH_PARAM,
+  parseEncodedShareManifest,
+} from "@foxglove/studio-base/util/shareManifest";
+
+class CoSceneShareManifestDataSourceFactory implements IDataSourceFactory {
+  public id = SHARE_MANIFEST_DATA_SOURCE_ID;
+  public type: IDataSourceFactory["type"] = "connection";
+  public displayName = "Shared manifest";
+  public iconName: IDataSourceFactory["iconName"] = "FileASPX";
+  public hidden = true;
+
+  public initialize(args: DataSourceFactoryInitializeArgs): Player | undefined {
+    const encodedManifest = args.params?.[SHARE_MANIFEST_HASH_PARAM];
+    if (!encodedManifest) {
+      throw new Error("Missing share manifest argument");
+    }
+
+    const result = parseEncodedShareManifest(encodedManifest);
+    if (result.status === "expired") {
+      throw new Error("Share manifest has expired");
+    }
+    if (result.status === "invalid") {
+      throw result.error;
+    }
+
+    const source = new WorkerSerializedIterableSource({
+      initWorker: () => {
+        return new Worker(
+          // foxglove-depcheck-used: babel-plugin-transform-import-meta
+          new URL(
+            "@foxglove/studio-base/players/IterablePlayer/Mcap/McapIterableSourceWorker.worker",
+            import.meta.url,
+          ),
+        );
+      },
+      initArgs: { url: result.manifest.links.mini_mcap },
+    });
+
+    return new IterablePlayer({
+      metricsCollector: args.metricsCollector,
+      source,
+      sourceId: this.id,
+      name: "Shared MCAP",
+      urlParams: { [SHARE_MANIFEST_HASH_PARAM]: encodedManifest },
+      readAheadDuration: { sec: 10, nsec: 0 },
+    });
+  }
+}
+
+export default CoSceneShareManifestDataSourceFactory;

--- a/packages/studio-base/src/hooks/useStateToURLSynchronization.ts
+++ b/packages/studio-base/src/hooks/useStateToURLSynchronization.ts
@@ -23,7 +23,8 @@ import { AppURLState, updateAppURLState } from "@foxglove/studio-base/util/appUR
 const selectCanSeek = (ctx: MessagePipelineContext) =>
   ctx.playerState.capabilities.includes(PlayerCapabilities.playbackControl);
 const selectCurrentTime = (ctx: MessagePipelineContext) => ctx.playerState.activeData?.currentTime;
-const selectLayoutId = (layoutState: LayoutState) => layoutState.selectedLayout?.id;
+const selectLayoutIdForUrlSync = (layoutState: LayoutState) =>
+  layoutState.selectedLayout?.transient === true ? undefined : layoutState.selectedLayout?.id;
 
 function updateUrl(newState: AppURLState) {
   const newStateUrl = updateAppURLState(new URL(window.location.href), newState);
@@ -38,7 +39,7 @@ export function useStateToURLSynchronization(): void {
   const canSeek = useMessagePipeline(selectCanSeek);
   const currentTime = useMessagePipeline(selectCurrentTime);
   const [debouncedCurrentTime] = useDebounce(currentTime, 500, { maxWait: 500 });
-  const layoutId = useCurrentLayoutSelector(selectLayoutId);
+  const layoutId = useCurrentLayoutSelector(selectLayoutIdForUrlSync);
 
   // Sync layoutId with the url.
   useEffect(() => {

--- a/packages/studio-base/src/index.ts
+++ b/packages/studio-base/src/index.ts
@@ -40,6 +40,7 @@ export { default as RemoteDataSourceFactory } from "./dataSources/RemoteDataSour
 export { default as McapLocalDataSourceFactory } from "./dataSources/McapLocalDataSourceFactory";
 export { default as SampleNuscenesDataSourceFactory } from "./dataSources/SampleNuscenesDataSourceFactory";
 export { default as PersistentCacheDataSourceFactory } from "./dataSources/PersistentCacheDataSourceFactory";
+export { default as CoSceneShareManifestDataSourceFactory } from "./dataSources/CoSceneShareManifestDataSourceFactory";
 export { LaunchPreferenceValue } from "@foxglove/studio-base/types/LaunchPreferenceValue";
 export { reportError, setReportErrorHandler } from "./reportError";
 export { makeWorkspaceContextInitialState } from "./providers/WorkspaceContextProvider";

--- a/packages/studio-base/src/panels/UserScriptEditor/Editor.test.tsx
+++ b/packages/studio-base/src/panels/UserScriptEditor/Editor.test.tsx
@@ -14,7 +14,9 @@ import Editor from "./Editor";
 const mockSetCompilerOptionsSpy = jest.fn();
 const mockSetDiagnosticsOptionsSpy = jest.fn();
 const mockGetCompilerOptionsSpy = jest.fn(() => ({ allowNonTsExtensions: true, target: 99 }));
-const mockAddExtraLibSpy = jest.fn(() => ({ dispose: jest.fn() }));
+const mockAddExtraLibSpy = jest.fn((_content: string, _filePath?: string) => ({
+  dispose: jest.fn(),
+}));
 const mockReactNull = ReactNull;
 
 function mockSetCompilerOptions(...args: unknown[]): void {
@@ -29,8 +31,8 @@ function mockGetCompilerOptions(): { allowNonTsExtensions: boolean; target: numb
   return mockGetCompilerOptionsSpy();
 }
 
-function mockAddExtraLib(...args: unknown[]): { dispose: () => void } {
-  return mockAddExtraLibSpy(...args);
+function mockAddExtraLib(content: string, filePath?: string): { dispose: () => void } {
+  return mockAddExtraLibSpy(content, filePath);
 }
 
 function mockUriParse(value: string) {
@@ -134,7 +136,7 @@ describe("UserScriptEditor Editor", () => {
         autoFormatOnSave={false}
         rosLib=""
         save={jest.fn()}
-        script={{ code: "", filePath: "script.ts" }}
+        script={{ code: "", filePath: "script.ts", readOnly: false }}
         setScriptCode={jest.fn()}
         setScriptOverride={jest.fn()}
         typesLib=""

--- a/packages/studio-base/src/providers/CoreDataProvider.test.tsx
+++ b/packages/studio-base/src/providers/CoreDataProvider.test.tsx
@@ -1,0 +1,42 @@
+/** @jest-environment jsdom */
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { renderHook, act } from "@testing-library/react";
+
+import { useCoreData } from "@foxglove/studio-base/context/CoreDataContext";
+import CoreDataProvider from "@foxglove/studio-base/providers/CoreDataProvider";
+import { SHARE_MANIFEST_DATA_SOURCE_ID } from "@foxglove/studio-base/util/shareManifest";
+
+describe("CoreDataProvider", () => {
+  it("disables login-backed workspace features for share manifest playback", () => {
+    const { result } = renderHook(
+      () => ({
+        setDataSource: useCoreData((state) => state.setDataSource),
+        getEnableList: useCoreData((state) => state.getEnableList),
+      }),
+      {
+        wrapper: CoreDataProvider,
+      },
+    );
+
+    act(() => {
+      result.current.setDataSource({
+        id: SHARE_MANIFEST_DATA_SOURCE_ID,
+        type: "connection",
+      });
+    });
+
+    expect(result.current.getEnableList()).toEqual({
+      event: "DISABLE",
+      playlist: "DISABLE",
+      task: "DISABLE",
+      layoutSync: "DISABLE",
+      recordInfo: "DISABLE",
+    });
+  });
+});

--- a/packages/studio-base/src/providers/CoreDataProvider.tsx
+++ b/packages/studio-base/src/providers/CoreDataProvider.tsx
@@ -26,6 +26,7 @@ import {
   CoordinatorConfig,
 } from "@foxglove/studio-base/context/CoreDataContext";
 import { DevicesApiFactory } from "@foxglove/studio-base/services/api/CoLink";
+import { SHARE_MANIFEST_DATA_SOURCE_ID } from "@foxglove/studio-base/util/shareManifest";
 
 const defaultCoreDataStore = {
   showtUrlKey: undefined,
@@ -134,6 +135,28 @@ function CreateCoreDataStore() {
 
     getEnableList: () => {
       const { dataSource, project, externalInitConfig } = get();
+
+      if (dataSource?.id === SHARE_MANIFEST_DATA_SOURCE_ID) {
+        const next: EnableList = {
+          event: "DISABLE",
+          playlist: "DISABLE",
+          task: "DISABLE",
+          layoutSync: "DISABLE",
+          recordInfo: "DISABLE",
+        };
+        if (
+          cachedEnableList &&
+          cachedEnableList.event === next.event &&
+          cachedEnableList.playlist === next.playlist &&
+          cachedEnableList.task === next.task &&
+          cachedEnableList.layoutSync === next.layoutSync &&
+          cachedEnableList.recordInfo === next.recordInfo
+        ) {
+          return cachedEnableList;
+        }
+        cachedEnableList = next;
+        return next;
+      }
 
       const next: EnableList = {
         event:

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/MockCurrentLayoutProvider.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/MockCurrentLayoutProvider.tsx
@@ -66,13 +66,21 @@ export default function MockCurrentLayoutProvider({
 
   const setCurrentLayout = useCallback(
     (newLayout: SelectedLayout | undefined) => {
+      if (newLayout == undefined) {
+        setLayoutState({ selectedLayout: undefined });
+        return;
+      }
+      const selectedLayout: NonNullable<LayoutState["selectedLayout"]> = {
+        data: newLayout.data,
+        id: newLayout.id ?? ("mock-id" as LayoutID),
+        edited: newLayout.edited,
+        name: newLayout.name,
+      };
+      if (newLayout.transient === true) {
+        selectedLayout.transient = true;
+      }
       setLayoutState({
-        selectedLayout: {
-          data: newLayout?.data,
-          id: "mock-id" as LayoutID,
-          edited: newLayout?.edited,
-          name: newLayout?.name,
-        },
+        selectedLayout,
       });
     },
     [setLayoutState],

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.test.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.test.tsx
@@ -320,6 +320,48 @@ describe("CurrentLayoutProvider", () => {
     (console.warn as jest.Mock).mockClear();
   });
 
+  it("does not save transient layout updates into LayoutStorage", async () => {
+    jest.useFakeTimers();
+    const mockLayoutManager = makeMockLayoutManager();
+    mockLayoutManager.updateLayout.mockResolvedValue(undefined);
+
+    const { result } = renderTest({ mockLayoutManager });
+
+    await act(async () => {
+      await result.current.childMounted;
+    });
+    act(() => {
+      result.current.actions.setCurrentLayout({
+        id: "share-layout" as LayoutID,
+        data: TEST_LAYOUT,
+        name: "Shared layout",
+        transient: true,
+      });
+    });
+    act(() => {
+      result.current.actions.savePanelConfigs({
+        configs: [{ id: "ExamplePanel!1", config: { foo: "bar" } }],
+      });
+    });
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+    await act(async () => {});
+
+    expect(mockLayoutManager.updateLayout).not.toHaveBeenCalled();
+    expect(result.current.layoutState.selectedLayout).toMatchObject({
+      id: "share-layout",
+      name: "Shared layout",
+      edited: true,
+      transient: true,
+      data: {
+        configById: { "ExamplePanel!1": { foo: "bar" } },
+      },
+    });
+    jest.useRealTimers();
+    (console.warn as jest.Mock).mockClear();
+  });
+
   it("keeps identity of action functions when modifying layout", async () => {
     jest.useFakeTimers();
     const condvar = new Condvar();

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -159,6 +159,30 @@ export default function CurrentLayoutProvider({
     [enqueueSnackbar, isMounted, layoutManager, setLayoutState],
   );
 
+  const setCurrentLayout = useCallback<ICurrentLayout["actions"]["setCurrentLayout"]>(
+    (newLayout) => {
+      if (newLayout == undefined) {
+        setLayoutState({ selectedLayout: undefined });
+        return;
+      }
+      setIncompatibleLayoutVersionError(false);
+      const selectedLayout: NonNullable<LayoutState["selectedLayout"]> = {
+        loading: false,
+        id: newLayout.id ?? (uuidv4() as LayoutID),
+        data: newLayout.data,
+        name: newLayout.name,
+        edited: newLayout.edited,
+      };
+      if (newLayout.transient === true) {
+        selectedLayout.transient = true;
+      }
+      setLayoutState({
+        selectedLayout,
+      });
+    },
+    [setLayoutState],
+  );
+
   const performAction = useCallback(
     (action: PanelsActions) => {
       if (
@@ -184,6 +208,7 @@ export default function CurrentLayoutProvider({
           loading: false,
           name: layoutStateRef.current.selectedLayout.name,
           edited: true,
+          ...(layoutStateRef.current.selectedLayout.transient === true ? { transient: true } : {}),
         },
       });
     },
@@ -252,7 +277,7 @@ export default function CurrentLayoutProvider({
   const actions: ICurrentLayout["actions"] = useMemo(
     () => ({
       updateSharedPanelState,
-      setCurrentLayout: () => {},
+      setCurrentLayout,
       setSelectedLayoutId,
       getCurrentLayoutState: () => layoutStateRef.current,
 
@@ -339,7 +364,14 @@ export default function CurrentLayoutProvider({
         performAction({ type: "END_DRAG", payload });
       },
     }),
-    [analytics, performAction, setSelectedLayoutId, setSelectedPanelIds, updateSharedPanelState],
+    [
+      analytics,
+      performAction,
+      setCurrentLayout,
+      setSelectedLayoutId,
+      setSelectedPanelIds,
+      updateSharedPanelState,
+    ],
   );
 
   const value: ICurrentLayout = useShallowMemo({

--- a/packages/studio-base/src/util/coscene/index.ts
+++ b/packages/studio-base/src/util/coscene/index.ts
@@ -16,6 +16,7 @@ import { v4 as uuidv4 } from "uuid";
 import { getAppConfig } from "@foxglove/studio-base/util/appConfig";
 import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 import { ACCESS_TOKEN_NAME } from "@foxglove/studio-base/util/queries";
+import { isShareManifestUrl } from "@foxglove/studio-base/util/shareManifest";
 import { Auth } from "@foxglove/studio-desktop/src/common/types";
 
 export * from "./cosel";
@@ -23,7 +24,14 @@ export * from "./cosel";
 const authBridge = (global as { authBridge?: Auth }).authBridge;
 
 export function isAuthlessDataSource(): boolean {
-  return false;
+  if (typeof window === "undefined") {
+    return false;
+  }
+  try {
+    return isShareManifestUrl(new URL(window.location.href));
+  } catch {
+    return false;
+  }
 }
 
 // window.navigator.platform is not reliable, use this function to check os

--- a/packages/studio-base/src/util/coscene/index.ts
+++ b/packages/studio-base/src/util/coscene/index.ts
@@ -16,22 +16,19 @@ import { v4 as uuidv4 } from "uuid";
 import { getAppConfig } from "@foxglove/studio-base/util/appConfig";
 import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 import { ACCESS_TOKEN_NAME } from "@foxglove/studio-base/util/queries";
-import { isShareManifestUrl } from "@foxglove/studio-base/util/shareManifest";
 import { Auth } from "@foxglove/studio-desktop/src/common/types";
 
 export * from "./cosel";
 
 const authBridge = (global as { authBridge?: Auth }).authBridge;
+let authlessDataSource = false;
 
 export function isAuthlessDataSource(): boolean {
-  if (typeof window === "undefined") {
-    return false;
-  }
-  try {
-    return isShareManifestUrl(new URL(window.location.href));
-  } catch {
-    return false;
-  }
+  return authlessDataSource;
+}
+
+export function setAuthlessDataSource({ authless }: { authless: boolean }): void {
+  authlessDataSource = authless;
 }
 
 // window.navigator.platform is not reliable, use this function to check os

--- a/packages/studio-base/src/util/shareManifest.test.ts
+++ b/packages/studio-base/src/util/shareManifest.test.ts
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import {
+  SHARE_MANIFEST_DATA_SOURCE_ID,
+  isShareManifestUrl,
+  parseShareManifestFromUrl,
+} from "@foxglove/studio-base/util/shareManifest";
+
+function encodeBase64Url(value: unknown): string {
+  const json = JSON.stringify(value);
+  if (json == undefined) {
+    throw new Error("Unable to encode share manifest");
+  }
+  return Buffer.from(json, "utf8").toString("base64url");
+}
+
+function encodeBase64(value: unknown): string {
+  const json = JSON.stringify(value);
+  if (json == undefined) {
+    throw new Error("Unable to encode share manifest");
+  }
+  return Buffer.from(json, "utf8").toString("base64");
+}
+
+describe("share manifest URL parsing", () => {
+  const future = "2026-06-30T10:00:00Z";
+  const past = "2026-06-20T10:00:00Z";
+  const now = new Date("2026-06-25T00:00:00Z");
+
+  it("parses only the manifest hash parameter", () => {
+    const manifest = {
+      version: 1,
+      expires_at: future,
+      links: {
+        mini_mcap: "https://mock-storage.example.com/artifacts/process.mini.mcap?sig=1",
+        layout: "https://mock-storage.example.com/shares/layout.json?sig=2",
+      },
+    };
+    const encoded = encodeBase64Url(manifest);
+
+    expect(
+      parseShareManifestFromUrl(new URL(`https://example.com/viz#manifest=${encoded}`), now),
+    ).toEqual({
+      status: "valid",
+      encodedManifest: encoded,
+      manifest,
+    });
+  });
+
+  it("does not treat a bare base64 hash as a share manifest", () => {
+    const encoded = encodeBase64Url({
+      version: 1,
+      expires_at: future,
+      links: {
+        mini_mcap: "https://mock-storage.example.com/artifacts/process.mini.mcap",
+        layout: "https://mock-storage.example.com/shares/layout.json",
+      },
+    });
+
+    expect(parseShareManifestFromUrl(new URL(`https://example.com/viz#${encoded}`), now)).toEqual({
+      status: "missing",
+    });
+  });
+
+  it("rejects standard base64 manifest hash parameters", () => {
+    const encoded = encodeBase64({
+      version: 1,
+      expires_at: future,
+      links: {
+        mini_mcap: "https://mock-storage.example.com/artifacts/process.mini.mcap",
+        layout: "https://mock-storage.example.com/shares/layout.json",
+      },
+    });
+
+    expect(
+      parseShareManifestFromUrl(
+        new URL(`https://example.com/viz#manifest=${encodeURIComponent(encoded)}`),
+        now,
+      ),
+    ).toMatchObject({
+      status: "invalid",
+    });
+  });
+
+  it("returns expired before validating other manifest fields", () => {
+    const encoded = encodeBase64Url({
+      expires_at: past,
+      links: {
+        mini_mcap: "not-a-url",
+      },
+    });
+
+    expect(
+      parseShareManifestFromUrl(new URL(`https://example.com/viz#manifest=${encoded}`), now),
+    ).toEqual({
+      status: "expired",
+      encodedManifest: encoded,
+      expiresAt: past,
+    });
+  });
+
+  it("rejects malformed non-expired manifests", () => {
+    const encoded = encodeBase64Url({
+      version: 2,
+      expires_at: future,
+      links: {
+        mini_mcap: "https://mock-storage.example.com/artifacts/process.mini.mcap",
+        layout: "https://mock-storage.example.com/shares/layout.json",
+      },
+    });
+
+    expect(
+      parseShareManifestFromUrl(new URL(`https://example.com/viz#manifest=${encoded}`), now),
+    ).toMatchObject({
+      status: "invalid",
+    });
+  });
+
+  it("treats valid and expired share URLs as authless entries", () => {
+    const validEncoded = encodeBase64Url({
+      version: 1,
+      expires_at: future,
+      links: {
+        mini_mcap: "https://mock-storage.example.com/artifacts/process.mini.mcap",
+        layout: "https://mock-storage.example.com/shares/layout.json",
+      },
+    });
+    const expiredEncoded = encodeBase64Url({ expires_at: past });
+
+    expect(SHARE_MANIFEST_DATA_SOURCE_ID).toBe("coscene-share-manifest");
+    expect(
+      isShareManifestUrl(new URL(`https://example.com/viz#manifest=${validEncoded}`), now),
+    ).toBe(true);
+    expect(
+      isShareManifestUrl(new URL(`https://example.com/viz#manifest=${expiredEncoded}`), now),
+    ).toBe(true);
+    expect(isShareManifestUrl(new URL(`https://example.com/viz#${validEncoded}`), now)).toBe(false);
+  });
+});

--- a/packages/studio-base/src/util/shareManifest.test.ts
+++ b/packages/studio-base/src/util/shareManifest.test.ts
@@ -35,7 +35,7 @@ describe("share manifest URL parsing", () => {
   it("parses only the manifest hash parameter", () => {
     const manifest = {
       version: 1,
-      expires_at: future,
+      expireTime: future,
       links: {
         mini_mcap: "https://mock-storage.example.com/artifacts/process.mini.mcap?sig=1",
         layout: "https://mock-storage.example.com/shares/layout.json?sig=2",
@@ -52,10 +52,27 @@ describe("share manifest URL parsing", () => {
     });
   });
 
-  it("does not treat a bare base64 hash as a share manifest", () => {
+  it("does not accept expires_at as the expiration field", () => {
     const encoded = encodeBase64Url({
       version: 1,
       expires_at: future,
+      links: {
+        mini_mcap: "https://mock-storage.example.com/artifacts/process.mini.mcap",
+        layout: "https://mock-storage.example.com/shares/layout.json",
+      },
+    });
+
+    expect(
+      parseShareManifestFromUrl(new URL(`https://example.com/viz#manifest=${encoded}`), now),
+    ).toMatchObject({
+      status: "invalid",
+    });
+  });
+
+  it("does not treat a bare base64 hash as a share manifest", () => {
+    const encoded = encodeBase64Url({
+      version: 1,
+      expireTime: future,
       links: {
         mini_mcap: "https://mock-storage.example.com/artifacts/process.mini.mcap",
         layout: "https://mock-storage.example.com/shares/layout.json",
@@ -70,7 +87,7 @@ describe("share manifest URL parsing", () => {
   it("rejects standard base64 manifest hash parameters", () => {
     const encoded = encodeBase64({
       version: 1,
-      expires_at: future,
+      expireTime: future,
       links: {
         mini_mcap: "https://mock-storage.example.com/artifacts/process.mini.mcap",
         layout: "https://mock-storage.example.com/shares/layout.json",
@@ -89,7 +106,7 @@ describe("share manifest URL parsing", () => {
 
   it("returns expired before validating other manifest fields", () => {
     const encoded = encodeBase64Url({
-      expires_at: past,
+      expireTime: past,
       links: {
         mini_mcap: "not-a-url",
       },
@@ -100,14 +117,14 @@ describe("share manifest URL parsing", () => {
     ).toEqual({
       status: "expired",
       encodedManifest: encoded,
-      expiresAt: past,
+      expireTime: past,
     });
   });
 
   it("rejects malformed non-expired manifests", () => {
     const encoded = encodeBase64Url({
       version: 2,
-      expires_at: future,
+      expireTime: future,
       links: {
         mini_mcap: "https://mock-storage.example.com/artifacts/process.mini.mcap",
         layout: "https://mock-storage.example.com/shares/layout.json",
@@ -124,13 +141,13 @@ describe("share manifest URL parsing", () => {
   it("treats valid and expired share URLs as authless entries", () => {
     const validEncoded = encodeBase64Url({
       version: 1,
-      expires_at: future,
+      expireTime: future,
       links: {
         mini_mcap: "https://mock-storage.example.com/artifacts/process.mini.mcap",
         layout: "https://mock-storage.example.com/shares/layout.json",
       },
     });
-    const expiredEncoded = encodeBase64Url({ expires_at: past });
+    const expiredEncoded = encodeBase64Url({ expireTime: past });
 
     expect(SHARE_MANIFEST_DATA_SOURCE_ID).toBe("coscene-share-manifest");
     expect(

--- a/packages/studio-base/src/util/shareManifest.ts
+++ b/packages/studio-base/src/util/shareManifest.ts
@@ -113,10 +113,14 @@ export function parseEncodedShareManifest(
   }
 
   if (isRecord(raw)) {
-    const expireTimeMs =
-      typeof raw.expireTime === "string" ? Date.parse(raw.expireTime) : Number.NaN;
-    if (Number.isFinite(expireTimeMs) && expireTimeMs <= now.getTime()) {
-      return { status: "expired", encodedManifest, expireTime: raw.expireTime };
+    const { expireTime } = raw;
+    const expireTimeMs = typeof expireTime === "string" ? Date.parse(expireTime) : Number.NaN;
+    if (
+      typeof expireTime === "string" &&
+      Number.isFinite(expireTimeMs) &&
+      expireTimeMs <= now.getTime()
+    ) {
+      return { status: "expired", encodedManifest, expireTime };
     }
   }
 

--- a/packages/studio-base/src/util/shareManifest.ts
+++ b/packages/studio-base/src/util/shareManifest.ts
@@ -10,7 +10,7 @@ export const SHARE_MANIFEST_HASH_PARAM = "manifest";
 
 export type ShareManifest = {
   version: 1;
-  expires_at: string;
+  expireTime: string;
   links: {
     mini_mcap: string;
     layout: string;
@@ -19,7 +19,7 @@ export type ShareManifest = {
 
 export type ShareManifestParseResult =
   | { status: "missing" }
-  | { status: "expired"; encodedManifest: string; expiresAt: string }
+  | { status: "expired"; encodedManifest: string; expireTime: string }
   | { status: "invalid"; encodedManifest: string; error: Error }
   | { status: "valid"; encodedManifest: string; manifest: ShareManifest };
 
@@ -62,8 +62,8 @@ function asShareManifest(raw: unknown): ShareManifest {
   if (raw.version !== 1) {
     throw new Error("Share manifest version must be 1");
   }
-  if (typeof raw.expires_at !== "string" || Number.isNaN(Date.parse(raw.expires_at))) {
-    throw new Error("Share manifest expires_at must be a valid date string");
+  if (typeof raw.expireTime !== "string" || Number.isNaN(Date.parse(raw.expireTime))) {
+    throw new Error("Share manifest expireTime must be a valid date string");
   }
   if (!isRecord(raw.links)) {
     throw new Error("Share manifest links must be an object");
@@ -77,7 +77,7 @@ function asShareManifest(raw: unknown): ShareManifest {
 
   return {
     version: 1,
-    expires_at: raw.expires_at,
+    expireTime: raw.expireTime,
     links: {
       mini_mcap: raw.links.mini_mcap,
       layout: raw.links.layout,
@@ -112,10 +112,11 @@ export function parseEncodedShareManifest(
     };
   }
 
-  if (isRecord(raw) && typeof raw.expires_at === "string") {
-    const expiresAtMs = Date.parse(raw.expires_at);
-    if (Number.isFinite(expiresAtMs) && expiresAtMs <= now.getTime()) {
-      return { status: "expired", encodedManifest, expiresAt: raw.expires_at };
+  if (isRecord(raw)) {
+    const expireTimeMs =
+      typeof raw.expireTime === "string" ? Date.parse(raw.expireTime) : Number.NaN;
+    if (Number.isFinite(expireTimeMs) && expireTimeMs <= now.getTime()) {
+      return { status: "expired", encodedManifest, expireTime: raw.expireTime };
     }
   }
 

--- a/packages/studio-base/src/util/shareManifest.ts
+++ b/packages/studio-base/src/util/shareManifest.ts
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export const SHARE_MANIFEST_DATA_SOURCE_ID = "coscene-share-manifest";
+export const SHARE_MANIFEST_HASH_PARAM = "manifest";
+
+export type ShareManifest = {
+  version: 1;
+  expires_at: string;
+  links: {
+    mini_mcap: string;
+    layout: string;
+  };
+};
+
+export type ShareManifestParseResult =
+  | { status: "missing" }
+  | { status: "expired"; encodedManifest: string; expiresAt: string }
+  | { status: "invalid"; encodedManifest: string; error: Error }
+  | { status: "valid"; encodedManifest: string; manifest: ShareManifest };
+
+const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value != undefined && !Array.isArray(value);
+}
+
+function decodeBase64UrlJson(encoded: string): unknown {
+  if (!BASE64URL_PATTERN.test(encoded)) {
+    throw new Error("Share manifest must be base64url encoded");
+  }
+  const base64 = encoded.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), "=");
+  const binary = atob(padded);
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  const json = new TextDecoder().decode(bytes);
+  return JSON.parse(json) as unknown;
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function getManifestHashParam(url: URL): string | undefined {
+  const params = new URLSearchParams(url.hash.startsWith("#") ? url.hash.slice(1) : url.hash);
+  return params.get(SHARE_MANIFEST_HASH_PARAM) ?? undefined;
+}
+
+function asShareManifest(raw: unknown): ShareManifest {
+  if (!isRecord(raw)) {
+    throw new Error("Share manifest must be a JSON object");
+  }
+  if (raw.version !== 1) {
+    throw new Error("Share manifest version must be 1");
+  }
+  if (typeof raw.expires_at !== "string" || Number.isNaN(Date.parse(raw.expires_at))) {
+    throw new Error("Share manifest expires_at must be a valid date string");
+  }
+  if (!isRecord(raw.links)) {
+    throw new Error("Share manifest links must be an object");
+  }
+  if (typeof raw.links.mini_mcap !== "string" || !isHttpUrl(raw.links.mini_mcap)) {
+    throw new Error("Share manifest links.mini_mcap must be an HTTP(S) URL");
+  }
+  if (typeof raw.links.layout !== "string" || !isHttpUrl(raw.links.layout)) {
+    throw new Error("Share manifest links.layout must be an HTTP(S) URL");
+  }
+
+  return {
+    version: 1,
+    expires_at: raw.expires_at,
+    links: {
+      mini_mcap: raw.links.mini_mcap,
+      layout: raw.links.layout,
+    },
+  };
+}
+
+export function parseShareManifestFromUrl(
+  url: URL,
+  now: Date = new Date(),
+): ShareManifestParseResult {
+  const encodedManifest = getManifestHashParam(url);
+  if (encodedManifest == undefined || encodedManifest.length === 0) {
+    return { status: "missing" };
+  }
+
+  return parseEncodedShareManifest(encodedManifest, now);
+}
+
+export function parseEncodedShareManifest(
+  encodedManifest: string,
+  now: Date = new Date(),
+): Exclude<ShareManifestParseResult, { status: "missing" }> {
+  let raw: unknown;
+  try {
+    raw = decodeBase64UrlJson(encodedManifest);
+  } catch (error) {
+    return {
+      status: "invalid",
+      encodedManifest,
+      error: error instanceof Error ? error : new Error(String(error)),
+    };
+  }
+
+  if (isRecord(raw) && typeof raw.expires_at === "string") {
+    const expiresAtMs = Date.parse(raw.expires_at);
+    if (Number.isFinite(expiresAtMs) && expiresAtMs <= now.getTime()) {
+      return { status: "expired", encodedManifest, expiresAt: raw.expires_at };
+    }
+  }
+
+  try {
+    return { status: "valid", encodedManifest, manifest: asShareManifest(raw) };
+  } catch (error) {
+    return {
+      status: "invalid",
+      encodedManifest,
+      error: error instanceof Error ? error : new Error(String(error)),
+    };
+  }
+}
+
+export function isShareManifestUrl(url: URL, now: Date = new Date()): boolean {
+  const result = parseShareManifestFromUrl(url, now);
+  return result.status === "valid" || result.status === "expired";
+}
+
+export function windowShareManifestParseResult(): ShareManifestParseResult {
+  if (typeof window === "undefined") {
+    return { status: "missing" };
+  }
+  try {
+    return parseShareManifestFromUrl(new URL(window.location.href));
+  } catch {
+    return { status: "missing" };
+  }
+}

--- a/packages/studio-desktop/src/renderer/Root.tsx
+++ b/packages/studio-desktop/src/renderer/Root.tsx
@@ -29,12 +29,14 @@ import {
   // VelodyneDataSourceFactory,
   ConsoleApi,
   CoSceneDataPlatformDataSourceFactory,
+  CoSceneShareManifestDataSourceFactory,
   SharedProviders,
   PersistentCacheDataSourceFactory,
 } from "@foxglove/studio-base";
 import NativeAppMenuContext from "@foxglove/studio-base/context/NativeAppMenuContext";
 import NativeWindowContext from "@foxglove/studio-base/context/NativeWindowContext";
 import { getAppConfig } from "@foxglove/studio-base/util/appConfig";
+import { isShareManifestUrl } from "@foxglove/studio-base/util/shareManifest";
 
 import { DesktopExtensionLoader } from "./services/DesktopExtensionLoader";
 import { NativeAppMenu } from "./services/NativeAppMenu";
@@ -141,6 +143,7 @@ export default function Root(props: {
       new RosbridgeDataSourceFactory(),
       new Ros1SocketDataSourceFactory(),
       new CoSceneDataPlatformDataSourceFactory(),
+      new CoSceneShareManifestDataSourceFactory(),
       new Ros1LocalBagDataSourceFactory(),
       new Ros2LocalBagDataSourceFactory(),
       new UlogLocalDataSourceFactory(),
@@ -163,7 +166,9 @@ export default function Root(props: {
     // We treat presence of the `ds` or `layoutId` params as indicative of active state.
     const windowUrl = new URL(window.location.href);
     const hasActiveURLState =
-      windowUrl.searchParams.has("ds") || windowUrl.searchParams.has("layoutId");
+      windowUrl.searchParams.has("ds") ||
+      windowUrl.searchParams.has("layoutId") ||
+      isShareManifestUrl(windowUrl);
     return hasActiveURLState ? [window.location.href] : desktopBridge.getDeepLinks();
   });
 

--- a/packages/studio-web/src/WebRoot.tsx
+++ b/packages/studio-web/src/WebRoot.tsx
@@ -18,6 +18,7 @@ import {
   ConsoleApi,
   SharedProviders,
   PersistentCacheDataSourceFactory,
+  CoSceneShareManifestDataSourceFactory,
 } from "@foxglove/studio-base";
 import { StudioApp } from "@foxglove/studio-base/StudioApp";
 import { getAppConfig } from "@foxglove/studio-base/util/appConfig";
@@ -56,6 +57,7 @@ export function WebRoot(props: {
   const dataSources = useMemo(() => {
     const sources = [
       new CoSceneDataPlatformDataSourceFactory(),
+      new CoSceneShareManifestDataSourceFactory(),
       new FoxgloveWebSocketDataSourceFactory(),
       new PersistentCacheDataSourceFactory(),
     ];


### PR DESCRIPTION
## Summary
- add hidden authless `coscene-share-manifest` data source for `#manifest=<base64url>` URLs
- block expired share manifests before data source/layout initialization
- load shared layouts as transient in-memory layouts and hide login-only/share-incompatible UI

## Validation
- `yarn jest packages/studio-base/src/util/shareManifest.test.ts packages/studio-base/src/dataSources/CoSceneShareManifestDataSourceFactory.test.ts packages/studio-base/src/components/DeepLinksSyncAdapter.test.tsx packages/studio-base/src/components/ShareManifestLayoutSyncAdapter.test.tsx packages/studio-base/src/providers/CoreDataProvider.test.tsx packages/studio-base/src/providers/CurrentLayoutProvider/index.test.tsx --config packages/studio-base/jest.config.json --runInBand`
- `yarn prettier --check ...`
- `yarn eslint --config eslint.config.ci.cjs --report-unused-disable-directives ...`
- `git diff --check`

## Notes
- `yarn tsc --noEmit --project packages/studio-base/tsconfig.json` still fails on existing unrelated test type errors in `BagView.test.tsx` and `UserScriptEditor/Editor.test.tsx`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784974735&installation_id=141984720&pr_number=1379&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1379&signature=889df478973e47bc7cf067c1e3187752ccc1f65a825df0d7bc3fd7ffa52417f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->