### PR TITLE
perf(shard-manifest): decimate preload cache for high-rate topics

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
@@ -259,6 +259,8 @@ export class BlockLoader {
         start: cursorStartTime,
         end: cursorEndTime,
         consumptionType: "full",
+        // This read fills the preload cache; sources may downsample high-rate topics.
+        allowDownsampling: true,
       };
 
       // If the source provides a message cursor we use its message cursor, otherwise we make one

--- a/packages/studio-base/src/players/IterablePlayer/IIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IIterableSource.ts
@@ -84,6 +84,14 @@ export type MessageIteratorArgs = {
    * next result may be blocked on network I/O.
    */
   abortSignal?: AbortSignal;
+
+  /**
+   * Hint that this read fills the preload cache (full-range block loading) and may be downsampled
+   * by the source to bound memory for very high-rate topics. Only set by the block loader; reads
+   * that need every message (playback, message-range/backfill) leave it unset. Sources that do not
+   * downsample ignore it.
+   */
+  allowDownsampling?: boolean;
 };
 
 /**

--- a/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/ShardManifestIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/ShardManifestIterableSource.ts
@@ -9,7 +9,7 @@ import { McapIndexedReader, McapTypes } from "@mcap/core";
 
 import Logger from "@foxglove/log";
 import { loadDecompressHandlers } from "@foxglove/mcap-support";
-import { compare, fromNanoSec } from "@foxglove/rostime";
+import { compare, fromNanoSec, toNanoSec } from "@foxglove/rostime";
 import { Immutable, MessageEvent } from "@foxglove/studio";
 import {
   GetBackfillMessagesArgs,
@@ -96,6 +96,36 @@ function readAheadBytesForShard(shard: ShardEntry): number {
   return Math.max(READ_AHEAD_MIN_BYTES, Math.min(READ_AHEAD_MAX_BYTES, target));
 }
 
+// Target number of messages to keep per topic across the whole recording when
+// filling the preload cache (full-range plots). Bounds cache memory for very
+// high-rate topics (e.g. 1 kHz control streams) regardless of duration. Live
+// playback (consumptionType "partial") is never decimated.
+const PRELOAD_POINTS_BUDGET_PER_TOPIC = 12_000;
+
+// Decimate a time-ordered, merged result stream to at most one message per
+// topic per time bucket. Buckets are aligned to a global grid (startNs +
+// k*intervalNs) so the result is consistent across the block loader's per-block
+// reads. Non-message results (problems/stamps) always pass through.
+async function* decimateByTime(
+  iter: AsyncIterable<Readonly<IteratorResult<Uint8Array>>>,
+  startNs: bigint,
+  intervalNs: bigint,
+): AsyncIterableIterator<Readonly<IteratorResult<Uint8Array>>> {
+  const lastBucketByTopic = new Map<string, bigint>();
+  for await (const result of iter) {
+    if (result.type === "message-event") {
+      const t = toNanoSec(result.msgEvent.receiveTime);
+      const bucket = (t - startNs) / intervalNs;
+      const topic = result.msgEvent.topic;
+      if (lastBucketByTopic.get(topic) === bucket) {
+        continue;
+      }
+      lastBucketByTopic.set(topic, bucket);
+    }
+    yield result;
+  }
+}
+
 export class ShardManifestIterableSource implements ISerializedIterableSource {
   public readonly sourceType = "serialized";
 
@@ -105,6 +135,11 @@ export class ShardManifestIterableSource implements ISerializedIterableSource {
   #manifest?: Manifest;
   #activeShards: ShardEntry[] = [];
   #decompressHandlers?: McapTypes.DecompressHandlers;
+
+  // Overall recording time range (from the manifest), used to compute the
+  // preload-decimation grid.
+  #rangeStartNs?: bigint;
+  #rangeDurationNs?: bigint;
 
   // Promise cache so concurrent ensureOpen() calls for the same shard share
   // a single open. Resolved children are stored in #openChildren too.
@@ -276,6 +311,10 @@ export class ShardManifestIterableSource implements ISerializedIterableSource {
     const start = startNs != undefined ? fromNanoSec(startNs) : { sec: 0, nsec: 0 };
     const end = endNs != undefined ? fromNanoSec(endNs) : { sec: 0, nsec: 0 };
 
+    this.#rangeStartNs = startNs;
+    this.#rangeDurationNs =
+      startNs != undefined && endNs != undefined && endNs > startNs ? endNs - startNs : undefined;
+
     return {
       start,
       end,
@@ -429,7 +468,23 @@ export class ShardManifestIterableSource implements ISerializedIterableSource {
     if (iterators.length === 0) {
       return;
     }
-    yield* mergeShards<Uint8Array>(iterators, args.abortSignal);
+
+    const merged = mergeShards<Uint8Array>(iterators, args.abortSignal);
+
+    // Downsample only the preload/cache path ("full"); leave live playback
+    // ("partial") at full fidelity. Keeps full-range plots bounded in memory.
+    if (
+      args.consumptionType === "full" &&
+      this.#rangeStartNs != undefined &&
+      this.#rangeDurationNs != undefined
+    ) {
+      const step = this.#rangeDurationNs / BigInt(PRELOAD_POINTS_BUDGET_PER_TOPIC);
+      const intervalNs = step > 0n ? step : 1n;
+      yield* decimateByTime(merged, this.#rangeStartNs, intervalNs);
+      return;
+    }
+
+    yield* merged;
   }
 
   public async getBackfillMessages(

--- a/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/ShardManifestIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/ShardManifestIterableSource.ts
@@ -98,29 +98,34 @@ function readAheadBytesForShard(shard: ShardEntry): number {
 
 // Target number of messages to keep per topic across the whole recording when
 // filling the preload cache (full-range plots). Bounds cache memory for very
-// high-rate topics (e.g. 1 kHz control streams) regardless of duration. Live
-// playback (consumptionType "partial") is never decimated.
+// high-rate topics (e.g. 1 kHz control streams) regardless of duration. Only
+// topics whose message count exceeds this budget are decimated; live playback
+// and message-range/backfill reads are never decimated.
 const PRELOAD_POINTS_BUDGET_PER_TOPIC = 12_000;
 
-// Decimate a time-ordered, merged result stream to at most one message per
-// topic per time bucket. Buckets are aligned to a global grid (startNs +
-// k*intervalNs) so the result is consistent across the block loader's per-block
-// reads. Non-message results (problems/stamps) always pass through.
+// Decimate a time-ordered, merged result stream to at most one message per topic
+// per time bucket, using a per-topic bucket interval. Topics absent from
+// `intervalByTopic` pass through untouched. Buckets are aligned to a global grid
+// (startNs + k*interval) so the result is consistent across the block loader's
+// per-block reads. Non-message results (problems/stamps) always pass through.
 async function* decimateByTime(
   iter: AsyncIterable<Readonly<IteratorResult<Uint8Array>>>,
   startNs: bigint,
-  intervalNs: bigint,
+  intervalByTopic: ReadonlyMap<string, bigint>,
 ): AsyncIterableIterator<Readonly<IteratorResult<Uint8Array>>> {
   const lastBucketByTopic = new Map<string, bigint>();
   for await (const result of iter) {
     if (result.type === "message-event") {
-      const t = toNanoSec(result.msgEvent.receiveTime);
-      const bucket = (t - startNs) / intervalNs;
       const topic = result.msgEvent.topic;
-      if (lastBucketByTopic.get(topic) === bucket) {
-        continue;
+      const interval = intervalByTopic.get(topic);
+      if (interval != undefined) {
+        const t = toNanoSec(result.msgEvent.receiveTime);
+        const bucket = (t - startNs) / interval;
+        if (lastBucketByTopic.get(topic) === bucket) {
+          continue;
+        }
+        lastBucketByTopic.set(topic, bucket);
       }
-      lastBucketByTopic.set(topic, bucket);
     }
     yield result;
   }
@@ -136,10 +141,11 @@ export class ShardManifestIterableSource implements ISerializedIterableSource {
   #activeShards: ShardEntry[] = [];
   #decompressHandlers?: McapTypes.DecompressHandlers;
 
-  // Overall recording time range (from the manifest), used to compute the
-  // preload-decimation grid.
+  // Preload decimation grid: the recording start (bucket origin) and, for each
+  // topic that exceeds the points budget, the per-topic bucket interval (ns).
+  // Topics not in the map are never decimated.
   #rangeStartNs?: bigint;
-  #rangeDurationNs?: bigint;
+  #decimationIntervalByTopic = new Map<string, bigint>();
 
   // Promise cache so concurrent ensureOpen() calls for the same shard share
   // a single open. Resolved children are stored in #openChildren too.
@@ -311,9 +317,48 @@ export class ShardManifestIterableSource implements ISerializedIterableSource {
     const start = startNs != undefined ? fromNanoSec(startNs) : { sec: 0, nsec: 0 };
     const end = endNs != undefined ? fromNanoSec(endNs) : { sec: 0, nsec: 0 };
 
+    // Build the preload decimation grid. Per topic, sum the message count and the
+    // active time span across the active shards; only decimate topics whose count
+    // exceeds the budget. Basing the interval on active span (sum of shard spans)
+    // rather than the wall-clock range keeps gaps between shards/files from
+    // inflating the bucket width and starving full-range plots.
     this.#rangeStartNs = startNs;
-    this.#rangeDurationNs =
-      startNs != undefined && endNs != undefined && endNs > startNs ? endNs - startNs : undefined;
+    this.#decimationIntervalByTopic = new Map();
+    const countByTopic = new Map<string, number>();
+    const activeSpanNsByTopic = new Map<string, bigint>();
+    for (const shard of this.#activeShards) {
+      let shardSpanNs: bigint;
+      try {
+        shardSpanNs = BigInt(shard.timeRange.endNs) - BigInt(shard.timeRange.startNs);
+      } catch {
+        shardSpanNs = 0n;
+      }
+      if (shardSpanNs < 0n) {
+        shardSpanNs = 0n;
+      }
+      const add = (name: string, count: number) => {
+        countByTopic.set(name, (countByTopic.get(name) ?? 0) + count);
+        activeSpanNsByTopic.set(name, (activeSpanNsByTopic.get(name) ?? 0n) + shardSpanNs);
+      };
+      if (shard.kind === "tail") {
+        for (const t of shard.topics) {
+          add(t.name, t.messageCount);
+        }
+      } else if (shard.topic != undefined) {
+        add(shard.topic, shard.messageCount ?? shard.topics[0]?.messageCount ?? 0);
+      }
+    }
+    for (const [topic, count] of countByTopic) {
+      if (count <= PRELOAD_POINTS_BUDGET_PER_TOPIC) {
+        continue;
+      }
+      const spanNs = activeSpanNsByTopic.get(topic) ?? 0n;
+      if (spanNs <= 0n) {
+        continue;
+      }
+      const interval = spanNs / BigInt(PRELOAD_POINTS_BUDGET_PER_TOPIC);
+      this.#decimationIntervalByTopic.set(topic, interval > 0n ? interval : 1n);
+    }
 
     return {
       start,
@@ -471,16 +516,16 @@ export class ShardManifestIterableSource implements ISerializedIterableSource {
 
     const merged = mergeShards<Uint8Array>(iterators, args.abortSignal);
 
-    // Downsample only the preload/cache path ("full"); leave live playback
-    // ("partial") at full fidelity. Keeps full-range plots bounded in memory.
+    // Downsample only when the block loader fills the preload cache
+    // (allowDownsampling), and only for the high-rate topics in the decimation
+    // map. Live playback and message-range/backfill reads pass through at full
+    // fidelity. Keeps full-range plots bounded in memory.
     if (
-      args.consumptionType === "full" &&
+      args.allowDownsampling === true &&
       this.#rangeStartNs != undefined &&
-      this.#rangeDurationNs != undefined
+      this.#decimationIntervalByTopic.size > 0
     ) {
-      const step = this.#rangeDurationNs / BigInt(PRELOAD_POINTS_BUDGET_PER_TOPIC);
-      const intervalNs = step > 0n ? step : 1n;
-      yield* decimateByTime(merged, this.#rangeStartNs, intervalNs);
+      yield* decimateByTime(merged, this.#rangeStartNs, this.#decimationIntervalByTopic);
       return;
     }
 


### PR DESCRIPTION
## Problem

Full-range plots make the IterablePlayer block loader **preload every message** of their topics across the whole recording. For ultra-high-rate streams — e.g. a Unitree G1 record with `/lowstate` + `/lowcmd` at **~1 kHz** carrying large nested CDR structs (35 motor sub-structs + IMU) — this fills the block cache far past its size *estimate* (the estimate undercounts the real V8 heap of decoded nested objects), so the renderer grows to multiple GB and **crashes (OOM)** after a while. CPU also spikes from deserializing ~3,000 msg/s.

This only bites the shard-manifest player because it pulls the whole tail client-side (the normal data-platform path serves windowed data from the backend).

## Fix

In `ShardManifestIterableSource`, when the block loader reads (`consumptionType: "full"`), decimate the merged stream to **~12k messages per topic** across the recording, on a globally-aligned time grid so results stay consistent across the block loader's per-block reads.

- **Live playback (`consumptionType: "partial"`) and `getBackfillMessages` are untouched** — seeking and current-frame panels (3D, Image, RawMessages) keep full fidelity.
- **Low-rate topics (images, etc.) are unaffected** — they never exceed the bucket interval.
- Result: full-range plots still cover the whole timeline, but cache memory is bounded regardless of recording length / message rate.

## Trade-off

Time-decimation samples the signal, so sub-bucket spikes can be missed. Envelope-preserving (min/max) downsampling would need a field-aware pass at a layer that has decoded messages; out of scope here.

## Testing

Verified on a Unitree G1 record (276k msgs, ~3k msg/s, 47 MB zstd tail): previously crashed the tab during preload; with this change the full-range plots populate and memory stays bounded. Lint + Prettier + the existing `coScene-shard-manifest` unit tests pass. Happy to add a focused unit test for the decimation path if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785007043&installation_id=141984720&pr_number=1380&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1380&signature=316bcf10bc2590bae0c465888c2c2e9fc257982eff0e5f235c835005409be017"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->