### PR TITLE
[codex] Support direct share shard manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.log
 *.tsbuildinfo
 .eslintcache
+.codegraph
 .idea/
 .DS_Store
 .webpack/

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -78,6 +78,7 @@ import { Language } from "@foxglove/studio-base/i18n";
 import { PlayerPresence } from "@foxglove/studio-base/players/types";
 import { PanelStateContextProvider } from "@foxglove/studio-base/providers/PanelStateContextProvider";
 import WorkspaceContextProvider from "@foxglove/studio-base/providers/WorkspaceContextProvider";
+import { isAuthlessDataSource } from "@foxglove/studio-base/util/coscene";
 import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
 import { useSubscriptionEntitlement } from "./context/SubscriptionEntitlementContext";
@@ -476,7 +477,7 @@ export default function Workspace(props: WorkspaceProps): React.JSX.Element {
 
   const syncLanguageWithOrgConfigMap = useCallback(async () => {
     // Only sync language if user is logged in
-    if (loginStatus !== "alreadyLogin" || !currentUser?.userId) {
+    if (loginStatus !== "alreadyLogin" || !currentUser?.userId || isAuthlessDataSource()) {
       return;
     }
 

--- a/packages/studio-base/src/components/AppBar/ShardProfileSelector.test.tsx
+++ b/packages/studio-base/src/components/AppBar/ShardProfileSelector.test.tsx
@@ -1,0 +1,106 @@
+/** @jest-environment jsdom */
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
+import type { PlayerURLState } from "@foxglove/studio-base/players/types";
+import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
+
+import { ShardProfileSelector } from "./ShardProfileSelector";
+
+function renderSelector(urlState: PlayerURLState): ReturnType<typeof render> {
+  return render(
+    <ThemeProvider isDark>
+      <MockMessagePipelineProvider urlState={urlState}>
+        <ShardProfileSelector />
+      </MockMessagePipelineProvider>
+    </ThemeProvider>,
+  );
+}
+
+describe("<ShardProfileSelector />", () => {
+  const manifestUrl = "https://mock-storage.example.com/public/shards/manifest.json";
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        profiles: [
+          { id: "360p", modality: "video", label: "360p", params: { h: 360 } },
+          { id: "720p", modality: "video", label: "720p", params: { h: 720 } },
+          { id: "raw", modality: "video", label: "Raw", params: { h: 1080 } },
+        ],
+      }),
+    } as Response);
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("does not render for encoded share manifest playback", () => {
+    renderSelector({
+      sourceId: "coscene-share-manifest",
+      parameters: { manifest: "encoded" },
+    });
+
+    expect(screen.queryByRole("combobox")).toBeNull();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("does not render for direct share manifest playback with one effective profile", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        profiles: [
+          { id: "720p", modality: "video", label: "720p", params: { h: 720 } },
+          { id: "raw", modality: "video", label: "Raw", params: { h: 1080 } },
+        ],
+      }),
+    } as Response);
+
+    renderSelector({
+      sourceId: "coscene-share-manifest",
+      parameters: { shardMode: "manifest", manifestUrl },
+    });
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(manifestUrl);
+    });
+    expect(screen.queryByRole("combobox")).toBeNull();
+  });
+
+  it("renders direct share manifest profiles only when multiple effective profiles exist", async () => {
+    renderSelector({
+      sourceId: "coscene-share-manifest",
+      parameters: { shardMode: "manifest", manifestUrl },
+    });
+
+    const select = await screen.findByRole("combobox");
+    fireEvent.mouseDown(select);
+
+    expect(await screen.findByRole("option", { name: "360p" })).not.toBeNull();
+    expect(screen.getByRole("option", { name: "720p" })).not.toBeNull();
+    expect(screen.queryByText("Raw")).toBeNull();
+    expect(screen.queryByText("Raw Data")).toBeNull();
+  });
+
+  it("keeps raw available for data-platform shard manifest playback", async () => {
+    renderSelector({
+      sourceId: "coscene-data-platform",
+      parameters: { shardMode: "manifest", manifestUrl },
+    });
+
+    const select = await screen.findByRole("combobox");
+    fireEvent.mouseDown(select);
+
+    expect(await screen.findByRole("option", { name: "Raw Data" })).not.toBeNull();
+  });
+});

--- a/packages/studio-base/src/components/AppBar/ShardProfileSelector.tsx
+++ b/packages/studio-base/src/components/AppBar/ShardProfileSelector.tsx
@@ -27,15 +27,17 @@ import type {
   ManifestProfile,
   ShardProfileOption,
 } from "@foxglove/studio-base/players/IterablePlayer/coScene-shard-manifest/profilePreference";
+import {
+  MANIFEST_URL_PARAM,
+  SHARD_MODE_MANIFEST,
+  SHARD_MODE_PARAM,
+  SHARD_MODE_RAW,
+} from "@foxglove/studio-base/util/shardManifestUrlParams";
+import { SHARE_MANIFEST_DATA_SOURCE_ID } from "@foxglove/studio-base/util/shareManifest";
 
 interface MinimalManifest {
   profiles?: ManifestProfile[];
 }
-
-const SHARD_MODE_PARAM = "shardMode";
-const SHARD_MODE_MANIFEST = "manifest";
-const SHARD_MODE_RAW = "raw";
-const MANIFEST_URL_PARAM = "manifestUrl";
 
 const selectUrlState = (ctx: MessagePipelineContext) => ctx.playerState.urlState;
 
@@ -55,12 +57,20 @@ export function ShardProfileSelector(): React.JSX.Element | ReactNull {
   const { t } = useTranslation("appBar");
   const urlState = useMessagePipeline(selectUrlState);
 
-  const isShardManifest =
-    urlState?.sourceId === "coscene-data-platform" &&
-    (urlState.parameters?.[SHARD_MODE_PARAM] === SHARD_MODE_MANIFEST ||
-      urlState.parameters?.[SHARD_MODE_PARAM] === SHARD_MODE_RAW);
+  const sourceId = urlState?.sourceId;
+  const shardMode = urlState?.parameters?.[SHARD_MODE_PARAM];
   const manifestUrl = urlState?.parameters?.[MANIFEST_URL_PARAM] ?? "";
-  const currentProfile = urlState?.parameters?.profile ?? "";
+  const isDataPlatformShardManifest =
+    sourceId === "coscene-data-platform" &&
+    (shardMode === SHARD_MODE_MANIFEST || shardMode === SHARD_MODE_RAW);
+  const isShareDirectShardManifest =
+    sourceId === SHARE_MANIFEST_DATA_SOURCE_ID &&
+    shardMode === SHARD_MODE_MANIFEST &&
+    manifestUrl !== "";
+  const isShardManifest = isDataPlatformShardManifest || isShareDirectShardManifest;
+  const allowRawProfile = isDataPlatformShardManifest;
+  const profileParam = urlState?.parameters?.profile ?? "";
+  const currentProfile = !allowRawProfile && profileParam === RAW_PROFILE ? "" : profileParam;
   const rawOption = useMemo<ShardProfileOption>(
     () => ({ value: RAW_PROFILE, label: t("rawData") }),
     [t],
@@ -103,11 +113,17 @@ export function ShardProfileSelector(): React.JSX.Element | ReactNull {
   }, [isShardManifest, manifestUrl]);
 
   const options = useMemo(() => {
+    if (!allowRawProfile) {
+      return profileOptions;
+    }
     if (profileOptions.some((opt) => opt.value === RAW_PROFILE)) {
       return profileOptions;
     }
     return [...profileOptions, rawOption];
-  }, [profileOptions, rawOption]);
+  }, [allowRawProfile, profileOptions, rawOption]);
+
+  const selectorVisible =
+    isDataPlatformShardManifest || (isShareDirectShardManifest && options.length > 1);
 
   const selectedValue =
     currentProfile !== "" && options.some((option) => option.value === currentProfile)
@@ -115,7 +131,7 @@ export function ShardProfileSelector(): React.JSX.Element | ReactNull {
       : defaultProfile;
 
   useEffect(() => {
-    if (!isShardManifest || options.length === 0) {
+    if (!selectorVisible || options.length === 0) {
       return;
     }
     const hasCurrentProfile =
@@ -137,7 +153,7 @@ export function ShardProfileSelector(): React.JSX.Element | ReactNull {
       next.set("ds.profile", savedOption.value);
     }
     window.location.search = next.toString();
-  }, [currentProfile, defaultProfile, isShardManifest, options]);
+  }, [currentProfile, defaultProfile, options, selectorVisible]);
 
   const onChange = useCallback(
     (value: string) => {
@@ -156,7 +172,7 @@ export function ShardProfileSelector(): React.JSX.Element | ReactNull {
     [defaultProfile, options],
   );
 
-  if (!isShardManifest) {
+  if (!selectorVisible) {
     return ReactNull;
   }
 

--- a/packages/studio-base/src/components/AuthlessDataSourceSyncAdapter.test.tsx
+++ b/packages/studio-base/src/components/AuthlessDataSourceSyncAdapter.test.tsx
@@ -78,4 +78,22 @@ describe("<AuthlessDataSourceSyncAdapter />", () => {
       expect(isAuthlessDataSource()).toBe(true);
     });
   });
+
+  it("treats direct share manifest URLs as authless before source selection", async () => {
+    const manifestUrl = "https://mock-storage.example.com/public/shards/manifest.json";
+    const layoutUrl = "https://mock-storage.example.com/public/layouts/share.json";
+    window.history.replaceState(
+      undefined,
+      "",
+      `${window.location.origin}/viz?ds=coscene-share-manifest#manifestUrl=${encodeURIComponent(
+        manifestUrl,
+      )}&layoutUrl=${encodeURIComponent(layoutUrl)}`,
+    );
+
+    renderWithSource(undefined);
+
+    await waitFor(() => {
+      expect(isAuthlessDataSource()).toBe(true);
+    });
+  });
 });

--- a/packages/studio-base/src/components/AuthlessDataSourceSyncAdapter.tsx
+++ b/packages/studio-base/src/components/AuthlessDataSourceSyncAdapter.tsx
@@ -9,13 +9,23 @@ import { useEffect } from "react";
 
 import { CoreDataStore, useCoreData } from "@foxglove/studio-base/context/CoreDataContext";
 import { setAuthlessDataSource } from "@foxglove/studio-base/util/coscene";
-import { SHARE_MANIFEST_DATA_SOURCE_ID } from "@foxglove/studio-base/util/shareManifest";
+import {
+  SHARE_MANIFEST_DATA_SOURCE_ID,
+  windowShareManifestParseResult,
+} from "@foxglove/studio-base/util/shareManifest";
 
-const selectIsAuthlessDataSource = (state: CoreDataStore) =>
-  state.dataSource?.id === SHARE_MANIFEST_DATA_SOURCE_ID;
+const selectDataSource = (state: CoreDataStore) => state.dataSource;
+
+function isShareManifestUrlAuthless(): boolean {
+  const result = windowShareManifestParseResult();
+  return result.status === "valid" || result.status === "expired";
+}
 
 export function AuthlessDataSourceSyncAdapter(): ReactNull {
-  const isAuthless = useCoreData(selectIsAuthlessDataSource);
+  const dataSource = useCoreData(selectDataSource);
+  const isAuthless =
+    dataSource?.id === SHARE_MANIFEST_DATA_SOURCE_ID ||
+    (dataSource == undefined && isShareManifestUrlAuthless());
 
   useEffect(() => {
     setAuthlessDataSource({ authless: isAuthless });

--- a/packages/studio-base/src/components/DeepLinksSyncAdapter.test.tsx
+++ b/packages/studio-base/src/components/DeepLinksSyncAdapter.test.tsx
@@ -98,6 +98,18 @@ function shareUrl(expiresAt: string): { url: string; encodedManifest: string } {
   };
 }
 
+function directShareUrl(profile?: string): string {
+  const search = new URLSearchParams({ ds: SHARE_MANIFEST_DATA_SOURCE_ID });
+  if (profile != undefined) {
+    search.set("ds.profile", profile);
+  }
+  const hash = new URLSearchParams({
+    manifestUrl: "https://mock-storage.example.com/public/shards/manifest.json",
+    layoutUrl: "https://mock-storage.example.com/public/layouts/share.json",
+  });
+  return `${window.location.origin}/viz?${search.toString()}#${hash.toString()}`;
+}
+
 describe("<DeepLinksSyncAdapter /> share manifest handling", () => {
   beforeEach(() => {
     jest.useFakeTimers({ now: new Date("2026-06-25T00:00:00Z") });
@@ -125,6 +137,42 @@ describe("<DeepLinksSyncAdapter /> share manifest handling", () => {
       });
     });
     expect(mockDataSourceClose).toHaveBeenCalled();
+  });
+
+  it("initializes direct shard share manifest URLs without login", async () => {
+    const url = directShareUrl("720p");
+    window.history.replaceState(undefined, "", url);
+
+    render(<DeepLinksSyncAdapter deepLinks={[url]} />);
+
+    await waitFor(() => {
+      expect(mockSelectSource).toHaveBeenCalledWith(SHARE_MANIFEST_DATA_SOURCE_ID, {
+        type: "connection",
+        params: {
+          manifestUrl: "https://mock-storage.example.com/public/shards/manifest.json",
+          layoutUrl: "https://mock-storage.example.com/public/layouts/share.json",
+          profile: "720p",
+        },
+      });
+    });
+    expect(mockDataSourceClose).toHaveBeenCalled();
+  });
+
+  it("drops raw profile from direct shard share manifest URLs", async () => {
+    const url = directShareUrl("raw");
+    window.history.replaceState(undefined, "", url);
+
+    render(<DeepLinksSyncAdapter deepLinks={[url]} />);
+
+    await waitFor(() => {
+      expect(mockSelectSource).toHaveBeenCalledWith(SHARE_MANIFEST_DATA_SOURCE_ID, {
+        type: "connection",
+        params: {
+          manifestUrl: "https://mock-storage.example.com/public/shards/manifest.json",
+          layoutUrl: "https://mock-storage.example.com/public/layouts/share.json",
+        },
+      });
+    });
   });
 
   it("shows a non-dismissible expired dialog and does not initialize playback", async () => {

--- a/packages/studio-base/src/components/DeepLinksSyncAdapter.tsx
+++ b/packages/studio-base/src/components/DeepLinksSyncAdapter.tsx
@@ -37,9 +37,12 @@ import { useSyncLayoutFromUrl } from "@foxglove/studio-base/hooks/useSyncLayoutF
 import { useSyncTimeFromUrl } from "@foxglove/studio-base/hooks/useSyncTimeFromUrl";
 import { getDomainConfig } from "@foxglove/studio-base/util/appConfig";
 import { parseAppURLState } from "@foxglove/studio-base/util/appURLState";
+import type { AppURLState } from "@foxglove/studio-base/util/appURLState";
 import { isAuthlessDataSource } from "@foxglove/studio-base/util/coscene";
 import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 import {
+  SHARE_MANIFEST_DIRECT_LAYOUT_URL_PARAM,
+  SHARE_MANIFEST_DIRECT_MANIFEST_URL_PARAM,
   SHARE_MANIFEST_DATA_SOURCE_ID,
   SHARE_MANIFEST_HASH_PARAM,
   parseShareManifestFromUrl,
@@ -94,7 +97,7 @@ export function DeepLinksSyncAdapter({
   const selectEvent = useEvents(selectSelectEvent);
 
   // ========== URL 解析和验证 ==========
-  const targetUrlState = useMemo(() => {
+  const targetUrlState = useMemo<AppURLState | undefined>(() => {
     if (deepLinks[0] == undefined) {
       return undefined;
     }
@@ -102,9 +105,21 @@ export function DeepLinksSyncAdapter({
     const url = new URL(deepLinks[0]);
     const shareManifest = parseShareManifestFromUrl(url);
     if (shareManifest.status === "valid") {
+      const dsParams: Record<string, string> = {};
+      if (shareManifest.kind === "encoded") {
+        dsParams[SHARE_MANIFEST_HASH_PARAM] = shareManifest.encodedManifest;
+      } else {
+        dsParams[SHARE_MANIFEST_DIRECT_MANIFEST_URL_PARAM] = shareManifest.manifestUrl;
+        if (shareManifest.layoutUrl != undefined) {
+          dsParams[SHARE_MANIFEST_DIRECT_LAYOUT_URL_PARAM] = shareManifest.layoutUrl;
+        }
+        if (shareManifest.profile != undefined) {
+          dsParams.profile = shareManifest.profile;
+        }
+      }
       return {
         ds: SHARE_MANIFEST_DATA_SOURCE_ID,
-        dsParams: { [SHARE_MANIFEST_HASH_PARAM]: shareManifest.encodedManifest },
+        dsParams,
       };
     }
     if (shareManifest.status === "expired") {

--- a/packages/studio-base/src/components/ShareManifestLayoutSyncAdapter.test.tsx
+++ b/packages/studio-base/src/components/ShareManifestLayoutSyncAdapter.test.tsx
@@ -37,7 +37,19 @@ function encodeBase64Url(value: unknown): string {
 
 describe("<ShareManifestLayoutSyncAdapter />", () => {
   const layoutUrl = "https://mock-storage.example.com/shares/layout.json?sig=layout";
+  const manifestUrl = "https://mock-storage.example.com/public/shards/manifest.json";
+  const directLayoutUrl = "https://mock-storage.example.com/public/layouts/share.json";
   const originalFetch = global.fetch;
+  const expectedBlankLayout = {
+    id: "share-manifest-layout",
+    name: "Shared layout",
+    transient: true,
+    data: {
+      configById: {},
+      globalVariables: {},
+      userNodes: {},
+    },
+  };
 
   beforeEach(() => {
     jest.useFakeTimers({ now: new Date("2026-06-25T00:00:00Z") });
@@ -90,5 +102,130 @@ describe("<ShareManifestLayoutSyncAdapter />", () => {
     });
     expect(global.fetch).toHaveBeenCalledWith(layoutUrl, { signal: expect.any(AbortSignal) });
     expect(SHARE_MANIFEST_DATA_SOURCE_ID).toBe("coscene-share-manifest");
+  });
+
+  it("loads direct layoutUrl as the highest priority transient layout", async () => {
+    window.history.replaceState(
+      undefined,
+      "",
+      `${window.location.origin}/viz?ds=coscene-share-manifest#manifestUrl=${encodeURIComponent(
+        manifestUrl,
+      )}&layoutUrl=${encodeURIComponent(directLayoutUrl)}`,
+    );
+
+    render(<ShareManifestLayoutSyncAdapter />);
+
+    await waitFor(() => {
+      expect(mockSetCurrentLayout).toHaveBeenCalledWith({
+        id: "share-manifest-layout",
+        name: "Shared layout",
+        transient: true,
+        data: {
+          layout: "RawMessages!1",
+          configById: { "RawMessages!1": { diffEnabled: true } },
+          globalVariables: {},
+          userNodes: {},
+        },
+      });
+    });
+    expect(global.fetch).toHaveBeenCalledWith(directLayoutUrl, {
+      signal: expect.any(AbortSignal),
+    });
+    expect(global.fetch).not.toHaveBeenCalledWith(manifestUrl, {
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("loads direct shard manifest links.layout when layoutUrl is missing", async () => {
+    window.history.replaceState(
+      undefined,
+      "",
+      `${window.location.origin}/viz?ds=coscene-share-manifest#manifestUrl=${encodeURIComponent(
+        manifestUrl,
+      )}`,
+    );
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          links: { layout: directLayoutUrl },
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          layout: "RawMessages!1",
+          savedProps: { "RawMessages!1": { diffEnabled: true } },
+          globalVariables: {},
+          userNodes: {},
+        }),
+      } as Response);
+
+    render(<ShareManifestLayoutSyncAdapter />);
+
+    await waitFor(() => {
+      expect(mockSetCurrentLayout).toHaveBeenCalledWith({
+        id: "share-manifest-layout",
+        name: "Shared layout",
+        transient: true,
+        data: {
+          layout: "RawMessages!1",
+          configById: { "RawMessages!1": { diffEnabled: true } },
+          globalVariables: {},
+          userNodes: {},
+        },
+      });
+    });
+    expect(global.fetch).toHaveBeenNthCalledWith(1, manifestUrl, {
+      signal: expect.any(AbortSignal),
+    });
+    expect(global.fetch).toHaveBeenNthCalledWith(2, directLayoutUrl, {
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("falls back to a blank transient layout when no layout URL is available", async () => {
+    window.history.replaceState(
+      undefined,
+      "",
+      `${window.location.origin}/viz?ds=coscene-share-manifest#manifestUrl=${encodeURIComponent(
+        manifestUrl,
+      )}`,
+    );
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ links: {} }),
+    } as Response);
+
+    render(<ShareManifestLayoutSyncAdapter />);
+
+    await waitFor(() => {
+      expect(mockSetCurrentLayout).toHaveBeenCalledWith(expectedBlankLayout);
+    });
+  });
+
+  it("reports layout fetch failures and falls back to a blank transient layout", async () => {
+    window.history.replaceState(
+      undefined,
+      "",
+      `${window.location.origin}/viz?ds=coscene-share-manifest#manifestUrl=${encodeURIComponent(
+        manifestUrl,
+      )}&layoutUrl=${encodeURIComponent(directLayoutUrl)}`,
+    );
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+    } as Response);
+
+    render(<ShareManifestLayoutSyncAdapter />);
+
+    await waitFor(() => {
+      expect(mockEnqueueSnackbar).toHaveBeenCalledWith(
+        "Shared layout could not be loaded. HTTP 403",
+        { variant: "error" },
+      );
+      expect(mockSetCurrentLayout).toHaveBeenCalledWith(expectedBlankLayout);
+    });
   });
 });

--- a/packages/studio-base/src/components/ShareManifestLayoutSyncAdapter.tsx
+++ b/packages/studio-base/src/components/ShareManifestLayoutSyncAdapter.tsx
@@ -25,6 +25,50 @@ import {
 const selectDataSource = (state: CoreDataStore) => state.dataSource;
 const SHARE_LAYOUT_ID = "share-manifest-layout" as LayoutID;
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value != undefined && !Array.isArray(value);
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function setBlankSharedLayout(
+  setCurrentLayout: ReturnType<typeof useCurrentLayoutActions>["setCurrentLayout"],
+) {
+  setCurrentLayout({
+    id: SHARE_LAYOUT_ID,
+    name: "Shared layout",
+    data: {
+      configById: {},
+      globalVariables: {},
+      userNodes: {},
+    },
+    transient: true,
+  });
+}
+
+async function fetchDirectManifestLayoutUrl(
+  manifestUrl: string,
+  signal: AbortSignal,
+): Promise<string | undefined> {
+  const response = await fetch(manifestUrl, { signal });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+  const rawManifest = await response.json();
+  if (!isRecord(rawManifest) || !isRecord(rawManifest.links)) {
+    return undefined;
+  }
+  const layout = rawManifest.links.layout;
+  return typeof layout === "string" && isHttpUrl(layout) ? layout : undefined;
+}
+
 export function ShareManifestLayoutSyncAdapter(): ReactNull {
   const dataSource = useCoreData(selectDataSource);
   const { setCurrentLayout } = useCurrentLayoutActions();
@@ -43,9 +87,17 @@ export function ShareManifestLayoutSyncAdapter(): ReactNull {
       }
 
       try {
-        const response = await fetch(manifestResult.manifest.links.layout, {
-          signal: controller.signal,
-        });
+        const layoutUrl =
+          manifestResult.kind === "encoded"
+            ? manifestResult.manifest.links.layout
+            : (manifestResult.layoutUrl ??
+              (await fetchDirectManifestLayoutUrl(manifestResult.manifestUrl, controller.signal)));
+        if (layoutUrl == undefined) {
+          setBlankSharedLayout(setCurrentLayout);
+          return;
+        }
+
+        const response = await fetch(layoutUrl, { signal: controller.signal });
         if (!response.ok) {
           throw new Error(`HTTP ${response.status}`);
         }
@@ -64,6 +116,7 @@ export function ShareManifestLayoutSyncAdapter(): ReactNull {
         enqueueSnackbar(`Shared layout could not be loaded. ${(error as Error).message}`, {
           variant: "error",
         });
+        setBlankSharedLayout(setCurrentLayout);
       }
     })();
 

--- a/packages/studio-base/src/dataSources/CoSceneDataPlatformDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/CoSceneDataPlatformDataSourceFactory.ts
@@ -15,11 +15,7 @@ import {
   IDataSourceFactory,
   DataSourceFactoryInitializeArgs,
 } from "@foxglove/studio-base/context/PlayerSelectionContext";
-import {
-  IterablePlayer,
-  WorkerIterableSource,
-  WorkerSerializedIterableSource,
-} from "@foxglove/studio-base/players/IterablePlayer";
+import { IterablePlayer, WorkerIterableSource } from "@foxglove/studio-base/players/IterablePlayer";
 import {
   findMatchingShardProfilePreference,
   loadShardProfilePreference,
@@ -33,49 +29,23 @@ import type {
 import { Player } from "@foxglove/studio-base/players/types";
 import { getAppConfig, getDomainConfig } from "@foxglove/studio-base/util/appConfig";
 import { parseAppURLState } from "@foxglove/studio-base/util/appURLState";
+import {
+  MANIFEST_URL_PARAM,
+  SHARD_MODE_RAW,
+  SHARD_MODE_PARAM,
+} from "@foxglove/studio-base/util/shardManifestUrlParams";
 
+import {
+  createShardManifestPlayer,
+  definedUrlParams,
+  stableJsonStringify,
+} from "./createShardManifestPlayer";
 import { buildManifestUrl, getManifestStorageBaseUrl, manifestExists } from "./manifestStorage";
 
 export { buildManifestUrl } from "./manifestStorage";
 
-const SHARD_MODE_PARAM = "shardMode";
-const SHARD_MODE_MANIFEST = "manifest";
-const SHARD_MODE_RAW = "raw";
-const MANIFEST_URL_PARAM = "manifestUrl";
-
 interface MinimalManifest {
   profiles?: ManifestProfile[];
-}
-
-function definedUrlParams(params?: Record<string, string | undefined>): Record<string, string> {
-  const definedParams: Record<string, string> = {};
-  if (params) {
-    for (const [key, value] of Object.entries(params)) {
-      if (value != undefined) {
-        definedParams[key] = value;
-      }
-    }
-  }
-  return definedParams;
-}
-
-function sortJsonValue(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map(sortJsonValue);
-  }
-  if (value != undefined && typeof value === "object") {
-    const input = value as Record<string, unknown>;
-    const output: Record<string, unknown> = {};
-    for (const key of Object.keys(input).sort()) {
-      output[key] = sortJsonValue(input[key]);
-    }
-    return output;
-  }
-  return value;
-}
-
-function stableJsonStringify(value: unknown): string {
-  return JSON.stringify(sortJsonValue(value)) ?? "";
 }
 
 async function fetchShardProfileOptions(manifestUrl: string): Promise<ShardProfileOption[]> {
@@ -286,40 +256,13 @@ class CoSceneDataPlatformDataSourceFactory implements IDataSourceFactory {
     manifestUrl: string,
   ): Player | undefined {
     const profile = args.params?.profile;
-    const params: Record<string, string> = { url: manifestUrl };
-    if (profile != undefined) {
-      params.profile = profile;
-    }
-
-    const source = new WorkerSerializedIterableSource({
-      initWorker: () => {
-        // foxglove-depcheck-used: babel-plugin-transform-import-meta
-        return new Worker(
-          new URL(
-            "@foxglove/studio-base/players/IterablePlayer/coScene-shard-manifest/ShardManifestIterableSource.worker",
-            import.meta.url,
-          ),
-        );
-      },
-      initArgs: { params },
-    });
-
-    return new IterablePlayer({
+    return createShardManifestPlayer({
       metricsCollector: args.metricsCollector,
-      source,
       sourceId: this.id,
-      urlParams: {
-        ...definedUrlParams(args.params),
-        [SHARD_MODE_PARAM]: SHARD_MODE_MANIFEST,
-        [MANIFEST_URL_PARAM]: manifestUrl,
-      },
-      readAheadDuration: { sec: 10, nsec: 0 },
+      manifestUrl,
+      profile,
       name: profile ? `Shard manifest (${profile})` : "Shard manifest",
-      enablePlaybackSpillCache: true,
-      playbackSpillCacheSourceKey: stableJsonStringify({
-        sourceId: this.id,
-        params,
-      }),
+      urlParams: args.params,
     });
   }
 }

--- a/packages/studio-base/src/dataSources/CoSceneShareManifestDataSourceFactory.test.ts
+++ b/packages/studio-base/src/dataSources/CoSceneShareManifestDataSourceFactory.test.ts
@@ -85,6 +85,77 @@ describe("CoSceneShareManifestDataSourceFactory", () => {
         url: manifest.links.mini_mcap,
       }),
     });
+    expect(mockIterablePlayer.mock.calls[0]?.[0]).not.toMatchObject({
+      urlParams: { shardMode: "manifest" },
+    });
+    expect(mockIterablePlayer.mock.calls[0]?.[0]).not.toMatchObject({
+      urlParams: { manifestUrl: expect.any(String) },
+    });
+  });
+
+  it("uses direct manifestUrl params as a shard manifest source", () => {
+    const manifestUrl = "https://mock-storage.example.com/public/shards/manifest.json";
+    const layoutUrl = "https://mock-storage.example.com/public/layouts/share.json";
+    const factory = new CoSceneShareManifestDataSourceFactory();
+
+    factory.initialize({
+      metricsCollector: undefined as never,
+      params: {
+        manifestUrl,
+        layoutUrl,
+        profile: "720p",
+      },
+    });
+
+    expect(mockWorkerSerializedIterableSource).toHaveBeenCalledTimes(1);
+    expect(mockWorkerSerializedIterableSource.mock.calls[0]?.[0]).toMatchObject({
+      initArgs: { params: { url: manifestUrl, profile: "720p" } },
+    });
+    expect(mockIterablePlayer).toHaveBeenCalledTimes(1);
+    expect(mockIterablePlayer.mock.calls[0]?.[0]).toMatchObject({
+      sourceId: SHARE_MANIFEST_DATA_SOURCE_ID,
+      urlParams: {
+        shardMode: "manifest",
+        manifestUrl,
+        layoutUrl,
+        profile: "720p",
+      },
+      name: "Shared shard manifest (720p)",
+      enablePlaybackSpillCache: true,
+      playbackSpillCacheSourceKey: JSON.stringify({
+        params: { profile: "720p", url: manifestUrl },
+        sourceId: SHARE_MANIFEST_DATA_SOURCE_ID,
+      }),
+    });
+  });
+
+  it("ignores raw profile params for direct shard manifest sources", () => {
+    const manifestUrl = "https://mock-storage.example.com/public/shards/manifest.json";
+    const factory = new CoSceneShareManifestDataSourceFactory();
+
+    factory.initialize({
+      metricsCollector: undefined as never,
+      params: {
+        manifestUrl,
+        profile: "raw",
+      },
+    });
+
+    expect(mockWorkerSerializedIterableSource.mock.calls[0]?.[0]).toMatchObject({
+      initArgs: { params: { url: manifestUrl } },
+    });
+    expect(mockWorkerSerializedIterableSource.mock.calls[0]?.[0]).not.toMatchObject({
+      initArgs: { params: { profile: "raw" } },
+    });
+    expect(mockIterablePlayer.mock.calls[0]?.[0]).toMatchObject({
+      urlParams: {
+        shardMode: "manifest",
+        manifestUrl,
+      },
+    });
+    expect(mockIterablePlayer.mock.calls[0]?.[0]).not.toMatchObject({
+      urlParams: { profile: "raw" },
+    });
   });
 
   it("rejects expired manifests before constructing a player", () => {

--- a/packages/studio-base/src/dataSources/CoSceneShareManifestDataSourceFactory.ts
+++ b/packages/studio-base/src/dataSources/CoSceneShareManifestDataSourceFactory.ts
@@ -15,10 +15,14 @@ import {
 } from "@foxglove/studio-base/players/IterablePlayer";
 import { Player } from "@foxglove/studio-base/players/types";
 import {
+  SHARE_MANIFEST_DIRECT_LAYOUT_URL_PARAM,
+  SHARE_MANIFEST_DIRECT_MANIFEST_URL_PARAM,
   SHARE_MANIFEST_DATA_SOURCE_ID,
   SHARE_MANIFEST_HASH_PARAM,
-  parseEncodedShareManifest,
+  parseShareManifestParams,
 } from "@foxglove/studio-base/util/shareManifest";
+
+import { createShardManifestPlayer } from "./createShardManifestPlayer";
 
 class CoSceneShareManifestDataSourceFactory implements IDataSourceFactory {
   public id = SHARE_MANIFEST_DATA_SOURCE_ID;
@@ -28,17 +32,34 @@ class CoSceneShareManifestDataSourceFactory implements IDataSourceFactory {
   public hidden = true;
 
   public initialize(args: DataSourceFactoryInitializeArgs): Player | undefined {
-    const encodedManifest = args.params?.[SHARE_MANIFEST_HASH_PARAM];
-    if (!encodedManifest) {
+    const result = parseShareManifestParams(args.params);
+    if (result.status === "missing") {
       throw new Error("Missing share manifest argument");
     }
-
-    const result = parseEncodedShareManifest(encodedManifest);
     if (result.status === "expired") {
       throw new Error("Share manifest has expired");
     }
     if (result.status === "invalid") {
       throw result.error;
+    }
+
+    if (result.kind === "direct") {
+      return createShardManifestPlayer({
+        metricsCollector: args.metricsCollector,
+        sourceId: this.id,
+        manifestUrl: result.manifestUrl,
+        profile: result.profile,
+        name: result.profile
+          ? `Shared shard manifest (${result.profile})`
+          : "Shared shard manifest",
+        urlParams: {
+          [SHARE_MANIFEST_DIRECT_MANIFEST_URL_PARAM]: result.manifestUrl,
+          ...(result.layoutUrl != undefined
+            ? { [SHARE_MANIFEST_DIRECT_LAYOUT_URL_PARAM]: result.layoutUrl }
+            : {}),
+          ...(result.profile != undefined ? { profile: result.profile } : {}),
+        },
+      });
     }
 
     const miniMcapUrl = result.manifest.links.mini_mcap;
@@ -60,7 +81,7 @@ class CoSceneShareManifestDataSourceFactory implements IDataSourceFactory {
       source,
       sourceId: this.id,
       name: "Shared MCAP",
-      urlParams: { [SHARE_MANIFEST_HASH_PARAM]: encodedManifest },
+      urlParams: { [SHARE_MANIFEST_HASH_PARAM]: result.encodedManifest },
       readAheadDuration: { sec: 10, nsec: 0 },
       enablePlaybackSpillCache: true,
       playbackSpillCacheSourceKey: JSON.stringify({ sourceId: this.id, url: miniMcapUrl }),

--- a/packages/studio-base/src/dataSources/createShardManifestPlayer.ts
+++ b/packages/studio-base/src/dataSources/createShardManifestPlayer.ts
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { DataSourceFactoryInitializeArgs } from "@foxglove/studio-base/context/PlayerSelectionContext";
+import {
+  IterablePlayer,
+  WorkerSerializedIterableSource,
+} from "@foxglove/studio-base/players/IterablePlayer";
+import { Player } from "@foxglove/studio-base/players/types";
+import {
+  MANIFEST_URL_PARAM,
+  SHARD_MODE_MANIFEST,
+  SHARD_MODE_PARAM,
+} from "@foxglove/studio-base/util/shardManifestUrlParams";
+
+export function definedUrlParams(
+  params?: Record<string, string | undefined>,
+): Record<string, string> {
+  const definedParams: Record<string, string> = {};
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      if (value != undefined) {
+        definedParams[key] = value;
+      }
+    }
+  }
+  return definedParams;
+}
+
+function sortJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortJsonValue);
+  }
+  if (value != undefined && typeof value === "object") {
+    const input = value as Record<string, unknown>;
+    const output: Record<string, unknown> = {};
+    for (const key of Object.keys(input).sort()) {
+      output[key] = sortJsonValue(input[key]);
+    }
+    return output;
+  }
+  return value;
+}
+
+export function stableJsonStringify(value: unknown): string {
+  return JSON.stringify(sortJsonValue(value)) ?? "";
+}
+
+export function createShardManifestPlayer(args: {
+  metricsCollector: DataSourceFactoryInitializeArgs["metricsCollector"];
+  sourceId: string;
+  manifestUrl: string;
+  profile?: string;
+  name: string;
+  urlParams?: Record<string, string | undefined>;
+}): Player {
+  const sourceParams: Record<string, string> = { url: args.manifestUrl };
+  if (args.profile != undefined) {
+    sourceParams.profile = args.profile;
+  }
+
+  const source = new WorkerSerializedIterableSource({
+    initWorker: () => {
+      return new Worker(
+        // foxglove-depcheck-used: babel-plugin-transform-import-meta
+        new URL(
+          "@foxglove/studio-base/players/IterablePlayer/coScene-shard-manifest/ShardManifestIterableSource.worker",
+          import.meta.url,
+        ),
+      );
+    },
+    initArgs: { params: sourceParams },
+  });
+
+  const urlParams: Record<string, string> = {
+    ...definedUrlParams(args.urlParams),
+    [SHARD_MODE_PARAM]: SHARD_MODE_MANIFEST,
+    [MANIFEST_URL_PARAM]: args.manifestUrl,
+  };
+  if (args.profile != undefined) {
+    urlParams.profile = args.profile;
+  } else {
+    delete urlParams.profile;
+  }
+
+  return new IterablePlayer({
+    metricsCollector: args.metricsCollector,
+    source,
+    sourceId: args.sourceId,
+    urlParams,
+    readAheadDuration: { sec: 10, nsec: 0 },
+    name: args.name,
+    enablePlaybackSpillCache: true,
+    playbackSpillCacheSourceKey: stableJsonStringify({
+      sourceId: args.sourceId,
+      params: sourceParams,
+    }),
+  });
+}

--- a/packages/studio-base/src/services/CoSceneConsoleApiRemoteLayoutStorage.ts
+++ b/packages/studio-base/src/services/CoSceneConsoleApiRemoteLayoutStorage.ts
@@ -21,7 +21,7 @@ import {
   RemoteLayout,
 } from "@foxglove/studio-base/services/CoSceneIRemoteLayoutStorage";
 import ConsoleApi from "@foxglove/studio-base/services/api/CoSceneConsoleApi";
-import { replaceNullWithUndefined } from "@foxglove/studio-base/util/coscene";
+import { isAuthlessDataSource, replaceNullWithUndefined } from "@foxglove/studio-base/util/coscene";
 
 import { ISO8601Timestamp } from "./CoSceneILayoutStorage";
 
@@ -97,6 +97,10 @@ export default class CoSceneConsoleApiRemoteLayoutStorage implements IRemoteLayo
   ) {}
 
   public async getLayouts(): Promise<readonly RemoteLayout[]> {
+    if (isAuthlessDataSource()) {
+      return [];
+    }
+
     try {
       const parents = [this.userName];
       if (this.projectName) {

--- a/packages/studio-base/src/util/shardManifestUrlParams.ts
+++ b/packages/studio-base/src/util/shardManifestUrlParams.ts
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export const SHARD_MODE_PARAM = "shardMode";
+export const SHARD_MODE_MANIFEST = "manifest";
+export const SHARD_MODE_RAW = "raw";
+export const MANIFEST_URL_PARAM = "manifestUrl";

--- a/packages/studio-base/src/util/shareManifest.test.ts
+++ b/packages/studio-base/src/util/shareManifest.test.ts
@@ -47,6 +47,99 @@ describe("share manifest URL parsing", () => {
       parseShareManifestFromUrl(new URL(`https://example.com/viz#manifest=${encoded}`), now),
     ).toEqual({
       status: "valid",
+      kind: "encoded",
+      encodedManifest: encoded,
+      manifest,
+    });
+  });
+
+  it("parses direct shard manifest hash parameters", () => {
+    expect(
+      parseShareManifestFromUrl(
+        new URL(
+          "https://example.com/viz?ds=coscene-share-manifest&ds.profile=720p#manifestUrl=https%3A%2F%2Fstorage.example.com%2Fshards%2Fmanifest.json&layoutUrl=https%3A%2F%2Fstorage.example.com%2Flayouts%2Fshare.json",
+        ),
+        now,
+      ),
+    ).toEqual({
+      status: "valid",
+      kind: "direct",
+      manifestUrl: "https://storage.example.com/shards/manifest.json",
+      layoutUrl: "https://storage.example.com/layouts/share.json",
+      profile: "720p",
+    });
+  });
+
+  it("allows direct shard manifest URLs without layout URLs", () => {
+    expect(
+      parseShareManifestFromUrl(
+        new URL(
+          "https://example.com/viz?ds=coscene-share-manifest#manifestUrl=https%3A%2F%2Fstorage.example.com%2Fshards%2Fmanifest.json",
+        ),
+        now,
+      ),
+    ).toEqual({
+      status: "valid",
+      kind: "direct",
+      manifestUrl: "https://storage.example.com/shards/manifest.json",
+    });
+  });
+
+  it("ignores raw profile on direct shard manifest URLs", () => {
+    expect(
+      parseShareManifestFromUrl(
+        new URL(
+          "https://example.com/viz?ds=coscene-share-manifest&ds.profile=raw#manifestUrl=https%3A%2F%2Fstorage.example.com%2Fshards%2Fmanifest.json",
+        ),
+        now,
+      ),
+    ).toEqual({
+      status: "valid",
+      kind: "direct",
+      manifestUrl: "https://storage.example.com/shards/manifest.json",
+    });
+  });
+
+  it("rejects direct shard manifest URLs with non-http URLs", () => {
+    expect(
+      parseShareManifestFromUrl(
+        new URL(
+          "https://example.com/viz#manifestUrl=file%3A%2F%2Fstorage.example.com%2Fmanifest.json",
+        ),
+        now,
+      ),
+    ).toMatchObject({ status: "invalid" });
+    expect(
+      parseShareManifestFromUrl(
+        new URL(
+          "https://example.com/viz#manifestUrl=https%3A%2F%2Fstorage.example.com%2Fmanifest.json&layoutUrl=ftp%3A%2F%2Fstorage.example.com%2Flayout.json",
+        ),
+        now,
+      ),
+    ).toMatchObject({ status: "invalid" });
+  });
+
+  it("prefers encoded manifests when both encoded and direct parameters exist", () => {
+    const manifest = {
+      version: 1,
+      expireTime: future,
+      links: {
+        mini_mcap: "https://mock-storage.example.com/artifacts/process.mini.mcap?sig=1",
+        layout: "https://mock-storage.example.com/shares/layout.json?sig=2",
+      },
+    };
+    const encoded = encodeBase64Url(manifest);
+
+    expect(
+      parseShareManifestFromUrl(
+        new URL(
+          `https://example.com/viz#manifest=${encoded}&manifestUrl=https%3A%2F%2Fstorage.example.com%2Fshards%2Fmanifest.json`,
+        ),
+        now,
+      ),
+    ).toEqual({
+      status: "valid",
+      kind: "encoded",
       encodedManifest: encoded,
       manifest,
     });
@@ -157,5 +250,13 @@ describe("share manifest URL parsing", () => {
       isShareManifestUrl(new URL(`https://example.com/viz#manifest=${expiredEncoded}`), now),
     ).toBe(true);
     expect(isShareManifestUrl(new URL(`https://example.com/viz#${validEncoded}`), now)).toBe(false);
+    expect(
+      isShareManifestUrl(
+        new URL(
+          "https://example.com/viz#manifestUrl=https%3A%2F%2Fstorage.example.com%2Fmanifest.json",
+        ),
+        now,
+      ),
+    ).toBe(true);
   });
 });

--- a/packages/studio-base/src/util/shareManifest.ts
+++ b/packages/studio-base/src/util/shareManifest.ts
@@ -7,6 +7,11 @@
 
 export const SHARE_MANIFEST_DATA_SOURCE_ID = "coscene-share-manifest";
 export const SHARE_MANIFEST_HASH_PARAM = "manifest";
+export const SHARE_MANIFEST_DIRECT_MANIFEST_URL_PARAM = "manifestUrl";
+export const SHARE_MANIFEST_DIRECT_LAYOUT_URL_PARAM = "layoutUrl";
+const SHARE_MANIFEST_PROFILE_PARAM = "profile";
+const URL_PROFILE_PARAM = "ds.profile";
+const RAW_PROFILE_ID = "raw";
 
 export type ShareManifest = {
   version: 1;
@@ -17,11 +22,24 @@ export type ShareManifest = {
   };
 };
 
-export type ShareManifestParseResult =
-  | { status: "missing" }
+export type EncodedShareManifestParseResult =
   | { status: "expired"; encodedManifest: string; expireTime: string }
   | { status: "invalid"; encodedManifest: string; error: Error }
-  | { status: "valid"; encodedManifest: string; manifest: ShareManifest };
+  | { status: "valid"; kind: "encoded"; encodedManifest: string; manifest: ShareManifest };
+
+export type DirectShareManifestParseResult = {
+  status: "valid";
+  kind: "direct";
+  manifestUrl: string;
+  layoutUrl?: string;
+  profile?: string;
+};
+
+export type ShareManifestParseResult =
+  | { status: "missing" }
+  | EncodedShareManifestParseResult
+  | { status: "invalid"; encodedManifest?: string; error: Error }
+  | DirectShareManifestParseResult;
 
 const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/;
 
@@ -50,9 +68,15 @@ function isHttpUrl(value: string): boolean {
   }
 }
 
-function getManifestHashParam(url: URL): string | undefined {
-  const params = new URLSearchParams(url.hash.startsWith("#") ? url.hash.slice(1) : url.hash);
-  return params.get(SHARE_MANIFEST_HASH_PARAM) ?? undefined;
+function getHashParams(url: URL): URLSearchParams {
+  return new URLSearchParams(url.hash.startsWith("#") ? url.hash.slice(1) : url.hash);
+}
+
+function cleanShareProfile(profile: string | undefined): string | undefined {
+  if (profile == undefined || profile.length === 0 || profile === RAW_PROFILE_ID) {
+    return undefined;
+  }
+  return profile;
 }
 
 function asShareManifest(raw: unknown): ShareManifest {
@@ -89,18 +113,65 @@ export function parseShareManifestFromUrl(
   url: URL,
   now: Date = new Date(),
 ): ShareManifestParseResult {
-  const encodedManifest = getManifestHashParam(url);
-  if (encodedManifest == undefined || encodedManifest.length === 0) {
-    return { status: "missing" };
+  const hashParams = getHashParams(url);
+  return parseShareManifestParams(
+    {
+      [SHARE_MANIFEST_HASH_PARAM]: hashParams.get(SHARE_MANIFEST_HASH_PARAM) ?? undefined,
+      [SHARE_MANIFEST_DIRECT_MANIFEST_URL_PARAM]:
+        hashParams.get(SHARE_MANIFEST_DIRECT_MANIFEST_URL_PARAM) ?? undefined,
+      [SHARE_MANIFEST_DIRECT_LAYOUT_URL_PARAM]:
+        hashParams.get(SHARE_MANIFEST_DIRECT_LAYOUT_URL_PARAM) ?? undefined,
+      [SHARE_MANIFEST_PROFILE_PARAM]: url.searchParams.get(URL_PROFILE_PARAM) ?? undefined,
+    },
+    now,
+  );
+}
+
+export function parseShareManifestParams(
+  params: Record<string, string | undefined> | undefined,
+  now: Date = new Date(),
+): ShareManifestParseResult {
+  const encodedManifest = params?.[SHARE_MANIFEST_HASH_PARAM];
+  if (encodedManifest != undefined && encodedManifest.length > 0) {
+    return parseEncodedShareManifest(encodedManifest, now);
   }
 
-  return parseEncodedShareManifest(encodedManifest, now);
+  const manifestUrl = params?.[SHARE_MANIFEST_DIRECT_MANIFEST_URL_PARAM];
+  if (manifestUrl == undefined) {
+    return { status: "missing" };
+  }
+  if (!isHttpUrl(manifestUrl)) {
+    return {
+      status: "invalid",
+      error: new Error("Share manifestUrl must be an HTTP(S) URL"),
+    };
+  }
+
+  const rawLayoutUrl = params?.[SHARE_MANIFEST_DIRECT_LAYOUT_URL_PARAM];
+  const layoutUrl = rawLayoutUrl != undefined && rawLayoutUrl.length > 0 ? rawLayoutUrl : undefined;
+  if (layoutUrl != undefined && !isHttpUrl(layoutUrl)) {
+    return {
+      status: "invalid",
+      error: new Error("Share layoutUrl must be an HTTP(S) URL"),
+    };
+  }
+
+  return {
+    status: "valid",
+    kind: "direct",
+    manifestUrl,
+    ...(layoutUrl != undefined ? { layoutUrl } : {}),
+    ...(() => {
+      const profile = cleanShareProfile(params?.[SHARE_MANIFEST_PROFILE_PARAM]);
+      return profile != undefined ? { profile } : {};
+    })(),
+  };
 }
 
 export function parseEncodedShareManifest(
   encodedManifest: string,
   now: Date = new Date(),
-): Exclude<ShareManifestParseResult, { status: "missing" }> {
+): EncodedShareManifestParseResult {
   let raw: unknown;
   try {
     raw = decodeBase64UrlJson(encodedManifest);
@@ -125,7 +196,7 @@ export function parseEncodedShareManifest(
   }
 
   try {
-    return { status: "valid", encodedManifest, manifest: asShareManifest(raw) };
+    return { status: "valid", kind: "encoded", encodedManifest, manifest: asShareManifest(raw) };
   } catch (error) {
     return {
       status: "invalid",


### PR DESCRIPTION
## Summary
- support both encoded `#manifest=<base64url>` and direct `#manifestUrl=...&layoutUrl=...` share manifest links
- route direct share links through shard manifest playback while preserving the old MCAP mini_mcap path
- hide/ignore `raw` for share links and only show the profile selector when multiple non-raw share profiles exist
- keep share layouts transient, with `layoutUrl > manifest.links.layout > blank layout` fallback

## Validation
- `yarn jest packages/studio-base/src/util/shareManifest.test.ts packages/studio-base/src/dataSources/CoSceneShareManifestDataSourceFactory.test.ts packages/studio-base/src/components/ShareManifestLayoutSyncAdapter.test.tsx packages/studio-base/src/components/DeepLinksSyncAdapter.test.tsx packages/studio-base/src/components/AppBar/ShardProfileSelector.test.tsx packages/studio-base/src/dataSources/CoSceneDataPlatformDataSourceFactory.test.ts --runInBand`
- `yarn tsc --noEmit --project packages/studio-base/tsconfig.json --pretty false`
- targeted `yarn eslint --config eslint.config.ci.cjs ...`
- targeted `yarn prettier --check ...`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785483943&installation_id=141984720&pr_number=1382&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1382&signature=cec659cbe62872e1094a34e53ae2c054ee1c7ada5bf4f92857fc9e3f9edad98f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->