### PR TITLE
Cherry-pick timeline scrubber improvements from bombus

### DIFF
--- a/packages/studio-base/src/components/HoverableIconButton.tsx
+++ b/packages/studio-base/src/components/HoverableIconButton.tsx
@@ -14,7 +14,10 @@ type Props = {
   color?: IconButtonProps["color"];
   activeColor?: IconButtonProps["color"];
   children?: React.ReactNode;
-} & Omit<IconButtonProps, "children" | "color">;
+  // Widen beyond the DOM `title` attribute (string) so callers can pass rich tooltip content,
+  // e.g. a label paired with keyboard-shortcut chips. Forwarded to the MUI Tooltip, not the button.
+  title?: React.ReactNode;
+} & Omit<IconButtonProps, "children" | "color" | "title">;
 
 const HoverableIconButton = forwardRef<HTMLButtonElement, Props>((props, ref) => {
   const {

--- a/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
@@ -732,8 +732,12 @@ export default function Scrubber(props: Props): React.JSX.Element {
     [beginTimelinePointerInteraction],
   );
 
+  // Attached as a non-passive native listener (see the effect below) rather than via React's
+  // `onWheel` prop: React registers wheel listeners as passive, which makes `preventDefault()` a
+  // no-op. Without it the browser's own Ctrl+wheel page-zoom fires on Windows/Linux (on macOS
+  // Ctrl+wheel isn't a page-zoom gesture, so the bug only shows up off-Mac).
   const onWheel = useCallback(
-    (event: React.WheelEvent<HTMLDivElement>): void => {
+    (event: WheelEvent): void => {
       const currentViewport = latestViewport.current;
       const target = scrubberRef.current;
       if (currentViewport == undefined || target == undefined) {
@@ -769,6 +773,19 @@ export default function Scrubber(props: Props): React.JSX.Element {
     },
     [latestViewport],
   );
+
+  // Register the wheel handler natively with `{ passive: false }` so the `preventDefault()` calls
+  // above actually suppress the browser default (Ctrl+wheel page zoom, horizontal trackpad scroll).
+  useEffect(() => {
+    const target = scrubberRef.current;
+    if (target == undefined) {
+      return;
+    }
+    target.addEventListener("wheel", onWheel, { passive: false });
+    return () => {
+      target.removeEventListener("wheel", onWheel);
+    };
+  }, [onWheel]);
 
   const zoomPercent = useMemo(
     () =>
@@ -808,6 +825,14 @@ export default function Scrubber(props: Props): React.JSX.Element {
     },
     [latestViewport, zoomAnchorSec],
   );
+
+  // After a mouse drag on the zoom slider, MUI releases focus to <body>, which sits outside the
+  // [data-timeline-scrubber] subtree. The timeline zoom shortcuts (Shift+Z, Ctrl/Cmd +/-) gate on
+  // focus being inside that subtree, so they'd go dead right after the user tweaks zoom via the
+  // slider. Return focus to the scrubber on drag-commit so the shortcuts stay active.
+  const restoreScrubberFocus = useCallback((): void => {
+    scrubberRef.current?.focus({ preventScroll: true });
+  }, []);
 
   // Keyboard zoom: Ctrl/Cmd +/- zoom in/out (anchored at the playhead), Shift+Z resets to fit.
   const zoomAnchorSecRef = useLatest(zoomAnchorSec);
@@ -918,7 +943,6 @@ export default function Scrubber(props: Props): React.JSX.Element {
     <div
       ref={scrubberRef}
       className={classes.root}
-      onWheel={onWheel}
       onPointerMoveCapture={onScrubberPointerMoveCapture}
       tabIndex={0}
       data-timeline-scrubber="true"
@@ -953,6 +977,7 @@ export default function Scrubber(props: Props): React.JSX.Element {
                 size="small"
                 value={zoomPercent ?? 0}
                 onChange={onZoomSliderChange}
+                onChangeCommitted={restoreScrubberFocus}
               />
               <Tooltip title={t("zoomIn")}>
                 <ZoomInIcon className={classes.zoomIcon} />

--- a/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
@@ -834,6 +834,12 @@ export default function Scrubber(props: Props): React.JSX.Element {
   // focus being inside that subtree, so they'd go dead right after the user tweaks zoom via the
   // slider. Return focus to the scrubber on drag-commit so the shortcuts stay active.
   const restoreScrubberFocus = useCallback((): void => {
+    // Only reclaim focus when the slider released it to <body> (the end of a pointer drag).
+    // Keyboard slider changes also fire onChangeCommitted but keep focus on the slider thumb;
+    // stealing it there would break repeated Arrow/Page/Home/End zoom adjustments.
+    if (document.activeElement !== document.body) {
+      return;
+    }
     scrubberRef.current?.focus({ preventScroll: true });
   }, []);
 

--- a/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
@@ -65,6 +65,7 @@ import { ProgressPlot } from "./ProgressPlot";
 import { ShortcutsHelpButton } from "./ShortcutsHelpButton";
 import Slider, { type ContextMenuEvent, type HoverOverEvent } from "./Slider";
 import { TIMELINE_POSITION_INDICATOR_HANDLE_HEIGHT_PX } from "./TimelinePositionIndicator";
+import TimelineScrollbar from "./TimelineScrollbar";
 import { layoutEventLanes, EVENT_LANE_HEIGHT_PX } from "./eventLanes";
 import { isTimelineKeyboardEvent } from "./timelineKeyboardFocus";
 import {
@@ -75,6 +76,7 @@ import {
   makeTimelineViewport,
   panViewportBySeconds,
   setTimelineViewportZoomPercentAtTime,
+  setViewportVisibleStartSec,
   viewportEquals,
   zoomViewportAtTime,
   type TimelineViewport,
@@ -863,6 +865,23 @@ export default function Scrubber(props: Props): React.JSX.Element {
     setViewport(defaultViewport);
   }, [defaultViewport]);
 
+  // Pan the visible window to start at the position requested by the horizontal scrollbar.
+  const onScrollbarScroll = useCallback(
+    (visibleStartSec: number): void => {
+      setViewport((oldViewport) => {
+        const sourceViewport = oldViewport ?? latestViewport.current;
+        if (sourceViewport == undefined) {
+          return oldViewport;
+        }
+        const nextViewport = setViewportVisibleStartSec(sourceViewport, visibleStartSec);
+        return viewportEquals(sourceViewport, nextViewport) ? sourceViewport : nextViewport;
+      });
+    },
+    [latestViewport],
+  );
+
+  const isZoomed = resolvedViewport != undefined && isViewportZoomed(resolvedViewport);
+
   // Zoom shortcuts only respond when focus is on the timeline scrubber, so they don't fire
   // globally (Ctrl/Cmd +/- otherwise also fights the browser's own zoom elsewhere).
   const zoomKeyDownHandlers = useMemo(
@@ -1014,6 +1033,7 @@ export default function Scrubber(props: Props): React.JSX.Element {
       <div className={classes.timelineViewport}>
         <div
           ref={timelineContentRef}
+          id="timeline-content"
           className={classes.timelineContent}
           data-testid="timeline-content"
           style={{ minHeight: timelineContentHeight }}
@@ -1084,6 +1104,13 @@ export default function Scrubber(props: Props): React.JSX.Element {
           )}
         </div>
       </div>
+      {isZoomed && (
+        <TimelineScrollbar
+          viewport={resolvedViewport}
+          onScroll={onScrollbarScroll}
+          disabled={disableControls}
+        />
+      )}
     </div>
   );
 }

--- a/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
@@ -67,6 +67,7 @@ import Slider, { type ContextMenuEvent, type HoverOverEvent } from "./Slider";
 import { TIMELINE_POSITION_INDICATOR_HANDLE_HEIGHT_PX } from "./TimelinePositionIndicator";
 import TimelineScrollbar from "./TimelineScrollbar";
 import { layoutEventLanes, EVENT_LANE_HEIGHT_PX } from "./eventLanes";
+import { MOD, SHORTCUTS, ShortcutHint } from "./keyboardShortcuts";
 import { isTimelineKeyboardEvent } from "./timelineKeyboardFocus";
 import {
   clampTimelineViewport,
@@ -362,7 +363,7 @@ function EventButton({ disableControls }: { disableControls: boolean }): React.J
       aria-label={label}
       disabled={disableControls}
       size="small"
-      title={label}
+      title={<ShortcutHint label={label} keys={SHORTCUTS.createMoment} />}
       icon={<EventIcon />}
       onClick={dispatchCreateMomentShortcut}
     />
@@ -836,6 +837,24 @@ export default function Scrubber(props: Props): React.JSX.Element {
     scrubberRef.current?.focus({ preventScroll: true });
   }, []);
 
+  // Surface the Ctrl/Cmd + scroll quick-zoom hint on the zoom slider — both on hover and while the
+  // user drags the thumb, since dragging is the moment they're most likely wanting a faster way.
+  const [zoomSliderHovered, setZoomSliderHovered] = useState(false);
+  const [zoomSliderDragging, setZoomSliderDragging] = useState(false);
+
+  const handleZoomSliderChange = useCallback(
+    (event: Event, value: number | number[]): void => {
+      setZoomSliderDragging(true);
+      onZoomSliderChange(event, value);
+    },
+    [onZoomSliderChange],
+  );
+
+  const handleZoomSliderChangeCommitted = useCallback((): void => {
+    setZoomSliderDragging(false);
+    restoreScrubberFocus();
+  }, [restoreScrubberFocus]);
+
   // Keyboard zoom: Ctrl/Cmd +/- zoom in/out (anchored at the playhead), Shift+Z resets to fit.
   const zoomAnchorSecRef = useLatest(zoomAnchorSec);
 
@@ -979,31 +998,50 @@ export default function Scrubber(props: Props): React.JSX.Element {
         <div className={classes.toolbarActions}>
           {isTimelineZoomEnabled() && (
             <div className={classes.zoomControl}>
-              <Tooltip title={t("zoomOut")}>
+              <Tooltip title={<ShortcutHint label={t("zoomOut")} keys={SHORTCUTS.zoomOut} />}>
                 <ZoomOutIcon className={classes.zoomIcon} />
               </Tooltip>
-              <MuiSlider
-                aria-label={t("timelineZoom")}
-                className={classes.zoomSlider}
-                disabled={
-                  zoomPercent == undefined ||
-                  zoomAnchorSec == undefined ||
-                  startTime == undefined ||
-                  endTime == undefined
+              <Tooltip
+                // The slider is already labeled "Timeline zoom"; surface the quick-zoom hint as a
+                // description so it doesn't override the slider's accessible name.
+                describeChild
+                open={zoomSliderHovered || zoomSliderDragging}
+                title={
+                  <ShortcutHint
+                    label={t("shortcutZoomCursor")}
+                    keys={[`${MOD} + ${t("mouseWheel")}`]}
+                  />
                 }
-                min={0}
-                max={100}
-                size="small"
-                value={zoomPercent ?? 0}
-                onChange={onZoomSliderChange}
-                onChangeCommitted={restoreScrubberFocus}
-              />
-              <Tooltip title={t("zoomIn")}>
+              >
+                <MuiSlider
+                  aria-label={t("timelineZoom")}
+                  className={classes.zoomSlider}
+                  disabled={
+                    zoomPercent == undefined ||
+                    zoomAnchorSec == undefined ||
+                    startTime == undefined ||
+                    endTime == undefined
+                  }
+                  min={0}
+                  max={100}
+                  size="small"
+                  value={zoomPercent ?? 0}
+                  onChange={handleZoomSliderChange}
+                  onChangeCommitted={handleZoomSliderChangeCommitted}
+                  onMouseEnter={() => {
+                    setZoomSliderHovered(true);
+                  }}
+                  onMouseLeave={() => {
+                    setZoomSliderHovered(false);
+                  }}
+                />
+              </Tooltip>
+              <Tooltip title={<ShortcutHint label={t("zoomIn")} keys={SHORTCUTS.zoomIn} />}>
                 <ZoomInIcon className={classes.zoomIcon} />
               </Tooltip>
               <HoverableIconButton
                 size="small"
-                title={t("shortcutZoomFit")}
+                title={<ShortcutHint label={t("shortcutZoomFit")} keys={SHORTCUTS.zoomFit} />}
                 aria-label={t("shortcutZoomFit")}
                 icon={<FitScreenIcon fontSize="small" />}
                 onClick={resetZoom}

--- a/packages/studio-base/src/components/PlaybackControls/ShortcutsHelpButton.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/ShortcutsHelpButton.tsx
@@ -7,14 +7,13 @@
 
 import KeyboardIcon from "@mui/icons-material/KeyboardOutlined";
 import { Dialog, DialogContent, DialogTitle, Typography } from "@mui/material";
-import { Fragment, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { makeStyles } from "tss-react/mui";
 
 import HoverableIconButton from "@foxglove/studio-base/components/HoverableIconButton";
 
-const isMac = typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.userAgent);
-const MOD = isMac ? "⌘" : "Ctrl";
+import { MOD, SHORTCUTS, ShortcutKeys } from "./keyboardShortcuts";
 
 const useStyles = makeStyles()((theme) => ({
   section: {
@@ -40,26 +39,6 @@ const useStyles = makeStyles()((theme) => ({
   label: {
     color: theme.palette.text.primary,
   },
-  keyGroup: {
-    alignItems: "center",
-    display: "inline-flex",
-    flex: "0 0 auto",
-    gap: theme.spacing(0.5),
-  },
-  keySeparator: {
-    color: theme.palette.text.secondary,
-  },
-  key: {
-    backgroundColor: theme.palette.action.hover,
-    border: `1px solid ${theme.palette.divider}`,
-    borderRadius: 4,
-    color: theme.palette.text.primary,
-    fontFamily: theme.typography.fontMonospace,
-    fontSize: theme.typography.pxToRem(12),
-    paddingBlock: theme.spacing(0.25),
-    paddingInline: theme.spacing(0.75),
-    whiteSpace: "nowrap",
-  },
 }));
 
 export function ShortcutsHelpButton(): React.JSX.Element {
@@ -67,34 +46,34 @@ export function ShortcutsHelpButton(): React.JSX.Element {
   const { t } = useTranslation("general");
   const [open, setOpen] = useState(false);
 
-  // Each row's `keys` is a list of interchangeable shortcuts rendered as separate key chips
-  // joined by a "/" — e.g. ["←", "→"] reads "← / →". Combined chords stay one chip ("Alt + 1").
+  // Rows reference the shared SHORTCUTS definitions so the dialog stays in sync with the per-control
+  // tooltips. The zoom-at-cursor row interpolates the localized "scroll" word, so it's built here.
   const sections = useMemo(
     () =>
       [
         {
           titleKey: "shortcutsSectionPlayback",
           rows: [
-            { keys: ["Space"], labelKey: "shortcutPlayPause" },
-            { keys: ["←", "→"], labelKey: "shortcutSeekStep" },
-            { keys: ["−", "+"], labelKey: "shortcutPlaybackSpeed" },
+            { keys: SHORTCUTS.playPause, labelKey: "shortcutPlayPause" },
+            { keys: SHORTCUTS.seekStep, labelKey: "shortcutSeekStep" },
+            { keys: SHORTCUTS.playbackSpeed, labelKey: "shortcutPlaybackSpeed" },
           ],
         },
         {
           titleKey: "shortcutsSectionMoments",
           rows: [
-            { keys: ["↑", "↓"], labelKey: "shortcutSelectMoment" },
-            { keys: ["Enter"], labelKey: "shortcutSeekToMoment" },
-            { keys: ["Alt + 1"], labelKey: "shortcutCreateMoment" },
-            { keys: ["I", "O"], labelKey: "shortcutSetInOut" },
-            { keys: ["Delete", "Backspace"], labelKey: "shortcutDeleteMoment" },
+            { keys: SHORTCUTS.selectMoment, labelKey: "shortcutSelectMoment" },
+            { keys: SHORTCUTS.seekToMoment, labelKey: "shortcutSeekToMoment" },
+            { keys: SHORTCUTS.createMoment, labelKey: "shortcutCreateMoment" },
+            { keys: SHORTCUTS.setInOut, labelKey: "shortcutSetInOut" },
+            { keys: SHORTCUTS.deleteMoment, labelKey: "shortcutDeleteMoment" },
           ],
         },
         {
           titleKey: "shortcutsSectionTimeline",
           rows: [
-            { keys: [`${MOD} + =`, `${MOD} + −`], labelKey: "shortcutZoom" },
-            { keys: ["Shift + Z"], labelKey: "shortcutZoomFit" },
+            { keys: SHORTCUTS.zoom, labelKey: "shortcutZoom" },
+            { keys: SHORTCUTS.zoomFit, labelKey: "shortcutZoomFit" },
             { keys: [`${MOD} + ${t("mouseWheel")}`], labelKey: "shortcutZoomCursor" },
           ],
         },
@@ -133,14 +112,7 @@ export function ShortcutsHelpButton(): React.JSX.Element {
                   <Typography variant="body2" className={classes.label}>
                     {t(row.labelKey)}
                   </Typography>
-                  <div className={classes.keyGroup}>
-                    {row.keys.map((key, index) => (
-                      <Fragment key={key}>
-                        {index > 0 && <span className={classes.keySeparator}>/</span>}
-                        <span className={classes.key}>{key}</span>
-                      </Fragment>
-                    ))}
-                  </div>
+                  <ShortcutKeys keys={row.keys} />
                 </div>
               ))}
             </div>

--- a/packages/studio-base/src/components/PlaybackControls/TimelineScrollbar.test.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/TimelineScrollbar.test.tsx
@@ -1,0 +1,161 @@
+/** @jest-environment jsdom */
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import TimelineScrollbar from "./TimelineScrollbar";
+import { makeTimelineViewport, type TimelineViewport } from "./timelineViewport";
+
+describe("<TimelineScrollbar />", () => {
+  // Visible window 20-40 of a 0-100 recording: thumb covers 20% of the track starting at 20%.
+  const zoomedViewport: TimelineViewport = {
+    ...makeTimelineViewport(0, 100),
+    visibleStartSec: 20,
+    visibleEndSec: 40,
+  };
+
+  function mockTrackRect(track: HTMLElement): void {
+    jest.spyOn(track, "getBoundingClientRect").mockReturnValue({
+      bottom: 12,
+      height: 8,
+      left: 0,
+      right: 200,
+      top: 0,
+      width: 200,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+  }
+
+  function firePointerEvent(target: Element | Window, type: string, clientX: number): void {
+    fireEvent(target, new MouseEvent(type, { bubbles: true, clientX }));
+  }
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("positions the thumb to mirror the visible window", () => {
+    render(<TimelineScrollbar viewport={zoomedViewport} onScroll={jest.fn()} />);
+
+    const thumb = screen.getByTestId("timeline-scrollbar-thumb");
+    expect(thumb.style.left).toBe("20%");
+    expect(thumb.style.width).toBe("20%");
+    expect(thumb.getAttribute("role")).toBe("scrollbar");
+    // Progress through the scrollable range: 0.2 / (1 - 0.2) = 25%.
+    expect(thumb.getAttribute("aria-valuenow")).toBe("25");
+  });
+
+  it("centers the visible window under a track click", () => {
+    const onScroll = jest.fn();
+    render(<TimelineScrollbar viewport={zoomedViewport} onScroll={onScroll} />);
+
+    const track = screen.getByTestId("timeline-scrollbar");
+    mockTrackRect(track);
+
+    // Click at 75% of the track: the 20s window should recenter there → starts at 65s.
+    firePointerEvent(track, "pointerdown", 150);
+
+    expect(onScroll).toHaveBeenLastCalledWith(65);
+  });
+
+  it("pans the visible window while dragging the thumb", () => {
+    const onScroll = jest.fn();
+    render(<TimelineScrollbar viewport={zoomedViewport} onScroll={onScroll} />);
+
+    const track = screen.getByTestId("timeline-scrollbar");
+    mockTrackRect(track);
+
+    // Grab the thumb (its left edge sits at 40px) and drag right by 40px (= 20s of a 100s range).
+    firePointerEvent(track, "pointerdown", 50);
+    firePointerEvent(window, "pointermove", 90);
+
+    expect(onScroll).toHaveBeenLastCalledWith(40);
+
+    // Releasing detaches the window listeners so later moves are ignored.
+    firePointerEvent(window, "pointerup", 90);
+    onScroll.mockClear();
+    firePointerEvent(window, "pointermove", 10);
+    expect(onScroll).not.toHaveBeenCalled();
+  });
+
+  it("clamps the visible window to the recording bounds", () => {
+    const onScroll = jest.fn();
+    render(<TimelineScrollbar viewport={zoomedViewport} onScroll={onScroll} />);
+
+    const track = screen.getByTestId("timeline-scrollbar");
+    mockTrackRect(track);
+
+    // Click far past the right edge: the window can start no later than 80s (100s - 20s window).
+    firePointerEvent(track, "pointerdown", 400);
+
+    expect(onScroll).toHaveBeenLastCalledWith(80);
+  });
+
+  it("can pan to the end when the thumb is clamped to its minimum width", () => {
+    // Visible window 95-100 of 100: proportional thumb is 5% (10px on a 200px track), so the 24px
+    // minimum kicks in and the thumb travel is 200 - 24 = 176px (not the full track).
+    const onScroll = jest.fn();
+    const endViewport: TimelineViewport = {
+      ...makeTimelineViewport(0, 100),
+      visibleStartSec: 95,
+      visibleEndSec: 100,
+    };
+    render(<TimelineScrollbar viewport={endViewport} onScroll={onScroll} />);
+
+    const track = screen.getByTestId("timeline-scrollbar");
+    mockTrackRect(track);
+
+    // Thumb sits at its rightmost (left 176px); grabbing its center (188px) must keep it at the end
+    // rather than snapping backward (the bug was emitting ~88 because it divided by full width).
+    fireEvent(track, new MouseEvent("pointerdown", { bubbles: true, clientX: 188 }));
+
+    expect(onScroll).toHaveBeenLastCalledWith(95);
+  });
+
+  it("pans with the keyboard when the thumb is focused", () => {
+    const onScroll = jest.fn();
+    render(<TimelineScrollbar viewport={zoomedViewport} onScroll={onScroll} />);
+
+    const thumb = screen.getByTestId("timeline-scrollbar-thumb");
+    expect(thumb.getAttribute("tabindex")).toBe("0");
+
+    // Window is 20-40 (duration 20); ArrowRight nudges by 10% of the window = 2s → starts at 22.
+    fireEvent.keyDown(thumb, { key: "ArrowRight" });
+    expect(onScroll).toHaveBeenLastCalledWith(22);
+
+    fireEvent.keyDown(thumb, { key: "ArrowLeft" });
+    expect(onScroll).toHaveBeenLastCalledWith(18);
+
+    // PageDown advances a full window width.
+    fireEvent.keyDown(thumb, { key: "PageDown" });
+    expect(onScroll).toHaveBeenLastCalledWith(40);
+
+    fireEvent.keyDown(thumb, { key: "Home" });
+    expect(onScroll).toHaveBeenLastCalledWith(0);
+
+    fireEvent.keyDown(thumb, { key: "End" });
+    expect(onScroll).toHaveBeenLastCalledWith(100);
+  });
+
+  it("ignores interaction when disabled", () => {
+    const onScroll = jest.fn();
+    render(<TimelineScrollbar viewport={zoomedViewport} onScroll={onScroll} disabled />);
+
+    const track = screen.getByTestId("timeline-scrollbar");
+    mockTrackRect(track);
+
+    firePointerEvent(track, "pointerdown", 150);
+    fireEvent.keyDown(screen.getByTestId("timeline-scrollbar-thumb"), { key: "End" });
+
+    expect(onScroll).not.toHaveBeenCalled();
+    // Disabled scrollbar drops out of the tab order.
+    expect(screen.getByTestId("timeline-scrollbar-thumb").getAttribute("tabindex")).toBe("-1");
+  });
+});

--- a/packages/studio-base/src/components/PlaybackControls/TimelineScrollbar.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/TimelineScrollbar.tsx
@@ -1,0 +1,311 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { alpha } from "@mui/material";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useResizeDetector } from "react-resize-detector";
+import { useLatest } from "react-use";
+import { makeStyles } from "tss-react/mui";
+
+import {
+  getViewportScrollMetrics,
+  type TimelineScrollMetrics,
+  type TimelineViewport,
+} from "./timelineViewport";
+
+// Horizontal scrollbar shown beneath the timeline while it is zoomed in. The thumb mirrors the
+// share of the recording currently visible; dragging it (or clicking the track) pans the viewport.
+
+export const TIMELINE_SCROLLBAR_HEIGHT_PX: number = 12;
+
+// Keep the thumb grabbable even when zoomed in so far that its true proportional width would be a
+// sliver. The drag math accounts for this widened thumb so panning still reaches both ends.
+const MIN_THUMB_WIDTH_PX: number = 24;
+
+// Fraction of the visible window panned per Arrow key press; Page keys move a full window.
+const ARROW_STEP_FRACTION: number = 0.1;
+
+function clamp(value: number, min: number, max: number): number {
+  if (max < min) {
+    return min;
+  }
+
+  return Math.min(Math.max(value, min), max);
+}
+
+type ThumbGeometry = {
+  /** Rendered thumb width in px (never below MIN_THUMB_WIDTH_PX). */
+  thumbWidthPx: number;
+  /** Rendered thumb left offset in px. */
+  thumbLeftPx: number;
+  /** Distance the thumb's left edge can travel across the track in px. */
+  travelPx: number;
+  /** Largest possible visible-window start as a fraction of the total range. */
+  maxStartFraction: number;
+};
+
+// Resolve the rendered thumb geometry for a track width. Because the thumb is clamped to a minimum
+// width, its travel is `trackWidth - thumbWidthPx` rather than the full track — both rendering and
+// pointer math go through here so they agree (otherwise the thumb can't pan to the very end).
+function getThumbGeometry(metrics: TimelineScrollMetrics, trackWidth: number): ThumbGeometry {
+  const thumbWidthPx = Math.max(metrics.thumbSizeFraction * trackWidth, MIN_THUMB_WIDTH_PX);
+  const travelPx = Math.max(0, trackWidth - thumbWidthPx);
+  const maxStartFraction = Math.max(0, 1 - metrics.thumbSizeFraction);
+  const scrollProgress = maxStartFraction > 0 ? metrics.thumbStartFraction / maxStartFraction : 0;
+  const thumbLeftPx = clamp(scrollProgress * travelPx, 0, travelPx);
+
+  return { thumbWidthPx, thumbLeftPx, travelPx, maxStartFraction };
+}
+
+const useStyles = makeStyles()((theme) => ({
+  root: {
+    alignItems: "center",
+    display: "flex",
+    flex: `0 0 ${TIMELINE_SCROLLBAR_HEIGHT_PX}px`,
+    height: TIMELINE_SCROLLBAR_HEIGHT_PX,
+    paddingInline: theme.spacing(0.5),
+  },
+  track: {
+    backgroundColor: alpha(theme.palette.text.primary, 0.06),
+    borderRadius: TIMELINE_SCROLLBAR_HEIGHT_PX / 2,
+    cursor: "pointer",
+    flex: "1 1 auto",
+    height: 8,
+    position: "relative",
+    touchAction: "none",
+  },
+  trackDisabled: {
+    cursor: "default",
+    opacity: theme.palette.action.disabledOpacity,
+    pointerEvents: "none",
+  },
+  thumb: {
+    backgroundColor: alpha(theme.palette.text.secondary, 0.45),
+    borderRadius: TIMELINE_SCROLLBAR_HEIGHT_PX / 2,
+    bottom: 0,
+    cursor: "grab",
+    minWidth: MIN_THUMB_WIDTH_PX,
+    position: "absolute",
+    top: 0,
+    transition: theme.transitions.create("background-color", {
+      duration: theme.transitions.duration.shortest,
+    }),
+
+    "&:hover": {
+      backgroundColor: alpha(theme.palette.text.secondary, 0.6),
+    },
+    "&:focus-visible": {
+      outline: `2px solid ${theme.palette.primary.main}`,
+      outlineOffset: 1,
+    },
+  },
+  thumbDragging: {
+    backgroundColor: alpha(theme.palette.text.secondary, 0.75),
+    cursor: "grabbing",
+
+    "&:hover": {
+      backgroundColor: alpha(theme.palette.text.secondary, 0.75),
+    },
+  },
+}));
+
+type Props = {
+  viewport: TimelineViewport;
+  /** Called with the desired visible-window start (seconds from the recording start). */
+  onScroll: (visibleStartSec: number) => void;
+  disabled?: boolean;
+};
+
+function TimelineScrollbar(props: Props): React.JSX.Element {
+  const { viewport, onScroll, disabled = false } = props;
+  const { classes, cx } = useStyles();
+  const { t } = useTranslation("general");
+
+  const { width: trackWidth, ref: trackRef } = useResizeDetector<HTMLDivElement>({
+    handleHeight: false,
+    refreshMode: "debounce",
+    refreshRate: 0,
+  });
+  // Distance between the pointer and the thumb's left edge captured at pointer-down, so the grabbed
+  // point stays glued under the cursor for the whole drag (drift-free near the track edges).
+  const grabOffsetRef = useRef(0);
+  const latestViewport = useLatest(viewport);
+  const onScrollRef = useLatest(onScroll);
+
+  const [dragging, setDragging] = useState(false);
+
+  const metrics = getViewportScrollMetrics(viewport);
+
+  // Map an absolute pointer position to a visible-window start and emit it. Reads the track rect
+  // fresh each call so resizes/scrolls mid-drag stay accurate.
+  const scrollToPointer = useCallback(
+    (clientX: number): void => {
+      const track = trackRef.current;
+      const currentViewport = latestViewport.current;
+      if (track == undefined) {
+        return;
+      }
+
+      const rect = track.getBoundingClientRect();
+      if (rect.width <= 0) {
+        return;
+      }
+
+      const { travelPx, maxStartFraction } = getThumbGeometry(
+        getViewportScrollMetrics(currentViewport),
+        rect.width,
+      );
+      const totalDuration = currentViewport.totalEndSec - currentViewport.totalStartSec;
+      const desiredLeftPx = clientX - rect.left - grabOffsetRef.current;
+      // Convert the desired thumb position back through the rendered travel, not the full track.
+      const scrollProgress = travelPx > 0 ? clamp(desiredLeftPx / travelPx, 0, 1) : 0;
+      const nextStartFraction = scrollProgress * maxStartFraction;
+
+      onScrollRef.current(currentViewport.totalStartSec + nextStartFraction * totalDuration);
+    },
+    [latestViewport, onScrollRef, trackRef],
+  );
+
+  const onPointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>): void => {
+      const track = trackRef.current;
+      if (disabled || event.button !== 0 || track == undefined) {
+        return;
+      }
+
+      event.preventDefault();
+
+      const rect = track.getBoundingClientRect();
+      const { thumbLeftPx, thumbWidthPx } = getThumbGeometry(
+        getViewportScrollMetrics(latestViewport.current),
+        rect.width,
+      );
+      const pointerPx = event.clientX - rect.left;
+
+      const onThumb = pointerPx >= thumbLeftPx && pointerPx <= thumbLeftPx + thumbWidthPx;
+      // On the thumb: keep the exact grabbed point under the cursor. On the track: center the thumb
+      // under the cursor so the click jumps the window there, then continue as a drag.
+      grabOffsetRef.current = onThumb ? pointerPx - thumbLeftPx : thumbWidthPx / 2;
+
+      setDragging(true);
+      scrollToPointer(event.clientX);
+    },
+    [disabled, latestViewport, scrollToPointer, trackRef],
+  );
+
+  // Keyboard panning so the scrollbar is operable without a pointer (it is announced as a
+  // scrollbar, so it must respond to the standard scroll keys).
+  const onKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>): void => {
+      if (disabled) {
+        return;
+      }
+
+      const currentViewport = latestViewport.current;
+      const visibleDuration = Math.max(
+        currentViewport.visibleEndSec - currentViewport.visibleStartSec,
+        0,
+      );
+      const step = visibleDuration * ARROW_STEP_FRACTION;
+
+      let target: number;
+      switch (event.key) {
+        case "ArrowLeft":
+          target = currentViewport.visibleStartSec - step;
+          break;
+        case "ArrowRight":
+          target = currentViewport.visibleStartSec + step;
+          break;
+        case "PageUp":
+          target = currentViewport.visibleStartSec - visibleDuration;
+          break;
+        case "PageDown":
+          target = currentViewport.visibleStartSec + visibleDuration;
+          break;
+        case "Home":
+          target = currentViewport.totalStartSec;
+          break;
+        case "End":
+          target = currentViewport.totalEndSec;
+          break;
+        default:
+          return;
+      }
+
+      event.preventDefault();
+      onScrollRef.current(target);
+    },
+    [disabled, latestViewport, onScrollRef],
+  );
+
+  useEffect(() => {
+    if (!dragging) {
+      return undefined;
+    }
+
+    const onPointerMove = (event: PointerEvent): void => {
+      scrollToPointer(event.clientX);
+    };
+    const onPointerUp = (): void => {
+      setDragging(false);
+    };
+
+    window.addEventListener("pointermove", onPointerMove);
+    window.addEventListener("pointerup", onPointerUp);
+    return () => {
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("pointerup", onPointerUp);
+    };
+  }, [dragging, scrollToPointer]);
+
+  // Once the track is measured, size and position the thumb in pixels so the minimum width is
+  // honored without ever overflowing the track edges. Fall back to proportional units until then.
+  let thumbStyle: React.CSSProperties;
+  if (trackWidth != undefined && trackWidth > 0) {
+    const { thumbLeftPx, thumbWidthPx } = getThumbGeometry(metrics, trackWidth);
+    thumbStyle = { left: thumbLeftPx, width: thumbWidthPx };
+  } else {
+    thumbStyle = {
+      left: `${metrics.thumbStartFraction * 100}%`,
+      width: `${metrics.thumbSizeFraction * 100}%`,
+    };
+  }
+
+  // Report progress through the scrollable range (0 at the start, 100 fully scrolled to the end).
+  const maxStartFraction = Math.max(0, 1 - metrics.thumbSizeFraction);
+  const scrollProgressPercent =
+    maxStartFraction > 0 ? Math.round((metrics.thumbStartFraction / maxStartFraction) * 100) : 0;
+
+  return (
+    <div className={classes.root}>
+      <div
+        ref={trackRef}
+        className={cx(classes.track, { [classes.trackDisabled]: disabled })}
+        data-testid="timeline-scrollbar"
+        onPointerDown={onPointerDown}
+      >
+        <div
+          aria-controls="timeline-content"
+          aria-label={t("panTimeline")}
+          aria-orientation="horizontal"
+          aria-valuemax={100}
+          aria-valuemin={0}
+          aria-valuenow={scrollProgressPercent}
+          className={cx(classes.thumb, { [classes.thumbDragging]: dragging })}
+          data-testid="timeline-scrollbar-thumb"
+          onKeyDown={onKeyDown}
+          role="scrollbar"
+          style={thumbStyle}
+          tabIndex={disabled ? -1 : 0}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default React.memo(TimelineScrollbar);

--- a/packages/studio-base/src/components/PlaybackControls/TimelineScrollbar.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/TimelineScrollbar.tsx
@@ -238,6 +238,9 @@ function TimelineScrollbar(props: Props): React.JSX.Element {
       }
 
       event.preventDefault();
+      // Stop the handled key from bubbling to the document-level KeyListener, whose Arrow handlers
+      // seek playback — otherwise panning the zoomed timeline would also move the playhead.
+      event.stopPropagation();
       onScrollRef.current(target);
     },
     [disabled, latestViewport, onScrollRef],

--- a/packages/studio-base/src/components/PlaybackControls/index.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.tsx
@@ -61,6 +61,7 @@ import { Player, PlayerPresence } from "@foxglove/studio-base/players/types";
 import PlaybackTimeDisplay from "./PlaybackTimeDisplay";
 import Scrubber from "./Scrubber";
 import SeekStepControls, { MIN_SEEK_STEP_MS, MAX_SEEK_STEP_MS } from "./SeekStepControls";
+import { SHORTCUTS, ShortcutHint } from "./keyboardShortcuts";
 import { DIRECTION, jumpSeek } from "./sharedHelpers";
 
 const TIMELINE_MIN_HEIGHT_PX = 126;
@@ -449,9 +450,13 @@ export default function PlaybackControls(props: {
             <HoverableIconButton
               disabled={disableControls}
               size="small"
-              title={t("seekBackward", {
-                ns: "general",
-              })}
+              aria-label={t("seekBackward", { ns: "general" })}
+              title={
+                <ShortcutHint
+                  label={t("seekBackward", { ns: "general" })}
+                  keys={SHORTCUTS.seekBackward}
+                />
+              }
               icon={<Previous20Regular />}
               activeIcon={<Previous20Filled />}
               onClick={() => {
@@ -462,14 +467,12 @@ export default function PlaybackControls(props: {
               disabled={disableControls}
               size="small"
               id="play-pause-button"
+              aria-label={isPlaying ? t("pause", { ns: "general" }) : t("play", { ns: "general" })}
               title={
-                isPlaying
-                  ? t("pause", {
-                      ns: "general",
-                    })
-                  : t("play", {
-                      ns: "general",
-                    })
+                <ShortcutHint
+                  label={isPlaying ? t("pause", { ns: "general" }) : t("play", { ns: "general" })}
+                  keys={SHORTCUTS.playPause}
+                />
               }
               onClick={togglePlayPause}
               icon={isPlaying ? <Pause20Regular /> : <Play20Regular />}
@@ -478,9 +481,13 @@ export default function PlaybackControls(props: {
             <HoverableIconButton
               disabled={disableControls}
               size="small"
-              title={t("seekForward", {
-                ns: "general",
-              })}
+              aria-label={t("seekForward", { ns: "general" })}
+              title={
+                <ShortcutHint
+                  label={t("seekForward", { ns: "general" })}
+                  keys={SHORTCUTS.seekForward}
+                />
+              }
               icon={<Next20Regular />}
               activeIcon={<Next20Filled />}
               onClick={() => {

--- a/packages/studio-base/src/components/PlaybackControls/keyboardShortcuts.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/keyboardShortcuts.tsx
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { alpha } from "@mui/material";
+import { Fragment } from "react";
+import { makeStyles } from "tss-react/mui";
+
+export const isMac =
+  typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.userAgent);
+
+/** Platform-specific modifier symbol: ⌘ on macOS, Ctrl elsewhere. */
+export const MOD = isMac ? "⌘" : "Ctrl";
+
+/**
+ * Keyboard shortcut definitions, keyed by action. Each value is a list of interchangeable
+ * shortcuts rendered as separate key chips joined by "/" — e.g. ["←", "→"] reads "← / →".
+ * Combined chords stay one chip ("Alt + 1").
+ *
+ * This is the single source of truth shared by the keyboard shortcuts help dialog
+ * (ShortcutsHelpButton) and the per-control tooltips (Scrubber, PlaybackControls,
+ * PlaybackSpeedControls), so the two never drift apart.
+ *
+ * `zoomCursor` interpolates the localized "scroll" word, so it's built at the call site where the
+ * translation is available rather than stored here.
+ */
+export const SHORTCUTS = {
+  playPause: ["Space"],
+  seekBackward: ["←"],
+  seekForward: ["→"],
+  seekStep: ["←", "→"],
+  playbackSpeed: ["−", "+"],
+  selectMoment: ["↑", "↓"],
+  seekToMoment: ["Enter"],
+  createMoment: ["Alt + 1"],
+  setInOut: ["I", "O"],
+  deleteMoment: ["Delete", "Backspace"],
+  zoom: [`${MOD} + =`, `${MOD} + −`],
+  zoomIn: [`${MOD} + =`],
+  zoomOut: [`${MOD} + −`],
+  zoomFit: ["Shift + Z"],
+} as const;
+
+const useStyles = makeStyles()((theme) => ({
+  keyGroup: {
+    alignItems: "center",
+    display: "inline-flex",
+    flex: "0 0 auto",
+    gap: theme.spacing(0.5),
+  },
+  keySeparator: {
+    color: theme.palette.text.secondary,
+  },
+  key: {
+    backgroundColor: theme.palette.action.hover,
+    border: `1px solid ${theme.palette.divider}`,
+    borderRadius: 4,
+    color: theme.palette.text.primary,
+    fontFamily: theme.typography.fontMonospace,
+    fontSize: theme.typography.pxToRem(12),
+    paddingBlock: theme.spacing(0.25),
+    paddingInline: theme.spacing(0.75),
+    whiteSpace: "nowrap",
+  },
+  // Tooltips render on a dark background, so the chips need light-on-dark styling instead of the
+  // panel's light-background palette.
+  keySeparatorOnDark: {
+    color: alpha(theme.palette.common.white, 0.6),
+  },
+  keyOnDark: {
+    backgroundColor: alpha(theme.palette.common.white, 0.16),
+    borderColor: alpha(theme.palette.common.white, 0.28),
+    color: theme.palette.common.white,
+  },
+  hint: {
+    alignItems: "center",
+    display: "inline-flex",
+    gap: theme.spacing(1),
+  },
+}));
+
+/**
+ * Renders a list of interchangeable shortcut keys as chips joined by "/".
+ * Use `variant="tooltip"` when rendering inside a (dark) MUI tooltip.
+ */
+export function ShortcutKeys({
+  keys,
+  variant = "panel",
+}: {
+  keys: readonly string[];
+  variant?: "panel" | "tooltip";
+}): React.JSX.Element {
+  const { classes, cx } = useStyles();
+  const onDark = variant === "tooltip";
+
+  return (
+    <span className={classes.keyGroup}>
+      {keys.map((key, index) => (
+        <Fragment key={key}>
+          {index > 0 && (
+            <span className={cx(classes.keySeparator, { [classes.keySeparatorOnDark]: onDark })}>
+              /
+            </span>
+          )}
+          <span className={cx(classes.key, { [classes.keyOnDark]: onDark })}>{key}</span>
+        </Fragment>
+      ))}
+    </span>
+  );
+}
+
+/**
+ * Tooltip body that pairs a control's existing hint text with its keyboard shortcut chip(s),
+ * so the shortcuts surfaced in the help dialog are also discoverable on the controls themselves.
+ */
+export function ShortcutHint({
+  label,
+  keys,
+}: {
+  label: string;
+  keys: readonly string[];
+}): React.JSX.Element {
+  const { classes } = useStyles();
+
+  return (
+    <span className={classes.hint}>
+      <span>{label}</span>
+      <ShortcutKeys keys={keys} variant="tooltip" />
+    </span>
+  );
+}

--- a/packages/studio-base/src/components/PlaybackControls/timelineViewport.test.ts
+++ b/packages/studio-base/src/components/PlaybackControls/timelineViewport.test.ts
@@ -8,9 +8,11 @@
 import {
   clientXToTime,
   getTimelineViewportZoomPercent,
+  getViewportScrollMetrics,
   makeTimelineViewport,
   panViewportBySeconds,
   setTimelineViewportZoomPercentAtTime,
+  setViewportVisibleStartSec,
   timeToFraction,
   timelineRangeToStyle,
   zoomViewportAtTime,
@@ -79,6 +81,72 @@ describe("timelineViewport", () => {
       visibleStartSec: 0,
       visibleEndSec: 20,
     });
+  });
+
+  it("moves the visible window start while preserving its duration", () => {
+    const viewport = {
+      ...makeTimelineViewport(0, 100),
+      visibleStartSec: 20,
+      visibleEndSec: 40,
+    };
+
+    expect(setViewportVisibleStartSec(viewport, 50)).toEqual({
+      totalStartSec: 0,
+      totalEndSec: 100,
+      visibleStartSec: 50,
+      visibleEndSec: 70,
+    });
+  });
+
+  it("clamps the visible window start to the total bounds", () => {
+    const viewport = {
+      ...makeTimelineViewport(0, 100),
+      visibleStartSec: 20,
+      visibleEndSec: 40,
+    };
+
+    expect(setViewportVisibleStartSec(viewport, 90)).toEqual({
+      totalStartSec: 0,
+      totalEndSec: 100,
+      visibleStartSec: 80,
+      visibleEndSec: 100,
+    });
+    expect(setViewportVisibleStartSec(viewport, -10)).toEqual({
+      totalStartSec: 0,
+      totalEndSec: 100,
+      visibleStartSec: 0,
+      visibleEndSec: 20,
+    });
+  });
+
+  it("reports scrollbar thumb position and size from the visible window", () => {
+    expect(getViewportScrollMetrics(makeTimelineViewport(0, 100))).toEqual({
+      thumbStartFraction: 0,
+      thumbSizeFraction: 1,
+    });
+
+    const viewport = {
+      ...makeTimelineViewport(0, 100),
+      visibleStartSec: 20,
+      visibleEndSec: 40,
+    };
+    expect(getViewportScrollMetrics(viewport)).toEqual({
+      thumbStartFraction: 0.2,
+      thumbSizeFraction: 0.2,
+    });
+  });
+
+  it("clamps the scrollbar thumb within the track at the end of the range", () => {
+    const viewport = {
+      ...makeTimelineViewport(0, 100),
+      visibleStartSec: 80,
+      visibleEndSec: 100,
+    };
+
+    const { thumbStartFraction, thumbSizeFraction } = getViewportScrollMetrics(viewport);
+    expect(thumbSizeFraction).toBeCloseTo(0.2);
+    expect(thumbStartFraction).toBeCloseTo(0.8);
+    expect(thumbStartFraction + thumbSizeFraction).toBeLessThanOrEqual(1);
   });
 
   it("clips ranges to the visible window", () => {

--- a/packages/studio-base/src/components/PlaybackControls/timelineViewport.ts
+++ b/packages/studio-base/src/components/PlaybackControls/timelineViewport.ts
@@ -212,6 +212,46 @@ export function panViewportBySeconds(
   });
 }
 
+// Move the visible window so it begins at `visibleStartSec`, preserving its duration. Used by the
+// horizontal scrollbar to map an absolute thumb position back onto the viewport.
+export function setViewportVisibleStartSec(
+  viewport: TimelineViewport,
+  visibleStartSec: number,
+): TimelineViewport {
+  const duration = getVisibleDuration(viewport);
+
+  return clampTimelineViewport({
+    ...viewport,
+    visibleStartSec,
+    visibleEndSec: visibleStartSec + duration,
+  });
+}
+
+export type TimelineScrollMetrics = {
+  /** Thumb offset from the track start, as a fraction (0-1) of the total range. */
+  thumbStartFraction: number;
+  /** Thumb length, as a fraction (0-1) of the total range. */
+  thumbSizeFraction: number;
+};
+
+// Describe where the horizontal scrollbar thumb sits: its size is the share of the total range
+// currently visible, and its offset is how far into the total range the visible window begins.
+export function getViewportScrollMetrics(viewport: TimelineViewport): TimelineScrollMetrics {
+  const totalDuration = viewport.totalEndSec - viewport.totalStartSec;
+  if (totalDuration <= 0) {
+    return { thumbStartFraction: 0, thumbSizeFraction: 1 };
+  }
+
+  const thumbSizeFraction = _.clamp(getVisibleDuration(viewport) / totalDuration, 0, 1);
+  const thumbStartFraction = _.clamp(
+    (viewport.visibleStartSec - viewport.totalStartSec) / totalDuration,
+    0,
+    1 - thumbSizeFraction,
+  );
+
+  return { thumbStartFraction, thumbSizeFraction };
+}
+
 export function viewportEquals(left: TimelineViewport, right: TimelineViewport): boolean {
   return (
     left.totalStartSec === right.totalStartSec &&

--- a/packages/studio-base/src/components/PlaybackSpeedControls.tsx
+++ b/packages/studio-base/src/components/PlaybackSpeedControls.tsx
@@ -79,7 +79,7 @@ function PlaybackSpeedControls(props: { disabled?: boolean }): React.JSX.Element
         <Button
           className={classes.button}
           id="playback-speed-button"
-          aria-label={t("playbackSpeed", { ns: "general" })}
+          aria-label={`${t("playbackSpeed", { ns: "general" })} ${formatPlaybackSpeed(speed)}`}
           aria-controls={open ? "playback-speed-menu" : undefined}
           aria-haspopup="true"
           aria-expanded={open ? "true" : undefined}

--- a/packages/studio-base/src/components/PlaybackSpeedControls.tsx
+++ b/packages/studio-base/src/components/PlaybackSpeedControls.tsx
@@ -14,6 +14,10 @@ import { makeStyles } from "tss-react/mui";
 
 import { useMessagePipeline } from "@foxglove/studio-base/components/MessagePipeline";
 import {
+  SHORTCUTS,
+  ShortcutHint,
+} from "@foxglove/studio-base/components/PlaybackControls/keyboardShortcuts";
+import {
   formatPlaybackSpeed,
   PLAYBACK_SPEED_OPTIONS,
 } from "@foxglove/studio-base/components/playbackSpeed";
@@ -64,10 +68,18 @@ function PlaybackSpeedControls(props: { disabled?: boolean }): React.JSX.Element
 
   return (
     <>
-      <Tooltip title={t("playbackSpeedShortcut", { ns: "general" })}>
+      <Tooltip
+        title={
+          <ShortcutHint
+            label={t("playbackSpeed", { ns: "general" })}
+            keys={SHORTCUTS.playbackSpeed}
+          />
+        }
+      >
         <Button
           className={classes.button}
           id="playback-speed-button"
+          aria-label={t("playbackSpeed", { ns: "general" })}
           aria-controls={open ? "playback-speed-menu" : undefined}
           aria-haspopup="true"
           aria-expanded={open ? "true" : undefined}

--- a/packages/studio-base/src/i18n/en/general.ts
+++ b/packages/studio-base/src/i18n/en/general.ts
@@ -46,7 +46,6 @@ export const general = {
   loopPlayback: "Loop playback",
   invalidSeekStep: "Seek step must be >= 1e-6s and <= 1 hour. Reset to 0.1 s.",
   playbackSpeed: "Playback speed",
-  playbackSpeedShortcut: "Playback speed (- / +)",
   enableMomentSubtitles: "Enable moment subtitles",
   disableMomentSubtitles: "Disable moment subtitles",
   decreaseMomentSubtitleFontSize: "Decrease subtitle font size",

--- a/packages/studio-base/src/i18n/en/general.ts
+++ b/packages/studio-base/src/i18n/en/general.ts
@@ -53,6 +53,7 @@ export const general = {
   increaseMomentSubtitleFontSize: "Increase subtitle font size",
   resetMomentSubtitlePosition: "Reset subtitle position",
   timelineZoom: "Timeline zoom",
+  panTimeline: "Pan timeline",
   zoomIn: "Zoom in",
   zoomOut: "Zoom out",
   keyboardShortcuts: "Keyboard shortcuts",

--- a/packages/studio-base/src/i18n/ja/general.ts
+++ b/packages/studio-base/src/i18n/ja/general.ts
@@ -21,4 +21,5 @@ export const general: Partial<TypeOptions["resources"]["general"]> = {
   decreaseMomentSubtitleFontSize: "Decrease subtitle font size",
   increaseMomentSubtitleFontSize: "Increase subtitle font size",
   resetMomentSubtitlePosition: "Reset subtitle position",
+  panTimeline: "Pan timeline",
 };

--- a/packages/studio-base/src/i18n/zh/general.ts
+++ b/packages/studio-base/src/i18n/zh/general.ts
@@ -53,6 +53,7 @@ export const general: Partial<TypeOptions["resources"]["general"]> = {
   increaseMomentSubtitleFontSize: "增大字幕字号",
   resetMomentSubtitlePosition: "重置位置",
   timelineZoom: "时间轴缩放",
+  panTimeline: "平移时间轴",
   zoomIn: "放大",
   zoomOut: "缩小",
   keyboardShortcuts: "键盘快捷键",

--- a/packages/studio-base/src/i18n/zh/general.ts
+++ b/packages/studio-base/src/i18n/zh/general.ts
@@ -46,7 +46,6 @@ export const general: Partial<TypeOptions["resources"]["general"]> = {
   loopPlayback: "循环播放",
   invalidSeekStep: "步长需大于等于 1e-6 秒且小于等于 1 小时，已重置为 0.1 秒。",
   playbackSpeed: "播放速度",
-  playbackSpeedShortcut: "播放速度（- / +）",
   enableMomentSubtitles: "开启一刻为字幕",
   disableMomentSubtitles: "关闭一刻为字幕",
   decreaseMomentSubtitleFontSize: "减小字幕字号",


### PR DESCRIPTION
Cherry-picks three timeline-scrubber improvements from the bombus repo, reapplied onto honeybee's diverged versions of these files. Each is a separate commit.

## Commits

1. **fix: prevent browser page zoom on Ctrl+scroll over timeline scrubber** (bombus `2e3fd01486`, #105)
   - Attach the scrubber wheel handler as a non-passive native listener so `preventDefault()` actually suppresses the browser's Ctrl+wheel page-zoom on Windows/Linux.
   - Restore focus to the scrubber on the zoom slider's `onChangeCommitted` so timeline zoom shortcuts stay active after dragging the slider.

2. **feat: add horizontal scrollbar to timeline when zoomed in** (bombus `770b19f125`, #109)
   - New `TimelineScrollbar` component (track/thumb, grab-offset dragging, click-to-pan, keyboard support) shown beneath the timeline while zoomed.
   - New pure helpers `setViewportVisibleStartSec` and `getViewportScrollMetrics` in `timelineViewport` (unit-tested).
   - New `panTimeline` i18n key (en/zh/ja).

3. **feat: surface keyboard shortcuts on playback control tooltips** (bombus `bc298f796e`, #110)
   - New shared `keyboardShortcuts` module (single `SHORTCUTS` source of truth + `ShortcutKeys`/`ShortcutHint` renderers) consumed by both the shortcuts help dialog and the per-control tooltips.
   - Shortcut chips on play/pause, seek back/forward, playback speed, create moment, zoom in/out/fit; Ctrl/Cmd+scroll quick-zoom hint on the zoom slider.
   - Widened `HoverableIconButton`'s `title` prop to `ReactNode`, with explicit `aria-label`s preserved for accessibility.
   - Removed the now-unused `playbackSpeedShortcut` i18n key.

## Notes on divergence

These files have diverged between bombus and honeybee, so the changes were reapplied by hand rather than `git cherry-pick`.

- The two `Scrubber.test.tsx` cases from #109 were **omitted**: honeybee's `Scrubber` test harness has diverged and lacks the `renderScrubber`/`getScrubberSliderViewport` helpers those tests depend on. The new `TimelineScrollbar.test.tsx` and the `timelineViewport.test.ts` additions cover the new logic.
- Only the `title`-prop widening from #110 was applied to `HoverableIconButton` (the source commit's diff also contained unrelated bombus-only refactoring).

## Verification

- `jest` on `PlaybackControls/`, `HoverableIconButton`, `PlaybackSpeedControls` — all green (new + existing).
- `tsc` on `studio-base` — no errors in touched files (3 pre-existing errors in untouched test files remain).
- `eslint` clean on all touched files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785128687&installation_id=141984720&pr_number=1381&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1381&signature=b412d4b497fd433878c15eb7c7d6d2f9e40a405811b716e0681c8bccd78ac722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->