### PR TITLE
Refine compressed video playback error handling

### DIFF
--- a/.codegraph
+++ b/.codegraph
@@ -1,0 +1,1 @@
+/Users/lijunhui/.omo/codegraph/projects/honeybee-bfa8759f191430a3

--- a/packages/den/video/VideoPlayer.test.ts
+++ b/packages/den/video/VideoPlayer.test.ts
@@ -29,12 +29,14 @@ class MockVideoDecoder {
 
   public state: CodecState = "unconfigured";
   public readonly chunks: MockEncodedVideoChunk[] = [];
+  public configuredConfig: VideoDecoderConfig | undefined;
 
   public constructor(private readonly init: VideoDecoderInit) {
     MockVideoDecoder.instances.push(this);
   }
 
-  public configure(_config: VideoDecoderConfig): void {
+  public configure(config: VideoDecoderConfig): void {
+    this.configuredConfig = config;
     this.state = "configured";
   }
 
@@ -89,6 +91,27 @@ describe("VideoPlayer", () => {
 
   afterEach(() => {
     jest.useRealTimers();
+  });
+
+  it("configures the decoder with the supported hardware acceleration preference", async () => {
+    const player = new VideoPlayer();
+    await player.init({ codec: "avc1.640028" });
+
+    const decoder = MockVideoDecoder.instances[0];
+    if (decoder == undefined) {
+      throw new Error("Expected a VideoDecoder instance");
+    }
+
+    expect(MockVideoDecoder.isConfigSupported).toHaveBeenCalledWith({
+      codec: "avc1.640028",
+      optimizeForLatency: true,
+      hardwareAcceleration: "prefer-hardware",
+    });
+    expect(decoder.configuredConfig).toEqual({
+      codec: "avc1.640028",
+      optimizeForLatency: true,
+      hardwareAcceleration: "prefer-hardware",
+    });
   });
 
   it("resolves decodeAndWaitForFrame with the frame matching the submitted timestamp", async () => {

--- a/packages/den/video/VideoPlayer.ts
+++ b/packages/den/video/VideoPlayer.ts
@@ -134,22 +134,24 @@ export class VideoPlayer extends EventEmitter<VideoPlayerEventTypes> {
     await this.#mutex.runExclusive(async () => {
       // Optimize for latency means we do not have to call flush() in every decode() call
       // See <https://github.com/w3c/webcodecs/issues/206>
-      decoderConfig.optimizeForLatency = true;
+      const latencyConfig: VideoDecoderConfig = { ...decoderConfig, optimizeForLatency: true };
 
       // Try with 'prefer-hardware' first
-      let modifiedConfig = { ...decoderConfig };
-      modifiedConfig.hardwareAcceleration = "prefer-hardware";
+      let selectedConfig: VideoDecoderConfig = {
+        ...latencyConfig,
+        hardwareAcceleration: "prefer-hardware",
+      };
 
-      let support = await VideoDecoder.isConfigSupported(modifiedConfig);
+      let support = await VideoDecoder.isConfigSupported(selectedConfig);
       if (support.supported !== true) {
         log.warn(
           `VideoDecoder does not support configuration ${JSON.stringify(
-            modifiedConfig,
+            selectedConfig,
           )}. Trying without 'prefer-hardware'`,
         );
         // If 'prefer-hardware' is not supported, try without it
-        modifiedConfig = { ...decoderConfig };
-        support = await VideoDecoder.isConfigSupported(modifiedConfig);
+        selectedConfig = latencyConfig;
+        support = await VideoDecoder.isConfigSupported(selectedConfig);
       }
 
       if (support.supported !== true) {
@@ -165,12 +167,12 @@ export class VideoPlayer extends EventEmitter<VideoPlayerEventTypes> {
         this.#decoder = new VideoDecoder(this.#decoderInit);
       }
 
-      this.emit("debug", `Configuring VideoDecoder with ${JSON.stringify(decoderConfig)}`);
-      this.#decoder.configure(decoderConfig);
-      this.#decoderConfig = decoderConfig;
+      this.emit("debug", `Configuring VideoDecoder with ${JSON.stringify(selectedConfig)}`);
+      this.#decoder.configure(selectedConfig);
+      this.#decoderConfig = selectedConfig;
       this.#codedSize = undefined;
-      if (decoderConfig.codedWidth != undefined && decoderConfig.codedHeight != undefined) {
-        this.#codedSize = { width: decoderConfig.codedWidth, height: decoderConfig.codedHeight };
+      if (selectedConfig.codedWidth != undefined && selectedConfig.codedHeight != undefined) {
+        this.#codedSize = { width: selectedConfig.codedWidth, height: selectedConfig.codedHeight };
       }
     });
   }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.test.ts
@@ -301,15 +301,16 @@ describe("ImageMode compressed video seek replay", () => {
 
     subscription.handler(keyframe);
     subscription.handler(delta);
+    await flushAsyncWork();
 
-    expect(messageHandler.handleCompressedVideo).toHaveBeenCalledTimes(2);
+    expect(messageHandler.handleCompressedVideo).toHaveBeenCalledTimes(1);
     expect(imageMode.createdRenderables).toHaveLength(0);
 
     renderer.currentTime = 10_000_000n;
     imageMode.handleSeek();
     await flushAsyncWork();
 
-    expect(messageHandler.handleCompressedVideo).toHaveBeenCalledTimes(2);
+    expect(messageHandler.handleCompressedVideo).toHaveBeenCalledTimes(1);
     expect(imageMode.createdRenderables).toHaveLength(1);
     expect(
       imageMode.createdRenderables[0]!.setCompressedVideoFrameBatches.map((batch) =>
@@ -402,7 +403,6 @@ describe("ImageMode compressed video seek replay", () => {
     await flushAsyncWork();
 
     expect(imageMode.createdRenderables[0]!.setImageCalls.map(timestampFromImage)).toEqual([
-      keyframe.message.timestamp,
       delta.message.timestamp,
     ]);
     expect(

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.test.ts
@@ -153,7 +153,7 @@ class TestImageRenderable extends ImageRenderable {
   ): Promise<ImageSetImageResult> {
     const targetFrame = frames[frames.length - 1];
     if (targetFrame == undefined) {
-      return { ok: false };
+      return { ok: false, reason: "failed" };
     }
 
     this.userData.image = targetFrame.message;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -110,7 +110,7 @@ import { topicIsConvertibleToSchema } from "../../topicIsConvertibleToSchema";
 import { ICameraHandler } from "../ICameraHandler";
 import { normalizeCompressedVideo } from "../Images/imageNormalizers";
 import { getTopicMatchPrefix, sortPrefixMatchesToFront } from "../Images/topicPrefixMatching";
-import { filterCompressedVideoQueue } from "../Images/videoMessageQueue";
+import { recordKeyframesAndFilterCompressedVideoQueue } from "../Images/videoMessageQueue";
 import { colorModeSettingsFields } from "../colorMode";
 
 const log = Logger.getLogger(__filename);
@@ -290,7 +290,7 @@ export class ImageMode
         subscription: {
           handler: this.#handleCompressedVideo,
           shouldSubscribe: this.imageShouldSubscribe,
-          filterQueue: filterCompressedVideoQueue,
+          filterQueue: this.#filterCompressedVideoQueue,
         },
       },
     ];
@@ -750,6 +750,14 @@ export class ImageMode
       message: normalizeCompressedVideo(messageEvent.message),
     } as MessageEvent<CompressedVideo>;
     this.#compressedVideoControllerForTopic(normalizedEvent.topic).processMessage(normalizedEvent);
+  };
+
+  #filterCompressedVideoQueue = (
+    queue: Parameters<typeof recordKeyframesAndFilterCompressedVideoQueue>[0],
+  ): ReturnType<typeof recordKeyframesAndFilterCompressedVideoQueue> => {
+    return recordKeyframesAndFilterCompressedVideoQueue(queue, (messageEvent) => {
+      this.#compressedVideoControllerForTopic(messageEvent.topic).recordKeyframeIndex(messageEvent);
+    });
   };
 
   #displayCompressedVideoFrames: CompressedVideoDisplayFrames = async (

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.ts
@@ -755,8 +755,11 @@ export class ImageMode
   #filterCompressedVideoQueue = (
     queue: Parameters<typeof recordKeyframesAndFilterCompressedVideoQueue>[0],
   ): ReturnType<typeof recordKeyframesAndFilterCompressedVideoQueue> => {
-    return recordKeyframesAndFilterCompressedVideoQueue(queue, (messageEvent) => {
-      this.#compressedVideoControllerForTopic(messageEvent.topic).recordKeyframeIndex(messageEvent);
+    return recordKeyframesAndFilterCompressedVideoQueue(queue, (topic, receiveTime) => {
+      this.#compressedVideoControllerForTopic(topic).recordKnownKeyframeReceiveTime(
+        topic,
+        receiveTime,
+      );
     });
   };
 
@@ -767,7 +770,7 @@ export class ImageMode
   ): Promise<ImageSetImageResult> => {
     const targetFrame = frames[frames.length - 1];
     if (targetFrame == undefined) {
-      return { ok: false };
+      return { ok: false, reason: "failed" };
     }
 
     if (mode === "direct") {
@@ -778,7 +781,7 @@ export class ImageMode
       return await this.#setCompressedVideoFramesOnRenderable(frames, mode, options);
     }
 
-    this.#lastSetImageResult = Promise.resolve({ ok: false });
+    this.#lastSetImageResult = Promise.resolve({ ok: false, reason: "failed" });
     this.messageHandler.handleCompressedVideo(targetFrame);
     return await this.#lastSetImageResult;
   };
@@ -841,7 +844,7 @@ export class ImageMode
   ): Promise<ImageSetImageResult> {
     const targetFrame = frames[frames.length - 1];
     if (targetFrame == undefined) {
-      return { ok: false };
+      return { ok: false, reason: "failed" };
     }
 
     const image = targetFrame.message;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.test.ts
@@ -77,7 +77,7 @@ class TestImageRenderable extends ImageRenderable {
   ): Promise<ImageSetImageResult> {
     const targetFrame = frames[frames.length - 1];
     if (targetFrame == undefined) {
-      return { ok: false };
+      return { ok: false, reason: "failed" };
     }
     this.userData.image = targetFrame.message;
     this.setCompressedVideoFrameBatches.push(frames.map((frame) => frame.message));

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.test.ts
@@ -271,8 +271,7 @@ describe("Images compressed video seek lookback", () => {
 
     subscription.handler(keyframe);
     subscription.handler(delta);
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushAsyncWork();
 
     images.removeAllRenderables();
     images.handleSeek();
@@ -283,8 +282,7 @@ describe("Images compressed video seek lookback", () => {
       renderable.setCompressedVideoFrameBatches.map((batch) => batch.map(timestampFromImage)),
     );
     expect(displayedBatches).toEqual([
-      [keyframe.message.timestamp],
-      [delta.message.timestamp],
+      [keyframe.message.timestamp, delta.message.timestamp],
       [keyframe.message.timestamp, delta.message.timestamp],
     ]);
   });
@@ -302,14 +300,13 @@ describe("Images compressed video seek lookback", () => {
       return jest.fn();
     });
     const renderer = makeRenderer({ subscribeMessageRange });
-    renderer.currentTime = 20_000_000n;
+    renderer.currentTime = 0n;
     const images = new TestImages(renderer);
     const subscription = compressedVideoSubscription(images);
 
     subscription.handler(keyframe);
     subscription.handler(delta);
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushAsyncWork();
 
     const previousRenderable = images.renderables.get("/video") as TestImageRenderable | undefined;
     expect(previousRenderable).toBeDefined();
@@ -319,6 +316,7 @@ describe("Images compressed video seek lookback", () => {
         removeAllRenderables(args?: { reason?: "seek" }): void;
       }
     ).removeAllRenderables({ reason: "seek" });
+    renderer.currentTime = 20_000_000n;
     images.handleSeek();
 
     expect(images.renderables.get("/video")).toBe(previousRenderable);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
@@ -33,7 +33,7 @@ import {
   normalizeRosImage,
 } from "./Images/imageNormalizers";
 import { getTopicMatchPrefix, sortPrefixMatchesToFront } from "./Images/topicPrefixMatching";
-import { filterCompressedVideoQueue } from "./Images/videoMessageQueue";
+import { recordKeyframesAndFilterCompressedVideoQueue } from "./Images/videoMessageQueue";
 import { cameraInfosEqual, normalizeCameraInfo } from "./projections";
 import type { AnyRendererSubscription, IRenderer } from "../IRenderer";
 import {
@@ -189,7 +189,7 @@ export class Images extends SceneExtension<ImageRenderable> {
         schemaNames: COMPRESSED_VIDEO_DATATYPES,
         subscription: {
           handler: this.#handleCompressedVideo,
-          filterQueue: filterCompressedVideoQueue,
+          filterQueue: this.#filterCompressedVideoQueue,
         },
       },
     ];
@@ -413,6 +413,14 @@ export class Images extends SceneExtension<ImageRenderable> {
     return await renderable.setCompressedVideoFrames(frames, {
       ...options,
       resizeWidth: options?.resizeWidth ?? DEFAULT_BITMAP_WIDTH,
+    });
+  };
+
+  #filterCompressedVideoQueue = (
+    queue: Parameters<typeof recordKeyframesAndFilterCompressedVideoQueue>[0],
+  ): ReturnType<typeof recordKeyframesAndFilterCompressedVideoQueue> => {
+    return recordKeyframesAndFilterCompressedVideoQueue(queue, (messageEvent) => {
+      this.#compressedVideoControllerForTopic(messageEvent.topic).recordKeyframeIndex(messageEvent);
     });
   };
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
@@ -407,7 +407,7 @@ export class Images extends SceneExtension<ImageRenderable> {
   #displayCompressedVideoFrames: CompressedVideoDisplayFrames = async (frames, _mode, options) => {
     const targetFrame = frames[frames.length - 1];
     if (targetFrame == undefined) {
-      return { ok: false };
+      return { ok: false, reason: "failed" };
     }
     const renderable = this.#prepareImageRenderable(targetFrame, targetFrame.message);
     return await renderable.setCompressedVideoFrames(frames, {
@@ -419,8 +419,11 @@ export class Images extends SceneExtension<ImageRenderable> {
   #filterCompressedVideoQueue = (
     queue: Parameters<typeof recordKeyframesAndFilterCompressedVideoQueue>[0],
   ): ReturnType<typeof recordKeyframesAndFilterCompressedVideoQueue> => {
-    return recordKeyframesAndFilterCompressedVideoQueue(queue, (messageEvent) => {
-      this.#compressedVideoControllerForTopic(messageEvent.topic).recordKeyframeIndex(messageEvent);
+    return recordKeyframesAndFilterCompressedVideoQueue(queue, (topic, receiveTime) => {
+      this.#compressedVideoControllerForTopic(topic).recordKnownKeyframeReceiveTime(
+        topic,
+        receiveTime,
+      );
     });
   };
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.test.ts
@@ -177,6 +177,26 @@ describe("CompressedVideoController", () => {
     ).toEqual([false]);
   });
 
+  it("continues playback decoding from the previous successful target in the same GOP", async () => {
+    const keyframe = makeVideoMessage(0n, "key");
+    const middle = makeVideoMessage(10_000_000n, "delta");
+    const target = makeVideoMessage(20_000_000n, "delta");
+    const displayFrames = makeSuccessfulDisplayFrames();
+    const controller = makeController({ displayFrames });
+
+    controller.processMessage(keyframe);
+    controller.processMessage(middle);
+    await flushAsyncWork();
+    displayFrames.mockClear();
+
+    controller.processMessage(target);
+    await flushAsyncWork();
+
+    expect(nonResetCalls(displayFrames).map(([frames]) => frameReceiveTimes(frames))).toEqual([
+      [20_000_000n],
+    ]);
+  });
+
   it("treats stale playback results as superseded and then displays the latest pending target", async () => {
     const keyframe = makeVideoMessage(0n, "key");
     const firstTarget = makeVideoMessage(10_000_000n, "delta");
@@ -192,7 +212,7 @@ describe("CompressedVideoController", () => {
       if (displayFrames.mock.calls.length === 1) {
         return await firstDisplay.then(() =>
           options?.isVideoFrameRequestCurrent?.() === false
-            ? { ok: false, stale: true }
+            ? { ok: false, reason: "stale" }
             : { ok: true },
         );
       }
@@ -209,13 +229,46 @@ describe("CompressedVideoController", () => {
     controller.processMessage(latestTarget);
     expect(nonResetCalls(displayFrames)[0]?.[2]?.isVideoFrameRequestCurrent?.()).toBe(false);
 
-    resolveFirstDisplay({ ok: false, stale: true });
+    resolveFirstDisplay({ ok: false, reason: "stale" });
     await flushAsyncWork();
 
     expect(resetDecoder).not.toHaveBeenCalled();
     expect(nonResetCalls(displayFrames).map(([frames]) => frameReceiveTimes(frames))).toEqual([
       [0n, 10_000_000n],
       [0n, 10_000_000n, 20_000_000n],
+    ]);
+  });
+
+  it("continues playback after a superseded target that still decoded successfully", async () => {
+    const keyframe = makeVideoMessage(0n, "key");
+    const firstTarget = makeVideoMessage(10_000_000n, "delta");
+    const latestTarget = makeVideoMessage(20_000_000n, "delta");
+    let resolveFirstDisplay!: (result: ImageSetImageResult) => void;
+    const firstDisplay = new Promise<ImageSetImageResult>((resolve) => {
+      resolveFirstDisplay = resolve;
+    });
+    const displayFrames = jest.fn<
+      Promise<ImageSetImageResult>,
+      Parameters<CompressedVideoDisplayFrames>
+    >(async () => {
+      if (displayFrames.mock.calls.length === 1) {
+        return await firstDisplay;
+      }
+      return { ok: true };
+    });
+    const controller = makeController({ displayFrames });
+
+    controller.processMessage(keyframe);
+    controller.processMessage(firstTarget);
+    await flushAsyncWork();
+
+    controller.processMessage(latestTarget);
+    resolveFirstDisplay({ ok: false, reason: "stale", staleTargetDecoded: true });
+    await flushAsyncWork();
+
+    expect(nonResetCalls(displayFrames).map(([frames]) => frameReceiveTimes(frames))).toEqual([
+      [0n, 10_000_000n],
+      [20_000_000n],
     ]);
   });
 
@@ -241,7 +294,7 @@ describe("CompressedVideoController", () => {
     });
     const controller = makeController({ renderer, displayFrames });
 
-    controller.recordKeyframeIndex(skippedKeyframe);
+    controller.recordKnownKeyframeReceiveTime(skippedKeyframe.topic, skippedKeyframe.receiveTime);
     controller.handleSeek();
     await flushAsyncWork();
 
@@ -434,7 +487,7 @@ describe("CompressedVideoController", () => {
           ? "reset"
           : `display:${frames.map((frame) => toNanoSec(frame.receiveTime)).join(",")}`,
       );
-      return { ok: true };
+      return { ok: true as const };
     });
     const renderer = makeRenderer();
     const controller = makeController({ renderer, displayFrames });
@@ -900,7 +953,7 @@ describe("CompressedVideoController", () => {
       Parameters<CompressedVideoDisplayFrames>
     >(async (frames, mode) => {
       if (mode === "seek" && frameReceiveTimes(frames).at(-1) === 20_000_000n) {
-        return { ok: false };
+        return { ok: false, reason: "failed" };
       }
       return { ok: true };
     });
@@ -976,7 +1029,7 @@ describe("CompressedVideoController", () => {
     ]);
     expect(nonResetCalls(displayFrames).map((call) => call[1])).toEqual(["seek"]);
 
-    resolveStabilization({ ok: false });
+    resolveStabilization({ ok: false, reason: "failed" });
     await flushAsyncWork();
 
     expect(nonResetCalls(displayFrames).map(([frames]) => frameReceiveTimes(frames))).toEqual([
@@ -1208,7 +1261,7 @@ describe("CompressedVideoController", () => {
     const displayFrames = jest.fn<
       Promise<ImageSetImageResult>,
       Parameters<CompressedVideoDisplayFrames>
-    >(async () => ({ ok: false }));
+    >(async () => ({ ok: false, reason: "failed" }));
     const subscribeMessageRange = jest.fn<
       ReturnType<SubscribeMessageRange>,
       Parameters<SubscribeMessageRange>
@@ -1243,7 +1296,7 @@ describe("CompressedVideoController", () => {
       const displayFrames = jest.fn<
         Promise<ImageSetImageResult>,
         Parameters<CompressedVideoDisplayFrames>
-      >(async () => ({ ok: false }));
+      >(async () => ({ ok: false, reason: "failed" }));
       const unsubscribes: jest.Mock[] = [];
       const subscribeMessageRange = jest.fn<
         ReturnType<SubscribeMessageRange>,
@@ -1440,7 +1493,7 @@ describe("CompressedVideoController", () => {
       Parameters<CompressedVideoDisplayFrames>
     >(async (frames, mode) => {
       if (frames.length === 0 || mode === "playback") {
-        return { ok: false };
+        return { ok: false, reason: "failed" };
       }
       return await new Promise<ImageSetImageResult>((resolve) => {
         pendingDisplays.push(resolve);
@@ -1468,8 +1521,8 @@ describe("CompressedVideoController", () => {
     pendingDisplays[1]?.({ ok: true });
     await expect(secondResult).resolves.toEqual({ ok: true });
 
-    pendingDisplays[0]?.({ ok: false });
-    await expect(firstResult).resolves.toEqual({ ok: false });
+    pendingDisplays[0]?.({ ok: false, reason: "failed" });
+    await expect(firstResult).resolves.toEqual({ ok: false, reason: "failed" });
 
     expect(resetCallCount(displayFrames)).toBe(0);
     expect(renderer.queueAnimationFrame).toHaveBeenCalledTimes(1);
@@ -1517,7 +1570,7 @@ describe("CompressedVideoController", () => {
     );
     await flushAsyncWork();
 
-    await expect(firstResult).resolves.toEqual({ ok: false });
+    await expect(firstResult).resolves.toEqual({ ok: false, reason: "failed" });
     await expect(secondResult).resolves.toEqual({ ok: true });
     expect(nonResetCalls(displayFrames).map(([frames]) => frameReceiveTimes(frames))).toEqual([
       [20_000_000n, 30_000_000n],

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.test.ts
@@ -76,6 +76,7 @@ function makeRenderer(
 function makeController(args: {
   renderer?: ReturnType<typeof makeRenderer>;
   displayFrames?: CompressedVideoDisplayFrames;
+  resetDecoder?: () => void;
   onSeekKeyframeSearchChange?: SeekKeyframeSearchChange;
   getSeekReplayTarget?: ConstructorParameters<
     typeof CompressedVideoController
@@ -85,6 +86,7 @@ function makeController(args: {
     topic: "/camera",
     renderer: args.renderer ?? makeRenderer(),
     displayFrames: args.displayFrames ?? (async () => ({ ok: true })),
+    resetDecoder: args.resetDecoder,
     onSeekKeyframeSearchChange: args.onSeekKeyframeSearchChange,
     getSeekReplayTarget: args.getSeekReplayTarget,
   };
@@ -136,20 +138,128 @@ describe("CompressedVideoController", () => {
     jest.restoreAllMocks();
   });
 
-  it("marks non-seek frames as playback display mode", () => {
+  it("marks non-seek frames as playback display mode", async () => {
     const keyframe = makeVideoMessage(0n, "key");
     const displayFrames = makeSuccessfulDisplayFrames();
     const controller = makeController({ displayFrames });
 
     controller.processMessage(keyframe);
+    await flushAsyncWork();
 
     expect(nonResetCalls(displayFrames).map((call) => call[1])).toEqual(["playback"]);
     expect(nonResetCalls(displayFrames).map(([frames]) => frameReceiveTimes(frames))).toEqual([
       [0n],
     ]);
+    expect(
+      nonResetCalls(displayFrames).map((call) => call[2]?.allowIntermediateVideoFrame),
+    ).toEqual([false]);
   });
 
-  it("replays cached GOP frames on seek", () => {
+  it("coalesces playback frames to the latest target while preserving GOP dependencies", async () => {
+    const keyframe = makeVideoMessage(0n, "key");
+    const middle = makeVideoMessage(10_000_000n, "delta");
+    const target = makeVideoMessage(20_000_000n, "delta");
+    const displayFrames = makeSuccessfulDisplayFrames();
+    const controller = makeController({ displayFrames });
+
+    controller.processMessage(keyframe);
+    controller.processMessage(middle);
+    controller.processMessage(target);
+    await flushAsyncWork();
+
+    expect(nonResetCalls(displayFrames)).toHaveLength(1);
+    expect(nonResetCalls(displayFrames).map(([frames]) => frameReceiveTimes(frames))).toEqual([
+      [0n, 10_000_000n, 20_000_000n],
+    ]);
+    expect(nonResetCalls(displayFrames).map((call) => call[1])).toEqual(["playback"]);
+    expect(
+      nonResetCalls(displayFrames).map((call) => call[2]?.allowIntermediateVideoFrame),
+    ).toEqual([false]);
+  });
+
+  it("treats stale playback results as superseded and then displays the latest pending target", async () => {
+    const keyframe = makeVideoMessage(0n, "key");
+    const firstTarget = makeVideoMessage(10_000_000n, "delta");
+    const latestTarget = makeVideoMessage(20_000_000n, "delta");
+    let resolveFirstDisplay!: (result: ImageSetImageResult) => void;
+    const firstDisplay = new Promise<ImageSetImageResult>((resolve) => {
+      resolveFirstDisplay = resolve;
+    });
+    const displayFrames = jest.fn<
+      Promise<ImageSetImageResult>,
+      Parameters<CompressedVideoDisplayFrames>
+    >(async (_frames, _mode, options) => {
+      if (displayFrames.mock.calls.length === 1) {
+        return await firstDisplay.then(() =>
+          options?.isVideoFrameRequestCurrent?.() === false
+            ? { ok: false, stale: true }
+            : { ok: true },
+        );
+      }
+      return { ok: true };
+    });
+    const resetDecoder = jest.fn();
+    const controller = makeController({ displayFrames, resetDecoder });
+
+    controller.processMessage(keyframe);
+    controller.processMessage(firstTarget);
+    await flushAsyncWork();
+    expect(nonResetCalls(displayFrames)).toHaveLength(1);
+
+    controller.processMessage(latestTarget);
+    expect(nonResetCalls(displayFrames)[0]?.[2]?.isVideoFrameRequestCurrent?.()).toBe(false);
+
+    resolveFirstDisplay({ ok: false, stale: true });
+    await flushAsyncWork();
+
+    expect(resetDecoder).not.toHaveBeenCalled();
+    expect(nonResetCalls(displayFrames).map(([frames]) => frameReceiveTimes(frames))).toEqual([
+      [0n, 10_000_000n],
+      [0n, 10_000_000n, 20_000_000n],
+    ]);
+  });
+
+  it("uses keyframe indexes recorded before playback filtering as seek range hints", async () => {
+    const skippedKeyframe = makeVideoMessage(10_000_000_000n, "key");
+    const skippedDelta = makeVideoMessage(12_000_000_000n, "delta");
+    const displayFrames = makeSuccessfulDisplayFrames();
+    const unsubscribe = jest.fn();
+    const subscribeMessageRange = jest.fn<
+      ReturnType<SubscribeMessageRange>,
+      Parameters<SubscribeMessageRange>
+    >(({ onNewRangeIterator }) => {
+      void onNewRangeIterator(
+        (async function* () {
+          yield [skippedKeyframe, skippedDelta];
+        })(),
+      );
+      return unsubscribe;
+    });
+    const renderer = makeRenderer({
+      currentTime: 12_000_000_000n,
+      subscribeMessageRange,
+    });
+    const controller = makeController({ renderer, displayFrames });
+
+    controller.recordKeyframeIndex(skippedKeyframe);
+    controller.handleSeek();
+    await flushAsyncWork();
+
+    expect(subscribeMessageRange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        topic: "/camera",
+        timeRange: {
+          start: { sec: 10, nsec: 0 },
+          end: { sec: 12, nsec: 0 },
+        },
+      }),
+    );
+    expect(nonResetCalls(displayFrames).map(([frames]) => frameReceiveTimes(frames))).toEqual([
+      [10_000_000_000n, 12_000_000_000n],
+    ]);
+  });
+
+  it("replays cached GOP frames on seek", async () => {
     const keyframe = makeVideoMessage(0n, "key");
     const delta = makeVideoMessage(10_000_000n, "delta");
     const displayFrames = makeSuccessfulDisplayFrames();
@@ -158,6 +268,7 @@ describe("CompressedVideoController", () => {
 
     controller.processMessage(keyframe);
     controller.processMessage(delta);
+    await flushAsyncWork();
     displayFrames.mockClear();
 
     renderer.currentTime = 10_000_000n;
@@ -183,6 +294,7 @@ describe("CompressedVideoController", () => {
 
     controller.processMessage(keyframe);
     controller.processMessage(middle);
+    await flushAsyncWork();
     displayFrames.mockClear();
 
     await controller.displayPublishTimeTarget(delta);
@@ -207,6 +319,7 @@ describe("CompressedVideoController", () => {
     controller.processMessage(keyframe);
     controller.processMessage(middle);
     controller.processMessage(delta);
+    await flushAsyncWork();
     displayFrames.mockClear();
 
     await controller.displayPublishTimeTarget(middle);
@@ -273,11 +386,13 @@ describe("CompressedVideoController", () => {
     controller.processMessage(keyframe);
     controller.processMessage(middle);
     controller.processMessage(delta);
+    await flushAsyncWork();
     displayFrames.mockClear();
 
     await controller.displayPublishTimeTarget(middle);
     renderer.currentTime = 20_000_000n;
     controller.handleSeek();
+    await flushAsyncWork();
     displayFrames.mockClear();
 
     await controller.displayPublishTimeTarget(delta);
@@ -295,6 +410,7 @@ describe("CompressedVideoController", () => {
     const controller = makeController({ displayFrames });
 
     controller.processMessage(keyframe);
+    await flushAsyncWork();
     displayFrames.mockClear();
 
     await controller.displayPublishTimeTarget(middle);
@@ -308,7 +424,7 @@ describe("CompressedVideoController", () => {
     ]);
   });
 
-  it("resets the decoder before replaying cached GOP frames on seek", () => {
+  it("resets the decoder before replaying cached GOP frames on seek", async () => {
     const keyframe = makeVideoMessage(0n, "key");
     const delta = makeVideoMessage(10_000_000n, "delta");
     const events: string[] = [];
@@ -325,6 +441,7 @@ describe("CompressedVideoController", () => {
 
     controller.processMessage(keyframe);
     controller.processMessage(delta);
+    await flushAsyncWork();
     displayFrames.mockClear();
     events.length = 0;
 
@@ -764,7 +881,7 @@ describe("CompressedVideoController", () => {
     expect(nonResetCalls(displayFrames).map(([frames]) => frameReceiveTimes(frames))).toEqual([
       [0n, 10_000_000n, 20_000_000n],
       [0n, 10_000_000n, 20_000_000n, 30_000_000n],
-      [40_000_000n],
+      [0n, 10_000_000n, 20_000_000n, 30_000_000n, 40_000_000n],
     ]);
     expect(nonResetCalls(displayFrames).map((call) => call[1])).toEqual([
       "seek",

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts
@@ -69,6 +69,7 @@ type ControllerState = {
   pendingPlaybackTarget?: PlaybackTarget;
   playbackFlushScheduled?: boolean;
   playbackInFlightRequestId?: number;
+  playbackDecoderProgress?: PlaybackDecoderProgress;
 };
 
 type PlaybackTarget = {
@@ -76,6 +77,12 @@ type PlaybackTarget = {
   generation: number;
   requestId: number;
   options: SetCompressedVideoFramesOptions | undefined;
+};
+
+type PlaybackDecoderProgress = {
+  generation: number;
+  keyframeReceiveTimeNs: bigint;
+  decodedThroughReceiveTimeNs: bigint;
 };
 
 type ControllerRenderer = Pick<
@@ -208,11 +215,11 @@ export class CompressedVideoController {
     this.#queuePlaybackTarget(normalizedEvent, options);
   }
 
-  public recordKeyframeIndex(messageEvent: Pick<MessageEvent, "topic" | "receiveTime">): void {
-    if (messageEvent.topic !== this.#topic) {
+  public recordKnownKeyframeReceiveTime(topic: string, receiveTime: Time): void {
+    if (topic !== this.#topic) {
       return;
     }
-    this.#cache.addKnownKeyframeReceiveTime(messageEvent.topic, messageEvent.receiveTime);
+    this.#cache.addKnownKeyframeReceiveTime(topic, receiveTime);
   }
 
   public async displayPublishTimeTarget(
@@ -221,14 +228,14 @@ export class CompressedVideoController {
   ): Promise<ImageSetImageResult> {
     const normalizedEvent = normalizeVideoMessageEvent(messageEvent);
     if (normalizedEvent.topic !== this.#topic) {
-      return { ok: false };
+      return { ok: false, reason: "failed" };
     }
 
     const generation = this.#beginReplayGeneration();
     const frameInfo = parseVideoFrameInfo(normalizedEvent);
     if (frameInfo == undefined) {
       const ok = await this.#displayReplayFrames([normalizedEvent], generation, "direct", options);
-      return { ok };
+      return ok ? { ok: true } : { ok: false, reason: "failed" };
     }
 
     this.#cache.addFrame(normalizedEvent);
@@ -248,7 +255,7 @@ export class CompressedVideoController {
     if (incrementalFrames != undefined) {
       const ok = await this.#displayReplayFrames(incrementalFrames, generation, "direct", options);
       if (!this.#isCurrentGeneration(generation)) {
-        return { ok: false };
+        return { ok: false, reason: "failed" };
       }
       if (ok) {
         this.#state.lastDisplayedPublishTimeNs = toNanoSec(frameInfo.frame.timestamp);
@@ -265,7 +272,7 @@ export class CompressedVideoController {
     if (frames != undefined) {
       const ok = await this.#displayReplayFrames(frames, generation, "direct", options);
       if (!this.#isCurrentGeneration(generation)) {
-        return { ok: false };
+        return { ok: false, reason: "failed" };
       }
       if (ok) {
         this.#state.lastDisplayedPublishTimeNs = toNanoSec(frameInfo.frame.timestamp);
@@ -275,17 +282,16 @@ export class CompressedVideoController {
       this.#resetDecoderForReplay();
     }
 
-    return {
-      ok: await this.#lookBackPublishTimeTarget(
-        normalizedEvent,
-        generation,
-        {
-          type: "publish",
-          time: frameInfo.frame.timestamp,
-        },
-        options,
-      ),
-    };
+    const ok = await this.#lookBackPublishTimeTarget(
+      normalizedEvent,
+      generation,
+      {
+        type: "publish",
+        time: frameInfo.frame.timestamp,
+      },
+      options,
+    );
+    return ok ? { ok: true } : { ok: false, reason: "failed" };
   }
 
   public handleSeek(options?: SetCompressedVideoFramesOptions): void {
@@ -377,6 +383,7 @@ export class CompressedVideoController {
     this.#playbackRequestId++;
     this.#state.pendingPlaybackTarget = undefined;
     this.#state.playbackFlushScheduled = false;
+    this.#state.playbackDecoderProgress = undefined;
   }
 
   #queuePlaybackTarget(
@@ -421,14 +428,29 @@ export class CompressedVideoController {
       return;
     }
 
-    const frames = this.#cache.framesForReceiveTime(
-      this.#topic,
-      target.messageEvent.receiveTime,
-    ) ?? [target.messageEvent];
+    const frames = this.#playbackFramesForTarget(target);
+    if (frames.length === 0) {
+      return;
+    }
     this.#state.playbackInFlightRequestId = target.requestId;
     try {
       const options = this.#playbackDisplayOptions(target);
-      await this.#displayReplayFrames(frames, target.generation, "playback", options);
+      const result = await this.#displayReplayFramesResult(
+        frames,
+        target.generation,
+        "playback",
+        options,
+      );
+      if (
+        result.ok ||
+        (result.reason === "stale" &&
+          result.staleTargetDecoded === true &&
+          this.#isCurrentGeneration(target.generation))
+      ) {
+        this.#recordPlaybackDecoderProgress(frames, target);
+      } else if (result.reason === "failed") {
+        this.#state.playbackDecoderProgress = undefined;
+      }
     } finally {
       if (this.#state.playbackInFlightRequestId === target.requestId) {
         this.#state.playbackInFlightRequestId = undefined;
@@ -451,6 +473,50 @@ export class CompressedVideoController {
     return (
       target.requestId === this.#playbackRequestId && this.#isCurrentGeneration(target.generation)
     );
+  }
+
+  #playbackFramesForTarget(target: PlaybackTarget): readonly MessageEvent[] {
+    const gopFrames = this.#cache.framesForReceiveTime(this.#topic, target.messageEvent.receiveTime);
+    if (gopFrames == undefined) {
+      this.#state.playbackDecoderProgress = undefined;
+      return [target.messageEvent];
+    }
+
+    const keyframe = gopFrames[0];
+    const keyframeReceiveTimeNs =
+      keyframe != undefined ? toNanoSec(keyframe.receiveTime) : undefined;
+    const progress = this.#state.playbackDecoderProgress;
+    if (
+      keyframeReceiveTimeNs == undefined ||
+      progress == undefined ||
+      progress.generation !== target.generation ||
+      progress.keyframeReceiveTimeNs !== keyframeReceiveTimeNs
+    ) {
+      return gopFrames;
+    }
+
+    const nextFrames = gopFrames.filter(
+      (frame) => toNanoSec(frame.receiveTime) > progress.decodedThroughReceiveTimeNs,
+    );
+    return nextFrames;
+  }
+
+  #recordPlaybackDecoderProgress(
+    frames: readonly MessageEvent[],
+    target: PlaybackTarget,
+  ): void {
+    const firstFrame = frames[0];
+    if (firstFrame == undefined || !this.#isCurrentGeneration(target.generation)) {
+      return;
+    }
+
+    const gopFrames = this.#cache.framesForReceiveTime(this.#topic, target.messageEvent.receiveTime);
+    const keyframe = gopFrames?.[0] ?? firstFrame;
+    this.#state.playbackDecoderProgress = {
+      generation: target.generation,
+      keyframeReceiveTimeNs: toNanoSec(keyframe.receiveTime),
+      decodedThroughReceiveTimeNs: toNanoSec(target.messageEvent.receiveTime),
+    };
   }
 
   #resetDecoderForSeek(generation: number): void {
@@ -1030,8 +1096,18 @@ export class CompressedVideoController {
     mode: VideoDisplayMode,
     options?: SetCompressedVideoFramesOptions,
   ): Promise<boolean> {
+    const result = await this.#displayReplayFramesResult(frames, generation, mode, options);
+    return result.ok;
+  }
+
+  async #displayReplayFramesResult(
+    frames: readonly MessageEvent[],
+    generation: number,
+    mode: VideoDisplayMode,
+    options?: SetCompressedVideoFramesOptions,
+  ): Promise<ImageSetImageResult> {
     if (frames.length === 0) {
-      return false;
+      return { ok: false, reason: "failed" };
     }
 
     try {
@@ -1043,9 +1119,15 @@ export class CompressedVideoController {
         mode,
         displayOptionsForMode(mode, options),
       );
-      return this.#isCurrentGeneration(generation) && result.ok;
+      if (!this.#isCurrentGeneration(generation)) {
+        return {
+          ok: false,
+          reason: mode === "playback" ? "stale" : "failed",
+        };
+      }
+      return result;
     } catch {
-      return false;
+      return { ok: false, reason: "failed" };
     }
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts
@@ -66,6 +66,16 @@ type ControllerState = {
   playbackStabilizationGeneration?: number;
   playbackStabilizationInFlightGeneration?: number;
   pendingPlaybackStabilizationReceiveTimeNs?: bigint;
+  pendingPlaybackTarget?: PlaybackTarget;
+  playbackFlushScheduled?: boolean;
+  playbackInFlightRequestId?: number;
+};
+
+type PlaybackTarget = {
+  messageEvent: MessageEvent<CompressedVideo>;
+  generation: number;
+  requestId: number;
+  options: SetCompressedVideoFramesOptions | undefined;
 };
 
 type ControllerRenderer = Pick<
@@ -94,6 +104,7 @@ export class CompressedVideoController {
   #releaseSeekKeyframeSearchPlaybackPause: (() => void) | undefined;
   #seekReplayPlaybackPauseGeneration: number | undefined;
   #releaseSeekReplayPlaybackPause: (() => void) | undefined;
+  #playbackRequestId = 0;
 
   public constructor(args: {
     topic: string;
@@ -194,7 +205,14 @@ export class CompressedVideoController {
     if (this.#displayStabilizedPlaybackAfterSeek(normalizedEvent, receiveTimeNs, options)) {
       return;
     }
-    void this.#displayReplayFrames([normalizedEvent], this.#generation, "playback", options);
+    this.#queuePlaybackTarget(normalizedEvent, options);
+  }
+
+  public recordKeyframeIndex(messageEvent: Pick<MessageEvent, "topic" | "receiveTime">): void {
+    if (messageEvent.topic !== this.#topic) {
+      return;
+    }
+    this.#cache.addKnownKeyframeReceiveTime(messageEvent.topic, messageEvent.receiveTime);
   }
 
   public async displayPublishTimeTarget(
@@ -272,6 +290,7 @@ export class CompressedVideoController {
 
   public handleSeek(options?: SetCompressedVideoFramesOptions): void {
     this.#generation++;
+    this.#invalidatePlayback();
     this.#seekTargetNs = this.#renderer.currentTime;
     this.#cache.handleSeek(fromNanoSec(this.#renderer.currentTime));
 
@@ -285,6 +304,7 @@ export class CompressedVideoController {
 
   public resetPlaybackState(): void {
     this.#generation++;
+    this.#invalidatePlayback();
     this.#seekTargetNs = undefined;
     this.#cancelLookback();
     this.#endSeekReplayPlaybackPause();
@@ -297,6 +317,7 @@ export class CompressedVideoController {
 
   public clear(): void {
     this.#generation++;
+    this.#invalidatePlayback();
     this.#cancelLookback();
     this.#endSeekReplayPlaybackPause();
     this.#cache.clearTopic(this.#topic);
@@ -333,6 +354,7 @@ export class CompressedVideoController {
 
   #startImplicitSeekBackfill(): void {
     this.#generation++;
+    this.#invalidatePlayback();
     this.#seekTargetNs = this.#renderer.currentTime;
     this.#cache.handleSeek(fromNanoSec(this.#seekTargetNs));
     this.#cancelLookback();
@@ -341,6 +363,7 @@ export class CompressedVideoController {
 
   #beginReplayGeneration(): number {
     const generation = ++this.#generation;
+    this.#invalidatePlayback();
     this.#cancelLookback();
     this.#state.replayGeneration = undefined;
     this.#state.completedSeekGeneration = undefined;
@@ -348,6 +371,86 @@ export class CompressedVideoController {
     this.#state.playbackStabilizationInFlightGeneration = undefined;
     this.#state.pendingPlaybackStabilizationReceiveTimeNs = undefined;
     return generation;
+  }
+
+  #invalidatePlayback(): void {
+    this.#playbackRequestId++;
+    this.#state.pendingPlaybackTarget = undefined;
+    this.#state.playbackFlushScheduled = false;
+  }
+
+  #queuePlaybackTarget(
+    messageEvent: MessageEvent<CompressedVideo>,
+    options: SetCompressedVideoFramesOptions | undefined,
+  ): void {
+    this.#state.pendingPlaybackTarget = {
+      messageEvent,
+      generation: this.#generation,
+      requestId: ++this.#playbackRequestId,
+      options,
+    };
+    this.#schedulePlaybackFlush();
+  }
+
+  #schedulePlaybackFlush(): void {
+    if (
+      this.#state.playbackFlushScheduled === true ||
+      this.#state.playbackInFlightRequestId != undefined
+    ) {
+      return;
+    }
+
+    this.#state.playbackFlushScheduled = true;
+    queueMicrotask(() => {
+      this.#state.playbackFlushScheduled = false;
+      void this.#flushPlaybackTarget();
+    });
+  }
+
+  async #flushPlaybackTarget(): Promise<void> {
+    if (this.#state.playbackInFlightRequestId != undefined) {
+      return;
+    }
+
+    const target = this.#state.pendingPlaybackTarget;
+    if (target == undefined) {
+      return;
+    }
+    this.#state.pendingPlaybackTarget = undefined;
+    if (!this.#isCurrentPlaybackTarget(target)) {
+      return;
+    }
+
+    const frames = this.#cache.framesForReceiveTime(
+      this.#topic,
+      target.messageEvent.receiveTime,
+    ) ?? [target.messageEvent];
+    this.#state.playbackInFlightRequestId = target.requestId;
+    try {
+      const options = this.#playbackDisplayOptions(target);
+      await this.#displayReplayFrames(frames, target.generation, "playback", options);
+    } finally {
+      if (this.#state.playbackInFlightRequestId === target.requestId) {
+        this.#state.playbackInFlightRequestId = undefined;
+      }
+      this.#schedulePlaybackFlush();
+    }
+  }
+
+  #playbackDisplayOptions(target: PlaybackTarget): SetCompressedVideoFramesOptions {
+    const upstreamGuard = target.options?.isVideoFrameRequestCurrent;
+    return {
+      ...target.options,
+      allowIntermediateVideoFrame: false,
+      isVideoFrameRequestCurrent: () =>
+        (upstreamGuard?.() ?? true) && this.#isCurrentPlaybackTarget(target),
+    };
+  }
+
+  #isCurrentPlaybackTarget(target: PlaybackTarget): boolean {
+    return (
+      target.requestId === this.#playbackRequestId && this.#isCurrentGeneration(target.generation)
+    );
   }
 
   #resetDecoderForSeek(generation: number): void {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts
@@ -163,7 +163,7 @@ class TestImageRenderable extends ImageRenderable {
   protected override async decodeImageWithResult(
     image: AnyImage,
     resizeWidth?: number,
-  ): Promise<{ image: TestDecodedImage; ok: boolean }> {
+  ): Promise<{ image: TestDecodedImage; ok: true }> {
     return { image: await this.decodeImage(image, resizeWidth), ok: true };
   }
 }
@@ -560,7 +560,7 @@ describe("ImageRenderable", () => {
         20n,
       ]);
       expect(renderable.getDecodedImage()).toBe(frame);
-      await expect(keyResult).resolves.toEqual<ImageSetImageResult>({ ok: false });
+      await expect(keyResult).resolves.toEqual<ImageSetImageResult>({ ok: false, reason: "failed" });
       await expect(deltaResult).resolves.toEqual<ImageSetImageResult>({ ok: true });
     } finally {
       time.restore();
@@ -665,7 +665,7 @@ describe("ImageRenderable", () => {
       expect(decodeVideoFrames.mock.calls[1]![0].frames.map((entry) => entry.receiveTime)).toEqual([
         20n,
       ]);
-      await expect(firstResult).resolves.toEqual<ImageSetImageResult>({ ok: false });
+      await expect(firstResult).resolves.toEqual<ImageSetImageResult>({ ok: false, reason: "failed" });
       await expect(secondResult).resolves.toEqual<ImageSetImageResult>({ ok: true });
       expect(renderable.getDecodedImage()).toBe(secondFrame);
       expect((firstFrame as unknown as MockVideoFrame).close).toHaveBeenCalledTimes(1);
@@ -715,8 +715,8 @@ describe("ImageRenderable", () => {
 
       renderable.resetForSeek();
 
-      await expect(activeResult).resolves.toEqual<ImageSetImageResult>({ ok: false });
-      await expect(queuedResult).resolves.toEqual<ImageSetImageResult>({ ok: false });
+      await expect(activeResult).resolves.toEqual<ImageSetImageResult>({ ok: false, reason: "failed" });
+      await expect(queuedResult).resolves.toEqual<ImageSetImageResult>({ ok: false, reason: "failed" });
       expect(resetVideoDecoder).toHaveBeenCalledTimes(1);
 
       resolveFirstDecode({
@@ -770,7 +770,7 @@ describe("ImageRenderable", () => {
       renderable.userData.receiveTime = 20n;
       await expect(
         renderable.setImage(videoFrame(2, "delta")),
-      ).resolves.toEqual<ImageSetImageResult>({ ok: false });
+      ).resolves.toEqual<ImageSetImageResult>({ ok: false, reason: "failed" });
 
       expect(renderable.getDecodedImage()).toBe(currentFrame);
       expect(renderable.userData.texture?.image).toBe(currentFrame);
@@ -807,7 +807,11 @@ describe("ImageRenderable", () => {
         onDecoded,
         isVideoFrameRequestCurrent: () => false,
       }),
-    ).resolves.toEqual<ImageSetImageResult>({ ok: false, stale: true });
+    ).resolves.toEqual<ImageSetImageResult>({
+      ok: false,
+      reason: "stale",
+      staleTargetDecoded: true,
+    });
 
     expect(renderable.getDecodedImage()).toBeUndefined();
     expect(renderable.userData.texture).toBeUndefined();
@@ -964,7 +968,7 @@ describe("ImageRenderable", () => {
         [videoFrameEvent(10n, 1, "key"), videoFrameEvent(20n, 2, "delta")],
         { allowIntermediateVideoFrame: false },
       ),
-    ).resolves.toEqual<ImageSetImageResult>({ ok: false });
+    ).resolves.toEqual<ImageSetImageResult>({ ok: false, reason: "failed" });
     expect(renderable.getDecodedImage()).toBeUndefined();
     expect((intermediateFrame as unknown as MockVideoFrame).close).toHaveBeenCalledTimes(1);
   });
@@ -1019,9 +1023,60 @@ describe("ImageRenderable", () => {
 
       await expect(
         race([replayResult, Promise.resolve("pending")]),
-      ).resolves.toEqual<ImageSetImageResult>({ ok: false });
+      ).resolves.toEqual<ImageSetImageResult>({ ok: false, reason: "failed" });
       expect(renderable.getDecodedImage()).toBe(currentFrame);
       expect(resetVideoDecoder).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("resolves stale without resetting the decoder when a superseded no-intermediate target waits", async () => {
+    jest.useFakeTimers();
+    try {
+      const intermediateFrame = new MockVideoFrame() as unknown as VideoFrame;
+      const targetPromise = new Promise<AwaitTargetFrameResult>(() => {});
+      const decodeVideoFrames = jest.fn<Promise<DecodeVideoFramesResult>, [DecodeVideoFramesArgs]>(
+        async ({ requestId }) => ({
+          type: "IntermediateFrame",
+          requestId,
+          frame: intermediateFrame,
+          originalTimestamp: 1n,
+          receiveTime: 10n,
+        }),
+      );
+      const resetVideoDecoder = jest.fn();
+      const decoder = {
+        decodeVideoFrames,
+        awaitTargetFrame: jest.fn(async () => await targetPromise),
+        resetVideoDecoder,
+        terminate: jest.fn(),
+      } as unknown as WorkerImageDecoder;
+      const renderable = new TestVideoBatchRenderable(decoder);
+      let isCurrent = true;
+
+      const replayResult = renderable.setCompressedVideoFrames(
+        [videoFrameEvent(10n, 1, "key"), videoFrameEvent(20n, 2, "delta")],
+        {
+          allowIntermediateVideoFrame: false,
+          isVideoFrameRequestCurrent: () => isCurrent,
+          targetFrameTimeoutMs: 25,
+        },
+      );
+      await flushPromises();
+      await flushPromises();
+
+      isCurrent = false;
+      await jest.advanceTimersByTimeAsync(25);
+      await flushPromises();
+
+      await expect(replayResult).resolves.toEqual<ImageSetImageResult>({
+        ok: false,
+        reason: "stale",
+      });
+      expect(renderable.getDecodedImage()).toBeUndefined();
+      expect((intermediateFrame as unknown as MockVideoFrame).close).toHaveBeenCalledTimes(1);
+      expect(resetVideoDecoder).not.toHaveBeenCalled();
     } finally {
       jest.useRealTimers();
     }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts
@@ -781,6 +781,42 @@ describe("ImageRenderable", () => {
     }
   });
 
+  it("closes stale playback target frames without updating texture or reporting decode failure", async () => {
+    const staleFrame = new MockVideoFrame() as unknown as VideoFrame;
+    const onDecoded = jest.fn();
+    const resetVideoDecoder = jest.fn();
+    const decoder = {
+      decodeVideoFrames: jest.fn<Promise<DecodeVideoFramesResult>, [DecodeVideoFramesArgs]>(
+        async ({ requestId }) => ({
+          type: "TargetFrame",
+          requestId,
+          frame: staleFrame,
+          originalTimestamp: 1n,
+          receiveTime: 10n,
+        }),
+      ),
+      awaitTargetFrame: abortAwaitTargetFrame(),
+      resetVideoDecoder,
+      terminate: jest.fn(),
+    } as unknown as WorkerImageDecoder;
+    const renderable = new TestVideoBatchRenderable(decoder);
+
+    jest.clearAllMocks();
+    await expect(
+      renderable.setCompressedVideoFrames([videoFrameEvent(10n, 1, "key")], {
+        onDecoded,
+        isVideoFrameRequestCurrent: () => false,
+      }),
+    ).resolves.toEqual<ImageSetImageResult>({ ok: false, stale: true });
+
+    expect(renderable.getDecodedImage()).toBeUndefined();
+    expect(renderable.userData.texture).toBeUndefined();
+    expect((staleFrame as unknown as MockVideoFrame).close).toHaveBeenCalledTimes(1);
+    expect(onDecoded).not.toHaveBeenCalled();
+    expect(mockRenderer.queueAnimationFrame).not.toHaveBeenCalled();
+    expect(resetVideoDecoder).not.toHaveBeenCalled();
+  });
+
   it("replaces an intermediate video frame when the target frame arrives later", async () => {
     const time = mockDateNow();
     try {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -71,16 +71,36 @@ const MIN_IMAGE_RENDER_INTERVAL_MS = 16;
 const DEFAULT_TARGET_FRAME_TIMEOUT_MS = 1000;
 
 type DecodedImageResource = ImageBitmap | ImageData | VideoFrame;
-type DecodedImageResult = {
-  image?: DecodedImageResource;
-  ok: boolean;
-  stale?: boolean;
-};
+type DecodedImageResult =
+  | {
+      image?: DecodedImageResource;
+      ok: true;
+    }
+  | {
+      image?: DecodedImageResource;
+      ok: false;
+      reason: "stale";
+      staleTargetDecoded?: true;
+    }
+  | {
+      image?: DecodedImageResource;
+      ok: false;
+      reason: "failed";
+    };
 
-export type ImageSetImageResult = {
-  ok: boolean;
-  stale?: boolean;
-};
+export type ImageSetImageResult =
+  | {
+      ok: true;
+    }
+  | {
+      ok: false;
+      reason: "stale";
+      staleTargetDecoded?: true;
+    }
+  | {
+      ok: false;
+      reason: "failed";
+    };
 
 export type CompressedVideoFrameEvent = MessageEvent<CompressedVideo>;
 
@@ -97,7 +117,6 @@ export type SetCompressedVideoFramesOptions = {
 type PendingDecodedImage = {
   seq: number;
   result: DecodedImageResource;
-  ok: boolean;
   isRequestCurrent: (() => boolean) | undefined;
   onDecoded: (() => void) | undefined;
   resolve: (result: ImageSetImageResult) => void;
@@ -294,7 +313,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
         .catch((err: unknown) => {
           log.error(err);
           if (this.isDisposed()) {
-            resolve({ ok: false });
+            resolve({ ok: false, reason: "failed" });
             return;
           }
           // avoid needing to recreate error image if it already shown
@@ -302,7 +321,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
             void this.#setErrorImage(seq, onDecoded);
           }
           this.addError(DECODE_IMAGE_ERR_KEY, `Error decoding image: ${(err as Error).message}`);
-          resolve({ ok: false });
+          resolve({ ok: false, reason: "failed" });
         });
     });
   }
@@ -313,7 +332,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
   ): Promise<ImageSetImageResult> {
     const targetFrame = frames[frames.length - 1];
     if (targetFrame == undefined) {
-      return { ok: false };
+      return { ok: false, reason: "failed" };
     }
 
     this.userData.image = targetFrame.message;
@@ -360,14 +379,14 @@ export class ImageRenderable extends Renderable<ImageUserData> {
         .catch((err: unknown) => {
           log.error(err);
           if (this.isDisposed()) {
-            resolve({ ok: false });
+            resolve({ ok: false, reason: "failed" });
             return;
           }
           if (!this.#showingErrorImage) {
             void this.#setErrorImage(seq, options.onDecoded);
           }
           this.addError(DECODE_IMAGE_ERR_KEY, `Error decoding image: ${(err as Error).message}`);
-          resolve({ ok: false });
+          resolve({ ok: false, reason: "failed" });
         });
     });
   }
@@ -381,31 +400,37 @@ export class ImageRenderable extends Renderable<ImageUserData> {
   ): void {
     const result = decoded.image;
     if (result == undefined) {
-      resolve({ ok: decoded.ok, stale: decoded.stale });
+      resolve(imageSetResult(decoded));
       return;
     }
 
-    if (decoded.stale === true) {
+    if (!decoded.ok && decoded.reason === "stale") {
       this.#closeDecodedImageIfUnused(result);
-      resolve({ ok: false, stale: true });
+      resolve(imageSetResult(decoded));
       return;
     }
 
     if (isRequestCurrent?.() === false) {
       this.#closeDecodedImageIfUnused(result);
-      resolve({ ok: false, stale: true });
+      resolve({ ok: false, reason: "stale", staleTargetDecoded: true });
+      return;
+    }
+
+    if (!decoded.ok) {
+      this.#closeDecodedImageIfUnused(result);
+      resolve(imageSetResult(decoded));
       return;
     }
 
     if (this.isDisposed()) {
       this.#closeDecodedImageIfUnused(result);
-      resolve({ ok: false });
+      resolve({ ok: false, reason: "failed" });
       return;
     }
 
     if (this.#displayedImageSequenceNumber > seq) {
       this.#closeDecodedImageIfUnused(result);
-      resolve({ ok: false });
+      resolve({ ok: false, reason: "failed" });
       return;
     }
 
@@ -414,13 +439,13 @@ export class ImageRenderable extends Renderable<ImageUserData> {
       this.update();
       this.#showingErrorImage = false;
       this.removeError(DECODE_IMAGE_ERR_KEY);
-      resolve({ ok: decoded.ok });
+      resolve({ ok: true });
       return;
     }
 
     if (seq < this.#receivedImageSequenceNumber) {
       this.#closeDecodedImageIfUnused(result);
-      resolve({ ok: false });
+      resolve({ ok: false, reason: "failed" });
       return;
     }
 
@@ -429,7 +454,6 @@ export class ImageRenderable extends Renderable<ImageUserData> {
       this.#setPendingDecodedImage({
         seq,
         result,
-        ok: decoded.ok,
         isRequestCurrent,
         onDecoded,
         resolve,
@@ -453,19 +477,25 @@ export class ImageRenderable extends Renderable<ImageUserData> {
   ): void {
     const result = decoded.image;
     if (result == undefined) {
-      resolve({ ok: decoded.ok, stale: decoded.stale });
+      resolve(imageSetResult(decoded));
       return;
     }
 
-    if (decoded.stale === true) {
+    if (!decoded.ok && decoded.reason === "stale") {
       this.#closeDecodedImageIfUnused(result);
-      resolve({ ok: false, stale: true });
+      resolve(imageSetResult(decoded));
       return;
     }
 
     if (isRequestCurrent?.() === false) {
       this.#closeDecodedImageIfUnused(result);
-      resolve({ ok: false, stale: true });
+      resolve({ ok: false, reason: "stale", staleTargetDecoded: true });
+      return;
+    }
+
+    if (!decoded.ok) {
+      this.#closeDecodedImageIfUnused(result);
+      resolve(imageSetResult(decoded));
       return;
     }
 
@@ -485,7 +515,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     onDecoded?.();
     this.removeError(DECODE_IMAGE_ERR_KEY);
     this.renderer.queueAnimationFrame();
-    resolve({ ok: decoded.ok });
+    resolve({ ok: true });
   }
 
   #setPendingDecodedImage(pending: PendingDecodedImage): void {
@@ -501,7 +531,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     this.#pendingDecodedImage = undefined;
     this.#handleDecodedImage(
       pending.seq,
-      { image: pending.result, ok: pending.ok },
+      { image: pending.result, ok: true },
       pending.onDecoded,
       pending.resolve,
       pending.isRequestCurrent,
@@ -517,7 +547,9 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     if (pending.result !== keep) {
       this.#closeDecodedImageIfUnused(pending.result);
       pending.resolve(
-        pending.isRequestCurrent?.() === false ? { ok: false, stale: true } : { ok: false },
+        pending.isRequestCurrent?.() === false
+          ? { ok: false, reason: "stale" }
+          : { ok: false, reason: "failed" },
       );
     }
   }
@@ -571,7 +603,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
         if (frameMsg.data.byteLength === 0) {
           const error = "Empty video frame";
           log.error(error);
-          return { ok: false };
+          return { ok: false, reason: "failed" };
         }
 
         const decoder = (this.decoder ??= new WorkerImageDecoder());
@@ -696,27 +728,33 @@ export class ImageRenderable extends Renderable<ImageUserData> {
         anyFrameTimeoutMs: options.anyFrameTimeoutMs,
       });
     } catch {
+      const staleResult = this.#staleVideoFrameResultIfRequestIsNotCurrent(options);
       for (const entry of entries) {
-        this.#settleVideoDecode(entry, this.#failedVideoFrameResult());
+        this.#settleVideoDecode(entry, staleResult ?? this.#failedVideoFrameResult());
       }
       return;
     }
 
     if (this.isDisposed() || result.requestId !== this.#videoDecodeRequestId) {
       closeDecodeResultFrame(result);
-      const staleResult = this.#videoFrameRequestIsCurrent(options)
-        ? this.#failedVideoFrameResult()
-        : this.#staleVideoFrameResult();
+      const staleResult = this.#staleVideoFrameResultIfRequestIsNotCurrent(
+        options,
+        result.type === "TargetFrame" ? { staleTargetDecoded: true } : undefined,
+      );
       for (const entry of entries) {
-        this.#settleVideoDecode(entry, staleResult);
+        this.#settleVideoDecode(entry, staleResult ?? this.#failedVideoFrameResult());
       }
       return;
     }
 
-    if (!this.#videoFrameRequestIsCurrent(options)) {
+    const staleResult = this.#staleVideoFrameResultIfRequestIsNotCurrent(
+      options,
+      result.type === "TargetFrame" ? { staleTargetDecoded: true } : undefined,
+    );
+    if (staleResult != undefined) {
       closeDecodeResultFrame(result);
       for (const entry of entries) {
-        this.#settleVideoDecode(entry, this.#staleVideoFrameResult());
+        this.#settleVideoDecode(entry, staleResult);
       }
       return;
     }
@@ -794,11 +832,22 @@ export class ImageRenderable extends Renderable<ImageUserData> {
           : await decoder.awaitTargetFrame({ requestId });
     } catch {
       if (options.settleTargetEntry === true) {
-        this.#settleVideoDecode(targetEntry, this.#failedVideoFrameResult());
+        this.#settleVideoDecode(
+          targetEntry,
+          this.#staleVideoFrameResultIfRequestIsNotCurrent(options) ??
+            this.#failedVideoFrameResult(),
+        );
       }
       return;
     }
     if (result == undefined) {
+      const staleResult = this.#staleVideoFrameResultIfRequestIsNotCurrent(options);
+      if (staleResult != undefined) {
+        if (options.settleTargetEntry === true) {
+          this.#settleVideoDecode(targetEntry, staleResult);
+        }
+        return;
+      }
       void Promise.resolve(decoder.resetVideoDecoder()).catch(() => {});
       if (options.settleTargetEntry === true) {
         this.#settleVideoDecode(targetEntry, this.#failedVideoFrameResult());
@@ -807,7 +856,11 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     }
     if (result.type !== "TargetFrame") {
       if (options.settleTargetEntry === true) {
-        this.#settleVideoDecode(targetEntry, this.#failedVideoFrameResult());
+        this.#settleVideoDecode(
+          targetEntry,
+          this.#staleVideoFrameResultIfRequestIsNotCurrent(options) ??
+            this.#failedVideoFrameResult(),
+        );
       }
       return;
     }
@@ -817,21 +870,22 @@ export class ImageRenderable extends Renderable<ImageUserData> {
       targetEntry.seq !== this.#receivedImageSequenceNumber
     ) {
       result.frame.close();
-      const staleResult =
-        options.isVideoFrameRequestCurrent != undefined &&
-        !this.#videoFrameRequestIsCurrent(options)
-          ? this.#staleVideoFrameResult()
-          : this.#failedVideoFrameResult();
+      const staleResult = this.#staleVideoFrameResultIfRequestIsNotCurrent(options, {
+        staleTargetDecoded: true,
+      });
       if (options.settleTargetEntry === true) {
-        this.#settleVideoDecode(targetEntry, staleResult);
+        this.#settleVideoDecode(targetEntry, staleResult ?? this.#failedVideoFrameResult());
       }
       return;
     }
 
-    if (!this.#videoFrameRequestIsCurrent(options)) {
+    const staleResult = this.#staleVideoFrameResultIfRequestIsNotCurrent(options, {
+      staleTargetDecoded: true,
+    });
+    if (staleResult != undefined) {
       result.frame.close();
       if (options.settleTargetEntry === true) {
-        this.#settleVideoDecode(targetEntry, this.#staleVideoFrameResult());
+        this.#settleVideoDecode(targetEntry, staleResult);
       }
       return;
     }
@@ -875,11 +929,23 @@ export class ImageRenderable extends Renderable<ImageUserData> {
   }
 
   #failedVideoFrameResult(): DecodedImageResult {
-    return { ok: false };
+    return { ok: false, reason: "failed" };
   }
 
-  #staleVideoFrameResult(): DecodedImageResult {
-    return { ok: false, stale: true };
+  #staleVideoFrameResult(options: { staleTargetDecoded?: true } = {}): DecodedImageResult {
+    return options.staleTargetDecoded === true
+      ? { ok: false, reason: "stale", staleTargetDecoded: true }
+      : { ok: false, reason: "stale" };
+  }
+
+  #staleVideoFrameResultIfRequestIsNotCurrent(
+    options: Pick<SetCompressedVideoFramesOptions, "isVideoFrameRequestCurrent">,
+    resultOptions?: { staleTargetDecoded?: true },
+  ): DecodedImageResult | undefined {
+    return options.isVideoFrameRequestCurrent != undefined &&
+      !this.#videoFrameRequestIsCurrent(options)
+      ? this.#staleVideoFrameResult(resultOptions)
+      : undefined;
   }
 
   #videoFrameRequestIsCurrent(
@@ -1235,6 +1301,16 @@ function closeDecodeResultFrame(result: DecodeVideoFramesResult): void {
   if (result.type === "TargetFrame" || result.type === "IntermediateFrame") {
     result.frame.close();
   }
+}
+
+function imageSetResult(result: DecodedImageResult): ImageSetImageResult {
+  if (result.ok) {
+    return { ok: true };
+  }
+  if (result.reason === "stale" && result.staleTargetDecoded === true) {
+    return { ok: false, reason: "stale", staleTargetDecoded: true };
+  }
+  return { ok: false, reason: result.reason };
 }
 
 async function awaitTargetFrameWithTimeout(

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -74,10 +74,12 @@ type DecodedImageResource = ImageBitmap | ImageData | VideoFrame;
 type DecodedImageResult = {
   image?: DecodedImageResource;
   ok: boolean;
+  stale?: boolean;
 };
 
 export type ImageSetImageResult = {
   ok: boolean;
+  stale?: boolean;
 };
 
 export type CompressedVideoFrameEvent = MessageEvent<CompressedVideo>;
@@ -89,12 +91,14 @@ export type SetCompressedVideoFramesOptions = {
   targetFrameTimeoutMs?: number;
   anyFrameTimeoutMs?: number;
   allowIntermediateVideoFrame?: boolean;
+  isVideoFrameRequestCurrent?: () => boolean;
 };
 
 type PendingDecodedImage = {
   seq: number;
   result: DecodedImageResource;
   ok: boolean;
+  isRequestCurrent: (() => boolean) | undefined;
   onDecoded: (() => void) | undefined;
   resolve: (result: ImageSetImageResult) => void;
 };
@@ -340,12 +344,18 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     return await new Promise<ImageSetImageResult>((resolve) => {
       decodePromise
         .then((result) => {
-          this.#handleDecodedImage(seq, result, options.onDecoded, (displayResult) => {
-            if (displayResult.ok) {
-              options.updateImageState?.(targetFrame);
-            }
-            resolve(displayResult);
-          });
+          this.#handleDecodedImage(
+            seq,
+            result,
+            options.onDecoded,
+            (displayResult) => {
+              if (displayResult.ok) {
+                options.updateImageState?.(targetFrame);
+              }
+              resolve(displayResult);
+            },
+            options.isVideoFrameRequestCurrent,
+          );
         })
         .catch((err: unknown) => {
           log.error(err);
@@ -367,10 +377,23 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     decoded: DecodedImageResult,
     onDecoded: (() => void) | undefined,
     resolve: (result: ImageSetImageResult) => void,
+    isRequestCurrent?: () => boolean,
   ): void {
     const result = decoded.image;
     if (result == undefined) {
-      resolve({ ok: decoded.ok });
+      resolve({ ok: decoded.ok, stale: decoded.stale });
+      return;
+    }
+
+    if (decoded.stale === true) {
+      this.#closeDecodedImageIfUnused(result);
+      resolve({ ok: false, stale: true });
+      return;
+    }
+
+    if (isRequestCurrent?.() === false) {
+      this.#closeDecodedImageIfUnused(result);
+      resolve({ ok: false, stale: true });
       return;
     }
 
@@ -403,7 +426,14 @@ export class ImageRenderable extends Renderable<ImageUserData> {
 
     const nextRenderDelayMs = this.#lastRenderImage + MIN_IMAGE_RENDER_INTERVAL_MS - Date.now();
     if (nextRenderDelayMs > 0) {
-      this.#setPendingDecodedImage({ seq, result, ok: decoded.ok, onDecoded, resolve });
+      this.#setPendingDecodedImage({
+        seq,
+        result,
+        ok: decoded.ok,
+        isRequestCurrent,
+        onDecoded,
+        resolve,
+      });
       this.#pendingRenderTimeout ??= setTimeout(() => {
         this.#pendingRenderTimeout = undefined;
         this.#flushPendingDecodedImage();
@@ -411,7 +441,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
       return;
     }
 
-    this.#displayDecodedImage(seq, decoded, onDecoded, resolve);
+    this.#displayDecodedImage(seq, decoded, onDecoded, resolve, isRequestCurrent);
   }
 
   #displayDecodedImage(
@@ -419,10 +449,23 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     decoded: DecodedImageResult,
     onDecoded: (() => void) | undefined,
     resolve: (result: ImageSetImageResult) => void,
+    isRequestCurrent?: () => boolean,
   ): void {
     const result = decoded.image;
     if (result == undefined) {
-      resolve({ ok: decoded.ok });
+      resolve({ ok: decoded.ok, stale: decoded.stale });
+      return;
+    }
+
+    if (decoded.stale === true) {
+      this.#closeDecodedImageIfUnused(result);
+      resolve({ ok: false, stale: true });
+      return;
+    }
+
+    if (isRequestCurrent?.() === false) {
+      this.#closeDecodedImageIfUnused(result);
+      resolve({ ok: false, stale: true });
       return;
     }
 
@@ -461,6 +504,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
       { image: pending.result, ok: pending.ok },
       pending.onDecoded,
       pending.resolve,
+      pending.isRequestCurrent,
     );
   }
 
@@ -472,7 +516,9 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     this.#pendingDecodedImage = undefined;
     if (pending.result !== keep) {
       this.#closeDecodedImageIfUnused(pending.result);
-      pending.resolve({ ok: false });
+      pending.resolve(
+        pending.isRequestCurrent?.() === false ? { ok: false, stale: true } : { ok: false },
+      );
     }
   }
 
@@ -634,7 +680,10 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     entries: PendingVideoDecode[],
     options: Pick<
       SetCompressedVideoFramesOptions,
-      "targetFrameTimeoutMs" | "anyFrameTimeoutMs" | "allowIntermediateVideoFrame"
+      | "targetFrameTimeoutMs"
+      | "anyFrameTimeoutMs"
+      | "allowIntermediateVideoFrame"
+      | "isVideoFrameRequestCurrent"
     > = {},
   ): Promise<void> {
     const requestId = ++this.#videoDecodeRequestId;
@@ -655,8 +704,19 @@ export class ImageRenderable extends Renderable<ImageUserData> {
 
     if (this.isDisposed() || result.requestId !== this.#videoDecodeRequestId) {
       closeDecodeResultFrame(result);
+      const staleResult = this.#videoFrameRequestIsCurrent(options)
+        ? this.#failedVideoFrameResult()
+        : this.#staleVideoFrameResult();
       for (const entry of entries) {
-        this.#settleVideoDecode(entry, this.#failedVideoFrameResult());
+        this.#settleVideoDecode(entry, staleResult);
+      }
+      return;
+    }
+
+    if (!this.#videoFrameRequestIsCurrent(options)) {
+      closeDecodeResultFrame(result);
+      for (const entry of entries) {
+        this.#settleVideoDecode(entry, this.#staleVideoFrameResult());
       }
       return;
     }
@@ -666,7 +726,9 @@ export class ImageRenderable extends Renderable<ImageUserData> {
         this.#settleVideoDecode(entry, this.#failedVideoFrameResult());
       }
       if (result.type === "Timeout") {
-        void this.#awaitTargetVideoFrame(decoder, requestId, entries[entries.length - 1]!);
+        void this.#awaitTargetVideoFrame(decoder, requestId, entries[entries.length - 1]!, {
+          isVideoFrameRequestCurrent: options.isVideoFrameRequestCurrent,
+        });
       }
       return;
     }
@@ -683,6 +745,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
       void this.#awaitTargetVideoFrame(decoder, requestId, targetEntry, {
         settleTargetEntry: true,
         targetFrameTimeoutMs: options.targetFrameTimeoutMs,
+        isVideoFrameRequestCurrent: options.isVideoFrameRequestCurrent,
       });
       return;
     }
@@ -704,7 +767,9 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     }
     this.#settleVideoDecode(resultEntry, { image: result.frame, ok: true });
     if (result.type === "IntermediateFrame") {
-      void this.#awaitTargetVideoFrame(decoder, requestId, targetEntry);
+      void this.#awaitTargetVideoFrame(decoder, requestId, targetEntry, {
+        isVideoFrameRequestCurrent: options.isVideoFrameRequestCurrent,
+      });
     }
   }
 
@@ -712,7 +777,10 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     decoder: WorkerImageDecoder,
     requestId: number,
     targetEntry: PendingVideoDecode,
-    options: { settleTargetEntry?: boolean; targetFrameTimeoutMs?: number } = {},
+    options: Pick<SetCompressedVideoFramesOptions, "isVideoFrameRequestCurrent"> & {
+      settleTargetEntry?: boolean;
+      targetFrameTimeoutMs?: number;
+    } = {},
   ): Promise<void> {
     let result: Awaited<ReturnType<WorkerImageDecoder["awaitTargetFrame"]>> | undefined;
     const timeoutMs =
@@ -749,8 +817,21 @@ export class ImageRenderable extends Renderable<ImageUserData> {
       targetEntry.seq !== this.#receivedImageSequenceNumber
     ) {
       result.frame.close();
+      const staleResult =
+        options.isVideoFrameRequestCurrent != undefined &&
+        !this.#videoFrameRequestIsCurrent(options)
+          ? this.#staleVideoFrameResult()
+          : this.#failedVideoFrameResult();
       if (options.settleTargetEntry === true) {
-        this.#settleVideoDecode(targetEntry, this.#failedVideoFrameResult());
+        this.#settleVideoDecode(targetEntry, staleResult);
+      }
+      return;
+    }
+
+    if (!this.#videoFrameRequestIsCurrent(options)) {
+      result.frame.close();
+      if (options.settleTargetEntry === true) {
+        this.#settleVideoDecode(targetEntry, this.#staleVideoFrameResult());
       }
       return;
     }
@@ -765,6 +846,7 @@ export class ImageRenderable extends Renderable<ImageUserData> {
       { image: result.frame, ok: true },
       targetEntry.onDecoded,
       () => {},
+      options.isVideoFrameRequestCurrent,
     );
   }
 
@@ -794,6 +876,16 @@ export class ImageRenderable extends Renderable<ImageUserData> {
 
   #failedVideoFrameResult(): DecodedImageResult {
     return { ok: false };
+  }
+
+  #staleVideoFrameResult(): DecodedImageResult {
+    return { ok: false, stale: true };
+  }
+
+  #videoFrameRequestIsCurrent(
+    options: Pick<SetCompressedVideoFramesOptions, "isVideoFrameRequestCurrent">,
+  ): boolean {
+    return options.isVideoFrameRequestCurrent?.() ?? true;
   }
 
   public update(): void {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoGopCache.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoGopCache.test.ts
@@ -248,6 +248,16 @@ describe("VideoGopCache", () => {
     expect(cache.nearestKeyframeReceiveTimeAtOrBefore(TOPIC, t(11))).toBeUndefined();
   });
 
+  it("indexes a known keyframe receive time without caching GOP frame data", () => {
+    const cache = new VideoGopCache();
+
+    cache.addKnownKeyframeReceiveTime(TOPIC, t(10));
+
+    expect(cache.byteSize()).toBe(0);
+    expect(cache.framesForReceiveTime(TOPIC, t(10))).toBeUndefined();
+    expect(cache.nearestKeyframeReceiveTimeAtOrBefore(TOPIC, t(12))).toEqual(t(10));
+  });
+
   it("retains keyframe times in the index after frame data is evicted", () => {
     const cache = new VideoGopCache({ maxBytes: 18 });
     const oldKey = h264Frame(1, 1, "key", 8);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoGopCache.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoGopCache.test.ts
@@ -258,6 +258,20 @@ describe("VideoGopCache", () => {
     expect(cache.nearestKeyframeReceiveTimeAtOrBefore(TOPIC, t(12))).toEqual(t(10));
   });
 
+  it("caps known keyframe receive time indexes without affecting cached GOP data", () => {
+    const cache = new VideoGopCache({ maxKeyframeIndexEntriesPerTopic: 2 });
+
+    cache.addKnownKeyframeReceiveTime(TOPIC, t(1));
+    cache.addKnownKeyframeReceiveTime(TOPIC, t(2));
+    cache.addKnownKeyframeReceiveTime(TOPIC, t(3));
+
+    expect(cache.byteSize()).toBe(0);
+    expect(cache.framesForReceiveTime(TOPIC, t(3))).toBeUndefined();
+    expect(cache.nearestKeyframeReceiveTimeAtOrBefore(TOPIC, t(1))).toBeUndefined();
+    expect(cache.nearestKeyframeReceiveTimeAtOrBefore(TOPIC, t(2))).toEqual(t(2));
+    expect(cache.nearestKeyframeReceiveTimeAtOrBefore(TOPIC, t(4))).toEqual(t(3));
+  });
+
   it("retains keyframe times in the index after frame data is evicted", () => {
     const cache = new VideoGopCache({ maxBytes: 18 });
     const oldKey = h264Frame(1, 1, "key", 8);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoGopCache.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoGopCache.ts
@@ -131,6 +131,10 @@ export class VideoGopCache {
     return true;
   }
 
+  public addKnownKeyframeReceiveTime(topic: string, receiveTime: Time): void {
+    this.#recordKeyframeReceiveTime(topic, toNanoSec(receiveTime));
+  }
+
   public handleSeek(targetTime: Time): void {
     this.#targetReceiveTimeNs = toNanoSec(targetTime);
     this.#activeRangeByTopic.clear();
@@ -302,13 +306,16 @@ export class VideoGopCache {
     if (!frame.isKeyframe) {
       return;
     }
-    const topic = frame.messageEvent.topic;
+    this.#recordKeyframeReceiveTime(frame.messageEvent.topic, frame.receiveTimeNs);
+  }
+
+  #recordKeyframeReceiveTime(topic: string, receiveTimeNs: bigint): void {
     let times = this.#keyframeReceiveTimesByTopic.get(topic);
     if (times == undefined) {
       times = [];
       this.#keyframeReceiveTimesByTopic.set(topic, times);
     }
-    sortedInsertUnique(times, frame.receiveTimeNs);
+    sortedInsertUnique(times, receiveTimeNs);
   }
 
   public byteSize(): number {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoGopCache.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoGopCache.ts
@@ -11,6 +11,7 @@ import { MessageEvent } from "@foxglove/studio";
 
 const VIDEO_FORMATS = new Set(["h264", "h265"]);
 export const DEFAULT_VIDEO_GOP_CACHE_MAX_BYTES = 64 * 1024 * 1024;
+export const DEFAULT_KEYFRAME_INDEX_MAX_ENTRIES_PER_TOPIC = 20_000;
 
 type CompressedVideoLike = {
   timestamp: Time;
@@ -97,11 +98,16 @@ export class VideoGopCache {
   // keyframes are, so a later seek can read exactly [keyframe, target] instead of guessing windows.
   readonly #keyframeReceiveTimesByTopic = new Map<string, bigint[]>();
   readonly #maxBytes: number;
+  readonly #maxKeyframeIndexEntriesPerTopic: number;
   #byteSize = 0;
   #targetReceiveTimeNs = 0n;
 
-  public constructor(options: { maxBytes?: number } = {}) {
+  public constructor(
+    options: { maxBytes?: number; maxKeyframeIndexEntriesPerTopic?: number } = {},
+  ) {
     this.#maxBytes = options.maxBytes ?? DEFAULT_VIDEO_GOP_CACHE_MAX_BYTES;
+    this.#maxKeyframeIndexEntriesPerTopic =
+      options.maxKeyframeIndexEntriesPerTopic ?? DEFAULT_KEYFRAME_INDEX_MAX_ENTRIES_PER_TOPIC;
   }
 
   public addFrame(msg: MessageEvent): boolean {
@@ -316,6 +322,9 @@ export class VideoGopCache {
       this.#keyframeReceiveTimesByTopic.set(topic, times);
     }
     sortedInsertUnique(times, receiveTimeNs);
+    if (times.length > this.#maxKeyframeIndexEntriesPerTopic) {
+      times.splice(0, times.length - this.#maxKeyframeIndexEntriesPerTopic);
+    }
   }
 
   public byteSize(): number {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoMessageQueue.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoMessageQueue.test.ts
@@ -146,17 +146,20 @@ describe("recordKeyframesAndFilterCompressedVideoQueue", () => {
     const firstDelta = makeMessage("/camera", 10_000_000n, "delta");
     const secondKeyframe = makeMessage("/camera", 20_000_000n, "key");
     const secondDelta = makeMessage("/camera", 30_000_000n, "delta");
-    const recordedKeyframes: MessageEvent<CompressedVideo>[] = [];
+    const recordedKeyframes: { topic: string; receiveTime: Time }[] = [];
 
     const result = recordKeyframesAndFilterCompressedVideoQueue(
       [firstKeyframe, firstDelta, secondKeyframe, secondDelta],
-      (messageEvent) => {
-        recordedKeyframes.push(messageEvent as MessageEvent<CompressedVideo>);
+      (topic, receiveTime) => {
+        recordedKeyframes.push({ topic, receiveTime });
       },
     );
 
     expect(result).toEqual([secondKeyframe, secondDelta]);
-    expect(recordedKeyframes).toEqual([firstKeyframe, secondKeyframe]);
+    expect(recordedKeyframes).toEqual([
+      { topic: firstKeyframe.topic, receiveTime: firstKeyframe.receiveTime },
+      { topic: secondKeyframe.topic, receiveTime: secondKeyframe.receiveTime },
+    ]);
     expect(H264.IsKeyframe).toHaveBeenCalledTimes(4);
   });
 });

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoMessageQueue.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoMessageQueue.test.ts
@@ -12,7 +12,10 @@ import { Time } from "@foxglove/rostime";
 import { MessageEvent } from "@foxglove/studio";
 
 import { CompressedVideo } from "./ImageTypes";
-import { filterCompressedVideoQueue } from "./videoMessageQueue";
+import {
+  filterCompressedVideoQueue,
+  recordKeyframesAndFilterCompressedVideoQueue,
+} from "./videoMessageQueue";
 
 function timeFromNanoseconds(timestamp: bigint): Time {
   return {
@@ -126,5 +129,34 @@ describe("filterCompressedVideoQueue", () => {
     const result = filterCompressedVideoQueue([]);
 
     expect(result).toEqual([]);
+  });
+});
+
+describe("recordKeyframesAndFilterCompressedVideoQueue", () => {
+  beforeEach(() => {
+    jest.spyOn(H264, "IsKeyframe").mockImplementation((data) => data[0] === 0x65);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("records every keyframe before filtering while returning only the newest GOP", () => {
+    const firstKeyframe = makeMessage("/camera", 0n, "key");
+    const firstDelta = makeMessage("/camera", 10_000_000n, "delta");
+    const secondKeyframe = makeMessage("/camera", 20_000_000n, "key");
+    const secondDelta = makeMessage("/camera", 30_000_000n, "delta");
+    const recordedKeyframes: MessageEvent<CompressedVideo>[] = [];
+
+    const result = recordKeyframesAndFilterCompressedVideoQueue(
+      [firstKeyframe, firstDelta, secondKeyframe, secondDelta],
+      (messageEvent) => {
+        recordedKeyframes.push(messageEvent as MessageEvent<CompressedVideo>);
+      },
+    );
+
+    expect(result).toEqual([secondKeyframe, secondDelta]);
+    expect(recordedKeyframes).toEqual([firstKeyframe, secondKeyframe]);
+    expect(H264.IsKeyframe).toHaveBeenCalledTimes(4);
   });
 });

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoMessageQueue.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoMessageQueue.ts
@@ -14,6 +14,8 @@ import { PartialMessage } from "../../SceneExtension";
 
 export type CompressedVideoMessageEvent = MessageEvent<PartialMessage<CompressedVideo>>;
 
+export type RecordCompressedVideoKeyframe = (messageEvent: CompressedVideoMessageEvent) => void;
+
 /**
  * Compressed video frames depend on previous frames. Keep the newest decodable GOP instead of
  * keeping only the last message. If a newer keyframe arrives, older frames on the same topic can be
@@ -22,32 +24,60 @@ export type CompressedVideoMessageEvent = MessageEvent<PartialMessage<Compressed
 export function filterCompressedVideoQueue(
   queue: CompressedVideoMessageEvent[],
 ): CompressedVideoMessageEvent[] {
+  return filterCompressedVideoQueueWithKeyframes(queue).messages;
+}
+
+export function recordKeyframesAndFilterCompressedVideoQueue(
+  queue: CompressedVideoMessageEvent[],
+  recordKeyframe: RecordCompressedVideoKeyframe,
+): CompressedVideoMessageEvent[] {
+  const result = filterCompressedVideoQueueWithKeyframes(queue);
+  for (const keyframe of result.keyframes) {
+    recordKeyframe(keyframe);
+  }
+  return result.messages;
+}
+
+function filterCompressedVideoQueueWithKeyframes(queue: CompressedVideoMessageEvent[]): {
+  messages: CompressedVideoMessageEvent[];
+  keyframes: CompressedVideoMessageEvent[];
+} {
   const selectedMessages = new Set<CompressedVideoMessageEvent>();
-  const messagesByTopic = new Map<string, CompressedVideoMessageEvent[]>();
+  const keyframes: CompressedVideoMessageEvent[] = [];
+  const messagesByTopic = new Map<
+    string,
+    { messageEvent: CompressedVideoMessageEvent; isKeyframe: boolean }[]
+  >();
 
   for (const messageEvent of queue) {
+    const normalizedMessage = normalizeCompressedVideo(messageEvent.message);
+    const isKeyframe = isVideoKeyframe(normalizedMessage);
+    if (isKeyframe) {
+      keyframes.push(messageEvent);
+    }
+
     const topicMessages = messagesByTopic.get(messageEvent.topic);
     if (topicMessages) {
-      topicMessages.push(messageEvent);
+      topicMessages.push({ messageEvent, isKeyframe });
     } else {
-      messagesByTopic.set(messageEvent.topic, [messageEvent]);
+      messagesByTopic.set(messageEvent.topic, [{ messageEvent, isKeyframe }]);
     }
   }
 
   for (const topicMessages of messagesByTopic.values()) {
-    const normalizedMessages = topicMessages.map((messageEvent) =>
-      normalizeCompressedVideo(messageEvent.message),
-    );
-    const lastKeyframeIndex = findLastIndex(normalizedMessages, isVideoKeyframe);
+    const lastKeyframeIndex = findLastIndex(topicMessages, (message) => message.isKeyframe);
 
     const selectedTopicMessages =
       lastKeyframeIndex >= 0 ? topicMessages.slice(lastKeyframeIndex) : topicMessages;
-    for (const messageEvent of selectedTopicMessages) {
+    for (const { messageEvent } of selectedTopicMessages) {
       selectedMessages.add(messageEvent);
     }
   }
 
-  return queue.filter((messageEvent) => selectedMessages.has(messageEvent));
+  return {
+    messages: queue.filter((messageEvent) => selectedMessages.has(messageEvent)),
+    keyframes,
+  };
 }
 
 function findLastIndex<T>(items: T[], predicate: (item: T) => boolean): number {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoMessageQueue.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoMessageQueue.ts
@@ -5,7 +5,8 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { MessageEvent } from "@foxglove/studio";
+import type { Time } from "@foxglove/rostime";
+import type { MessageEvent } from "@foxglove/studio";
 
 import { CompressedVideo } from "./ImageTypes";
 import { isVideoKeyframe } from "./decodeImage";
@@ -14,7 +15,7 @@ import { PartialMessage } from "../../SceneExtension";
 
 export type CompressedVideoMessageEvent = MessageEvent<PartialMessage<CompressedVideo>>;
 
-export type RecordCompressedVideoKeyframe = (messageEvent: CompressedVideoMessageEvent) => void;
+export type RecordCompressedVideoKeyframe = (topic: string, receiveTime: Time) => void;
 
 /**
  * Compressed video frames depend on previous frames. Keep the newest decodable GOP instead of
@@ -24,26 +25,21 @@ export type RecordCompressedVideoKeyframe = (messageEvent: CompressedVideoMessag
 export function filterCompressedVideoQueue(
   queue: CompressedVideoMessageEvent[],
 ): CompressedVideoMessageEvent[] {
-  return filterCompressedVideoQueueWithKeyframes(queue).messages;
+  return filterCompressedVideoQueueWithKeyframes(queue);
 }
 
 export function recordKeyframesAndFilterCompressedVideoQueue(
   queue: CompressedVideoMessageEvent[],
   recordKeyframe: RecordCompressedVideoKeyframe,
 ): CompressedVideoMessageEvent[] {
-  const result = filterCompressedVideoQueueWithKeyframes(queue);
-  for (const keyframe of result.keyframes) {
-    recordKeyframe(keyframe);
-  }
-  return result.messages;
+  return filterCompressedVideoQueueWithKeyframes(queue, recordKeyframe);
 }
 
-function filterCompressedVideoQueueWithKeyframes(queue: CompressedVideoMessageEvent[]): {
-  messages: CompressedVideoMessageEvent[];
-  keyframes: CompressedVideoMessageEvent[];
-} {
+function filterCompressedVideoQueueWithKeyframes(
+  queue: CompressedVideoMessageEvent[],
+  recordKeyframe?: RecordCompressedVideoKeyframe,
+): CompressedVideoMessageEvent[] {
   const selectedMessages = new Set<CompressedVideoMessageEvent>();
-  const keyframes: CompressedVideoMessageEvent[] = [];
   const messagesByTopic = new Map<
     string,
     { messageEvent: CompressedVideoMessageEvent; isKeyframe: boolean }[]
@@ -53,7 +49,7 @@ function filterCompressedVideoQueueWithKeyframes(queue: CompressedVideoMessageEv
     const normalizedMessage = normalizeCompressedVideo(messageEvent.message);
     const isKeyframe = isVideoKeyframe(normalizedMessage);
     if (isKeyframe) {
-      keyframes.push(messageEvent);
+      recordKeyframe?.(messageEvent.topic, messageEvent.receiveTime);
     }
 
     const topicMessages = messagesByTopic.get(messageEvent.topic);
@@ -74,10 +70,7 @@ function filterCompressedVideoQueueWithKeyframes(queue: CompressedVideoMessageEv
     }
   }
 
-  return {
-    messages: queue.filter((messageEvent) => selectedMessages.has(messageEvent)),
-    keyframes,
-  };
+  return queue.filter((messageEvent) => selectedMessages.has(messageEvent));
 }
 
 function findLastIndex<T>(items: T[], predicate: (item: T) => boolean): number {


### PR DESCRIPTION
## Summary
- Distinguish failed, stale, and successful image decode results with explicit result shapes
- Preserve decoder progress across playback so later frames in the same GOP can skip already-decoded work
- Update compressed video and image renderable tests for the new result contract and playback behavior

## Testing
- Updated unit tests to cover stale-vs-failed outcomes and incremental playback continuation
- Not run (not requested)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785573468&installation_id=141984720&pr_number=1384&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1384&signature=6750cbe155874787a9447b7b06f42ace7a4fcf628530a6f75ae1a70794526ffc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->