### PR TITLE
feat(workspace): share-manifest default panel layout + reset button

### DIFF
--- a/packages/studio-base/src/components/AppBar/index.test.tsx
+++ b/packages/studio-base/src/components/AppBar/index.test.tsx
@@ -174,9 +174,7 @@ describe("<AppBar />", () => {
       </Wrapper>,
     );
     await waitFor(() => {
-      expect(
-        shared.container.querySelector('[data-tourid="reset-panels-button"]'),
-      ).not.toBeNull();
+      expect(shared.container.querySelector('[data-tourid="reset-panels-button"]')).not.toBeNull();
     });
     shared.unmount();
   });

--- a/packages/studio-base/src/components/AppBar/index.test.tsx
+++ b/packages/studio-base/src/components/AppBar/index.test.tsx
@@ -157,4 +157,27 @@ describe("<AppBar />", () => {
       global.fetch = originalFetch;
     }
   });
+
+  it("shows the reset layout button only for share manifest playback", async () => {
+    const normal = render(
+      <Wrapper>
+        <AppBar />
+      </Wrapper>,
+    );
+    expect(normal.container.querySelector('[data-tourid="reset-panels-button"]')).toBeNull();
+    normal.unmount();
+
+    const shared = render(
+      <Wrapper>
+        <SelectShareManifestSource />
+        <AppBar />
+      </Wrapper>,
+    );
+    await waitFor(() => {
+      expect(
+        shared.container.querySelector('[data-tourid="reset-panels-button"]'),
+      ).not.toBeNull();
+    });
+    shared.unmount();
+  });
 });

--- a/packages/studio-base/src/components/AppBar/index.tsx
+++ b/packages/studio-base/src/components/AppBar/index.tsx
@@ -14,6 +14,7 @@ import {
   QuestionCircle24Regular,
   ChevronDown12Regular,
   Desktop24Regular,
+  ArrowCounterclockwise24Regular,
 } from "@fluentui/react-icons";
 import PersonIcon from "@mui/icons-material/Person";
 import { Avatar, Checkbox, IconButton, Link, Tooltip, Typography, Divider } from "@mui/material";
@@ -206,7 +207,7 @@ export function AppBar(props: AppBarProps): React.JSX.Element {
   const leftSidebarOpen = useWorkspaceStore(selectLeftSidebarOpen);
   const rightSidebarOpen = useWorkspaceStore(selectRightSidebarOpen);
 
-  const { sidebarActions } = useWorkspaceActions();
+  const { sidebarActions, resetPanels } = useWorkspaceActions();
 
   const [appMenuEl, setAppMenuEl] = useState<undefined | HTMLElement>(undefined);
   const [userAnchorEl, setUserAnchorEl] = useState<undefined | HTMLElement>(undefined);
@@ -403,6 +404,18 @@ export function AppBar(props: AppBarProps): React.JSX.Element {
                     <PanelRight24Regular color={theme.palette.appBar.icon} />
                   )}
                 </AppBarIconButton>
+                {isShareManifestSource && (
+                  <AppBarIconButton
+                    title={t("resetPanels")}
+                    aria-label={t("resetPanels")}
+                    onClick={() => {
+                      resetPanels();
+                    }}
+                    data-tourid="reset-panels-button"
+                  >
+                    <ArrowCounterclockwise24Regular color={theme.palette.appBar.icon} />
+                  </AppBarIconButton>
+                )}
                 <AppBarIconButton
                   title={t("help")}
                   aria-label={t("help")}

--- a/packages/studio-base/src/components/PlaybackControls/constants.ts
+++ b/packages/studio-base/src/components/PlaybackControls/constants.ts
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+/** Minimum height (px) of the bottom timeline / playback panel. */
+export const TIMELINE_MIN_HEIGHT_PX = 126;
+
+/** Maximum height (px) of the bottom timeline / playback panel. */
+export const TIMELINE_MAX_HEIGHT_PX = 360;

--- a/packages/studio-base/src/components/PlaybackControls/index.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/index.tsx
@@ -61,11 +61,9 @@ import { Player, PlayerPresence } from "@foxglove/studio-base/players/types";
 import PlaybackTimeDisplay from "./PlaybackTimeDisplay";
 import Scrubber from "./Scrubber";
 import SeekStepControls, { MIN_SEEK_STEP_MS, MAX_SEEK_STEP_MS } from "./SeekStepControls";
+import { TIMELINE_MIN_HEIGHT_PX, TIMELINE_MAX_HEIGHT_PX } from "./constants";
 import { SHORTCUTS, ShortcutHint } from "./keyboardShortcuts";
 import { DIRECTION, jumpSeek } from "./sharedHelpers";
-
-const TIMELINE_MIN_HEIGHT_PX = 126;
-const TIMELINE_MAX_HEIGHT_PX = 360;
 
 const useStyles = makeStyles()((theme) => ({
   root: {

--- a/packages/studio-base/src/context/Workspace/shareManifestWorkspaceDefaults.test.ts
+++ b/packages/studio-base/src/context/Workspace/shareManifestWorkspaceDefaults.test.ts
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { TIMELINE_MIN_HEIGHT_PX } from "@foxglove/studio-base/components/PlaybackControls/constants";
+
+import {
+  SHARE_MANIFEST_PANEL_DEFAULTS,
+  SHARE_MANIFEST_WORKSPACE_PERSIST_KEY,
+} from "./shareManifestWorkspaceDefaults";
+
+describe("share-manifest workspace defaults", () => {
+  it("uses a persistence key distinct from the normal-mode workspace store", () => {
+    expect(SHARE_MANIFEST_WORKSPACE_PERSIST_KEY).toBe("fox.workspace.shareManifest");
+    expect(SHARE_MANIFEST_WORKSPACE_PERSIST_KEY).not.toBe("fox.workspace");
+  });
+
+  it("hides both sidebars and pins the timeline to its minimum height", () => {
+    expect(SHARE_MANIFEST_PANEL_DEFAULTS.sidebars?.left?.open).toBe(false);
+    expect(SHARE_MANIFEST_PANEL_DEFAULTS.sidebars?.right?.open).toBe(false);
+    expect(SHARE_MANIFEST_PANEL_DEFAULTS.sidebars?.left?.size).toBeUndefined();
+    expect(SHARE_MANIFEST_PANEL_DEFAULTS.sidebars?.right?.size).toBeUndefined();
+    expect(SHARE_MANIFEST_PANEL_DEFAULTS.playbackControls?.timelineHeight).toBe(
+      TIMELINE_MIN_HEIGHT_PX,
+    );
+  });
+
+  it("does not override sidebar tab selection", () => {
+    expect(SHARE_MANIFEST_PANEL_DEFAULTS.sidebars?.left?.item).toBeUndefined();
+    expect(SHARE_MANIFEST_PANEL_DEFAULTS.sidebars?.right?.item).toBeUndefined();
+  });
+});

--- a/packages/studio-base/src/context/Workspace/shareManifestWorkspaceDefaults.ts
+++ b/packages/studio-base/src/context/Workspace/shareManifestWorkspaceDefaults.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { DeepPartial } from "ts-essentials";
+
+import { TIMELINE_MIN_HEIGHT_PX } from "@foxglove/studio-base/components/PlaybackControls/constants";
+
+import { WorkspaceContextStore } from "./WorkspaceContext";
+
+/**
+ * Persistence key for the workspace store when running in share-manifest mode.
+ * Distinct from the normal-mode `fox.workspace` key so a share viewer's panel
+ * adjustments persist independently and never mutate normal-mode state.
+ */
+export const SHARE_MANIFEST_WORKSPACE_PERSIST_KEY = "fox.workspace.shareManifest";
+
+/**
+ * Panel state overrides applied on top of the base workspace defaults when opening
+ * in share-manifest mode: left sidebar hidden, right sidebar hidden, timeline panel
+ * at minimum height. Also the single source of truth for the `resetPanels` action so
+ * first-load defaults and reset can never diverge.
+ *
+ * Scope: panel visibility + size only. Sidebar tab selection (`item`) and other
+ * playback settings are intentionally left untouched.
+ */
+export const SHARE_MANIFEST_PANEL_DEFAULTS: DeepPartial<WorkspaceContextStore> = {
+  sidebars: {
+    left: {
+      open: false,
+      size: undefined,
+    },
+    right: {
+      open: false,
+      size: undefined,
+    },
+  },
+  playbackControls: {
+    timelineHeight: TIMELINE_MIN_HEIGHT_PX,
+  },
+};

--- a/packages/studio-base/src/context/Workspace/useWorkspaceActions.test.tsx
+++ b/packages/studio-base/src/context/Workspace/useWorkspaceActions.test.tsx
@@ -1,0 +1,97 @@
+/** @jest-environment jsdom */
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { renderHook, act } from "@testing-library/react";
+import { PropsWithChildren } from "react";
+
+import { TIMELINE_MIN_HEIGHT_PX } from "@foxglove/studio-base/components/PlaybackControls/constants";
+import PlayerSelectionContext, {
+  PlayerSelection,
+} from "@foxglove/studio-base/context/PlayerSelectionContext";
+import WorkspaceContextProvider from "@foxglove/studio-base/providers/WorkspaceContextProvider";
+
+import { useWorkspaceStore } from "./WorkspaceContext";
+import { useWorkspaceActions } from "./useWorkspaceActions";
+
+const mockPlayerSelection: PlayerSelection = {
+  selectSource: jest.fn(),
+  selectRecent: jest.fn(),
+  reloadCurrentSource: jest.fn(async () => {}),
+  availableSources: [],
+  recentSources: [],
+  selectedSource: undefined,
+};
+
+function Wrapper({ children }: PropsWithChildren): React.JSX.Element {
+  return (
+    <PlayerSelectionContext.Provider value={mockPlayerSelection}>
+      <WorkspaceContextProvider
+        disablePersistence
+        initialState={
+          {
+            sidebars: {
+              left: { item: "playlist", open: true, size: 300 },
+              right: { item: "variables", open: true, size: 220 },
+            },
+            playbackControls: { timelineHeight: 320 },
+          } as never
+        }
+      >
+        {children}
+      </WorkspaceContextProvider>
+    </PlayerSelectionContext.Provider>
+  );
+}
+
+describe("useWorkspaceActions resetPanels", () => {
+  it("resets sidebar visibility + size and timeline height to share-manifest defaults", () => {
+    const { result } = renderHook(
+      () => ({
+        actions: useWorkspaceActions(),
+        left: useWorkspaceStore((store) => store.sidebars.left),
+        right: useWorkspaceStore((store) => store.sidebars.right),
+        timelineHeight: useWorkspaceStore((store) => store.playbackControls.timelineHeight),
+      }),
+      { wrapper: Wrapper },
+    );
+
+    // Precondition: dirtied panel state from initialState.
+    expect(result.current.left.open).toBe(true);
+    expect(result.current.left.size).toBe(300);
+    expect(result.current.right.open).toBe(true);
+    expect(result.current.timelineHeight).toBe(320);
+
+    act(() => {
+      result.current.actions.resetPanels();
+    });
+
+    expect(result.current.left.open).toBe(false);
+    expect(result.current.left.size).toBeUndefined();
+    expect(result.current.right.open).toBe(false);
+    expect(result.current.right.size).toBeUndefined();
+    expect(result.current.timelineHeight).toBe(TIMELINE_MIN_HEIGHT_PX);
+  });
+
+  it("leaves sidebar tab selection (item) untouched", () => {
+    const { result } = renderHook(
+      () => ({
+        actions: useWorkspaceActions(),
+        left: useWorkspaceStore((store) => store.sidebars.left),
+        right: useWorkspaceStore((store) => store.sidebars.right),
+      }),
+      { wrapper: Wrapper },
+    );
+
+    act(() => {
+      result.current.actions.resetPanels();
+    });
+
+    expect(result.current.left.item).toBe("playlist");
+    expect(result.current.right.item).toBe("variables");
+  });
+});

--- a/packages/studio-base/src/context/Workspace/useWorkspaceActions.ts
+++ b/packages/studio-base/src/context/Workspace/useWorkspaceActions.ts
@@ -12,6 +12,7 @@ import { Dispatch, SetStateAction, useCallback, useMemo } from "react";
 import { useGuaranteedContext } from "@foxglove/hooks";
 import { AppSettingsTab } from "@foxglove/studio-base/components/AppSettingsDialog/AppSettingsDialog";
 import { DataSourceDialogItem } from "@foxglove/studio-base/components/DataSourceDialog";
+import { TIMELINE_MIN_HEIGHT_PX } from "@foxglove/studio-base/components/PlaybackControls/constants";
 import {
   IDataSourceFactory,
   usePlayerSelection,
@@ -27,6 +28,7 @@ import {
   WorkspaceContext,
   WorkspaceContextStore,
 } from "./WorkspaceContext";
+import { SHARE_MANIFEST_PANEL_DEFAULTS } from "./shareManifestWorkspaceDefaults";
 import { useOpenFile } from "./useOpenFile";
 
 export type WorkspaceActions = {
@@ -78,6 +80,13 @@ export type WorkspaceActions = {
       setSize: (size: undefined | number) => void;
     };
   };
+
+  /**
+   * Reset panel visibility + size to the share-manifest default layout: left and
+   * right sidebars hidden, timeline panel at minimum height. Sidebar tab selection
+   * and other playback settings are left untouched.
+   */
+  resetPanels: () => void;
 };
 
 function setterValue<T>(action: SetStateAction<T>, value: T): T {
@@ -291,6 +300,22 @@ export function useWorkspaceActions(): WorkspaceActions {
             });
           },
         },
+      },
+
+      resetPanels: () => {
+        set((draft) => {
+          // Single source of truth: every field is read from SHARE_MANIFEST_PANEL_DEFAULTS
+          // so first-load defaults and reset can never diverge. Fallbacks satisfy the
+          // DeepPartial typing but are never hit — the constant defines all of them.
+          const { sidebars, playbackControls } = SHARE_MANIFEST_PANEL_DEFAULTS;
+
+          draft.sidebars.left.open = sidebars?.left?.open ?? false;
+          draft.sidebars.left.size = sidebars?.left?.size;
+          draft.sidebars.right.open = sidebars?.right?.open ?? false;
+          draft.sidebars.right.size = sidebars?.right?.size;
+          draft.playbackControls.timelineHeight =
+            playbackControls?.timelineHeight ?? TIMELINE_MIN_HEIGHT_PX;
+        });
       },
     };
   }, [openFile, set]);

--- a/packages/studio-base/src/i18n/en/appBar.ts
+++ b/packages/studio-base/src/i18n/en/appBar.ts
@@ -25,6 +25,7 @@ export const appBar = {
   openLocalFile: "Open local file…",
   recentDataSources: "Recent data sources",
   recentlyViewed: "Recently viewed",
+  resetPanels: "Reset layout",
   visualizationSettings: "Visualization settings",
   showLeftSidebar: "Show left sidebar",
   showRightSidebar: "Show right sidebar",

--- a/packages/studio-base/src/i18n/ja/appBar.ts
+++ b/packages/studio-base/src/i18n/ja/appBar.ts
@@ -24,6 +24,7 @@ export const appBar: Partial<TypeOptions["resources"]["appBar"]> = {
   openConnection: "接続を開く",
   openLocalFile: "ローカルファイルを開く",
   recentDataSources: "最近のデータソース",
+  resetPanels: "レイアウトをリセット",
   settings: "設定",
   signIn: "ログイン",
   signOut: "ログアウト",

--- a/packages/studio-base/src/i18n/zh/appBar.ts
+++ b/packages/studio-base/src/i18n/zh/appBar.ts
@@ -25,6 +25,7 @@ export const appBar: Partial<TypeOptions["resources"]["appBar"]> = {
   openConnection: "打开连接……",
   openLocalFile: "打开本地文件……",
   recentDataSources: "最近使用的数据源",
+  resetPanels: "重置布局",
   visualizationSettings: "可视化设置",
   showLeftSidebar: "显示左侧边栏",
   showRightSidebar: "显示右侧边栏",

--- a/packages/studio-base/src/providers/WorkspaceContextProvider.test.tsx
+++ b/packages/studio-base/src/providers/WorkspaceContextProvider.test.tsx
@@ -6,10 +6,19 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { render } from "@testing-library/react";
+import { render, act } from "@testing-library/react";
+import { useContext } from "react";
+import { StoreApi } from "zustand";
 
 import { TIMELINE_MIN_HEIGHT_PX } from "@foxglove/studio-base/components/PlaybackControls/constants";
-import { useWorkspaceStore } from "@foxglove/studio-base/context/Workspace/WorkspaceContext";
+import { DataSource, useCoreData } from "@foxglove/studio-base/context/CoreDataContext";
+import {
+  WorkspaceContext,
+  WorkspaceContextStore,
+  useWorkspaceStore,
+} from "@foxglove/studio-base/context/Workspace/WorkspaceContext";
+import CoreDataProvider from "@foxglove/studio-base/providers/CoreDataProvider";
+import { SHARE_MANIFEST_DATA_SOURCE_ID } from "@foxglove/studio-base/util/shareManifest";
 
 import WorkspaceContextProvider from "./WorkspaceContextProvider";
 
@@ -140,5 +149,105 @@ describe("WorkspaceContextProvider share-manifest branch", () => {
     // Normal mode must not pick up the share-store's hidden-sidebar state.
     expect(state.leftOpen).toBe(true);
     expect(state.timelineHeight).toBe(200);
+  });
+});
+
+describe("WorkspaceContextProvider data-source-scoped stores", () => {
+  const originalUrl = window.location.href;
+
+  afterEach(() => {
+    window.history.replaceState(undefined, "", originalUrl);
+    window.localStorage.clear();
+  });
+
+  type Harness = {
+    timelineHeight: number;
+    store: StoreApi<WorkspaceContextStore> | undefined;
+    setDataSource: (dataSource: DataSource | undefined) => void;
+  };
+
+  function renderScenario(): Harness {
+    const harness: Harness = {
+      timelineHeight: -1,
+      store: undefined,
+      setDataSource: () => {},
+    };
+    function Capture(): ReactNull {
+      harness.store = useContext(WorkspaceContext);
+      harness.setDataSource = useCoreData((s) => s.setDataSource);
+      harness.timelineHeight = useWorkspaceStore((s) => s.playbackControls.timelineHeight);
+      return ReactNull;
+    }
+    render(
+      <CoreDataProvider>
+        <WorkspaceContextProvider>
+          <Capture />
+        </WorkspaceContextProvider>
+      </CoreDataProvider>,
+    );
+    return harness;
+  }
+
+  it("switches stores on data source change and does not inherit share adjustments", () => {
+    window.localStorage.setItem(
+      NORMAL_KEY,
+      persistedWorkspace({ leftOpen: true, timelineHeight: 300 }),
+    );
+    window.localStorage.setItem(
+      SHARE_KEY,
+      persistedWorkspace({ leftOpen: false, timelineHeight: 140 }),
+    );
+
+    const h = renderScenario();
+
+    // Before a data source resolves, a non-share URL uses the normal store.
+    expect(h.timelineHeight).toBe(300);
+
+    // Switch to share-manifest -> isolated share store.
+    act(() => {
+      h.setDataSource({ id: SHARE_MANIFEST_DATA_SOURCE_ID, type: "connection" });
+    });
+    expect(h.timelineHeight).toBe(140);
+
+    // Switch to another data source -> back to the normal store, NOT the share value.
+    act(() => {
+      h.setDataSource({ id: "coscene-data-platform", type: "connection" });
+    });
+    expect(h.timelineHeight).toBe(300);
+    expect(h.timelineHeight).not.toBe(140);
+  });
+
+  it("a share session never writes the normal key, and vice versa", () => {
+    const h = renderScenario();
+
+    // Normal store active but untouched -> its key is never written.
+    expect(window.localStorage.getItem(NORMAL_KEY)).toBeNull();
+
+    // Switch to share-manifest and mutate -> writes ONLY the share key.
+    act(() => {
+      h.setDataSource({ id: SHARE_MANIFEST_DATA_SOURCE_ID, type: "connection" });
+    });
+    act(() => {
+      h.store?.setState((s) => ({
+        playbackControls: { ...s.playbackControls, timelineHeight: 222 },
+      }));
+    });
+
+    expect(window.localStorage.getItem(NORMAL_KEY)).toBeNull();
+    expect(window.localStorage.getItem(SHARE_KEY)).toContain("222");
+
+    // Switch back to normal and mutate -> writes ONLY the normal key; share key intact.
+    act(() => {
+      h.setDataSource({ id: "coscene-data-platform", type: "connection" });
+    });
+    act(() => {
+      h.store?.setState((s) => ({
+        playbackControls: { ...s.playbackControls, timelineHeight: 333 },
+      }));
+    });
+
+    expect(window.localStorage.getItem(NORMAL_KEY)).toContain("333");
+    expect(window.localStorage.getItem(SHARE_KEY)).toContain("222");
+    expect(window.localStorage.getItem(SHARE_KEY)).not.toContain("333");
   });
 });

--- a/packages/studio-base/src/providers/WorkspaceContextProvider.test.tsx
+++ b/packages/studio-base/src/providers/WorkspaceContextProvider.test.tsx
@@ -1,0 +1,124 @@
+/** @jest-environment jsdom */
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { render } from "@testing-library/react";
+
+import { TIMELINE_MIN_HEIGHT_PX } from "@foxglove/studio-base/components/PlaybackControls/constants";
+import { useWorkspaceStore } from "@foxglove/studio-base/context/Workspace/WorkspaceContext";
+
+import WorkspaceContextProvider from "./WorkspaceContextProvider";
+
+const NORMAL_KEY = "fox.workspace";
+const SHARE_KEY = "fox.workspace.shareManifest";
+const SHARE_URL =
+  "http://localhost/viz?ds=coscene-share-manifest#manifestUrl=https%3A%2F%2Fstorage.example.com%2Fmanifest.json";
+const NORMAL_URL = "http://localhost/viz?ds=coscene-data-platform";
+
+function persistedWorkspace({
+  leftOpen,
+  timelineHeight,
+}: {
+  leftOpen: boolean;
+  timelineHeight: number;
+}): string {
+  return (
+    JSON.stringify({
+      version: 1,
+      state: {
+        sidebars: {
+          left: { item: "playlist", open: leftOpen, size: 400 },
+          right: { item: undefined, open: false, size: undefined },
+        },
+        playbackControls: { timelineHeight },
+      },
+    }) ?? ""
+  );
+}
+
+function renderWithProvider(): {
+  leftOpen: boolean;
+  rightOpen: boolean;
+  timelineHeight: number;
+} {
+  const captured = { leftOpen: true, rightOpen: false, timelineHeight: -1 };
+  function Capture(): ReactNull {
+    captured.leftOpen = useWorkspaceStore((s) => s.sidebars.left.open);
+    captured.rightOpen = useWorkspaceStore((s) => s.sidebars.right.open);
+    captured.timelineHeight = useWorkspaceStore((s) => s.playbackControls.timelineHeight);
+    return ReactNull;
+  }
+  render(
+    <WorkspaceContextProvider>
+      <Capture />
+    </WorkspaceContextProvider>,
+  );
+  return captured;
+}
+
+describe("WorkspaceContextProvider share-manifest branch", () => {
+  const originalUrl = window.location.href;
+
+  afterEach(() => {
+    window.history.replaceState(undefined, "", originalUrl);
+    window.localStorage.clear();
+  });
+
+  it("applies share defaults (sidebars hidden, timeline min) on a first share visit", () => {
+    window.history.replaceState(undefined, "", SHARE_URL);
+
+    const state = renderWithProvider();
+
+    expect(state.leftOpen).toBe(false);
+    expect(state.rightOpen).toBe(false);
+    expect(state.timelineHeight).toBe(TIMELINE_MIN_HEIGHT_PX);
+  });
+
+  it("respects the viewer's persisted share-store state on a return share visit", () => {
+    window.localStorage.setItem(SHARE_KEY, persistedWorkspace({ leftOpen: true, timelineHeight: 250 }));
+    window.history.replaceState(undefined, "", SHARE_URL);
+
+    const state = renderWithProvider();
+
+    // Persisted viewer changes win over the share defaults.
+    expect(state.leftOpen).toBe(true);
+    expect(state.timelineHeight).toBe(250);
+  });
+
+  it("reads only the share key in share mode, ignoring normal-mode state", () => {
+    // Normal-mode store says left CLOSED; share mode must not read it.
+    window.localStorage.setItem(NORMAL_KEY, persistedWorkspace({ leftOpen: false, timelineHeight: 999 }));
+    window.history.replaceState(undefined, "", SHARE_URL);
+
+    const state = renderWithProvider();
+
+    // No share-key persistence => share defaults, NOT the normal-key values.
+    expect(state.leftOpen).toBe(false);
+    expect(state.timelineHeight).toBe(TIMELINE_MIN_HEIGHT_PX);
+    expect(state.timelineHeight).not.toBe(999);
+  });
+
+  it("uses normal defaults and reads the normal key for a non-share URL", () => {
+    window.history.replaceState(undefined, "", NORMAL_URL);
+
+    const state = renderWithProvider();
+
+    expect(state.leftOpen).toBe(true);
+    expect(state.timelineHeight).toBe(200);
+  });
+
+  it("reads only the normal key in normal mode, ignoring share-mode state", () => {
+    window.localStorage.setItem(SHARE_KEY, persistedWorkspace({ leftOpen: false, timelineHeight: 126 }));
+    window.history.replaceState(undefined, "", NORMAL_URL);
+
+    const state = renderWithProvider();
+
+    // Normal mode must not pick up the share-store's hidden-sidebar state.
+    expect(state.leftOpen).toBe(true);
+    expect(state.timelineHeight).toBe(200);
+  });
+});

--- a/packages/studio-base/src/providers/WorkspaceContextProvider.test.tsx
+++ b/packages/studio-base/src/providers/WorkspaceContextProvider.test.tsx
@@ -89,13 +89,13 @@ describe("WorkspaceContextProvider share-manifest branch", () => {
     expect(state.timelineHeight).toBe(TIMELINE_MIN_HEIGHT_PX);
   });
 
-  it("applies share defaults for the app-state query form (ds.* params, no hash)", () => {
+  it("uses normal defaults for unsupported ds.* query-form manifest params", () => {
     window.history.replaceState(undefined, "", QUERY_SHARE_URL);
 
     const state = renderWithProvider();
 
-    expect(state.leftOpen).toBe(false);
-    expect(state.timelineHeight).toBe(TIMELINE_MIN_HEIGHT_PX);
+    expect(state.leftOpen).toBe(true);
+    expect(state.timelineHeight).toBe(200);
   });
 
   it("respects the viewer's persisted share-store state on a return share visit", () => {

--- a/packages/studio-base/src/providers/WorkspaceContextProvider.test.tsx
+++ b/packages/studio-base/src/providers/WorkspaceContextProvider.test.tsx
@@ -17,6 +17,8 @@ const NORMAL_KEY = "fox.workspace";
 const SHARE_KEY = "fox.workspace.shareManifest";
 const SHARE_URL =
   "http://localhost/viz?ds=coscene-share-manifest#manifestUrl=https%3A%2F%2Fstorage.example.com%2Fmanifest.json";
+const QUERY_SHARE_URL =
+  "http://localhost/viz?ds=coscene-share-manifest&ds.manifestUrl=https%3A%2F%2Fstorage.example.com%2Fmanifest.json";
 const NORMAL_URL = "http://localhost/viz?ds=coscene-data-platform";
 
 function persistedWorkspace({
@@ -75,6 +77,15 @@ describe("WorkspaceContextProvider share-manifest branch", () => {
 
     expect(state.leftOpen).toBe(false);
     expect(state.rightOpen).toBe(false);
+    expect(state.timelineHeight).toBe(TIMELINE_MIN_HEIGHT_PX);
+  });
+
+  it("applies share defaults for the app-state query form (ds.* params, no hash)", () => {
+    window.history.replaceState(undefined, "", QUERY_SHARE_URL);
+
+    const state = renderWithProvider();
+
+    expect(state.leftOpen).toBe(false);
     expect(state.timelineHeight).toBe(TIMELINE_MIN_HEIGHT_PX);
   });
 

--- a/packages/studio-base/src/providers/WorkspaceContextProvider.test.tsx
+++ b/packages/studio-base/src/providers/WorkspaceContextProvider.test.tsx
@@ -90,7 +90,10 @@ describe("WorkspaceContextProvider share-manifest branch", () => {
   });
 
   it("respects the viewer's persisted share-store state on a return share visit", () => {
-    window.localStorage.setItem(SHARE_KEY, persistedWorkspace({ leftOpen: true, timelineHeight: 250 }));
+    window.localStorage.setItem(
+      SHARE_KEY,
+      persistedWorkspace({ leftOpen: true, timelineHeight: 250 }),
+    );
     window.history.replaceState(undefined, "", SHARE_URL);
 
     const state = renderWithProvider();
@@ -102,7 +105,10 @@ describe("WorkspaceContextProvider share-manifest branch", () => {
 
   it("reads only the share key in share mode, ignoring normal-mode state", () => {
     // Normal-mode store says left CLOSED; share mode must not read it.
-    window.localStorage.setItem(NORMAL_KEY, persistedWorkspace({ leftOpen: false, timelineHeight: 999 }));
+    window.localStorage.setItem(
+      NORMAL_KEY,
+      persistedWorkspace({ leftOpen: false, timelineHeight: 999 }),
+    );
     window.history.replaceState(undefined, "", SHARE_URL);
 
     const state = renderWithProvider();
@@ -123,7 +129,10 @@ describe("WorkspaceContextProvider share-manifest branch", () => {
   });
 
   it("reads only the normal key in normal mode, ignoring share-mode state", () => {
-    window.localStorage.setItem(SHARE_KEY, persistedWorkspace({ leftOpen: false, timelineHeight: 126 }));
+    window.localStorage.setItem(
+      SHARE_KEY,
+      persistedWorkspace({ leftOpen: false, timelineHeight: 126 }),
+    );
     window.history.replaceState(undefined, "", NORMAL_URL);
 
     const state = renderWithProvider();

--- a/packages/studio-base/src/providers/WorkspaceContextProvider.tsx
+++ b/packages/studio-base/src/providers/WorkspaceContextProvider.tsx
@@ -16,6 +16,11 @@ import {
   WorkspaceContextStore,
 } from "@foxglove/studio-base/context/Workspace/WorkspaceContext";
 import { migrateV0WorkspaceState } from "@foxglove/studio-base/context/Workspace/migrations";
+import {
+  SHARE_MANIFEST_PANEL_DEFAULTS,
+  SHARE_MANIFEST_WORKSPACE_PERSIST_KEY,
+} from "@foxglove/studio-base/context/Workspace/shareManifestWorkspaceDefaults";
+import { windowIsShareManifestMode } from "@foxglove/studio-base/util/shareManifest";
 
 /**
  * Creates the default initial state for the workspace store.
@@ -70,10 +75,25 @@ function createWorkspaceContextStore(
   initialState?: DeepPartial<WorkspaceContextStore>,
   options?: { disablePersistence?: boolean },
 ): StoreApi<WorkspaceContextStore> {
+  // Share-manifest mode gets its own default panel layout (sidebars hidden, timeline
+  // at minimum height) and a separate persistence key, so the share viewer's own panel
+  // adjustments persist independently and never mutate normal-mode `fox.workspace`.
+  //
+  // Detection MUST stay in lockstep with the AppBar's share-only UI gate
+  // (`dataSource?.id === SHARE_MANIFEST_DATA_SOURCE_ID`); both derive from the same
+  // "valid share manifest" predicate (see `isShareManifestModeFromUrl`). Do not change
+  // one without the other, or the store key/defaults and the share UI can diverge.
+  //
+  // Known limitation: this reads `window.location` at mount. On the Electron desktop
+  // app, an OS-delivered `coscene://` share deeplink may not be reflected in
+  // `window.location`, so desktop share sessions fall back to the normal store. Share
+  // manifests are a web-viewer feature; revisit if desktop share support is added.
+  const shareManifestMode = windowIsShareManifestMode();
   const stateCreator = () => {
     const store: WorkspaceContextStore = _.merge(
       {},
       makeWorkspaceContextInitialState(),
+      shareManifestMode ? SHARE_MANIFEST_PANEL_DEFAULTS : undefined,
       initialState,
     );
     return store;
@@ -83,7 +103,7 @@ function createWorkspaceContextStore(
   }
   return createStore<WorkspaceContextStore>()(
     persist(stateCreator, {
-      name: "fox.workspace",
+      name: shareManifestMode ? SHARE_MANIFEST_WORKSPACE_PERSIST_KEY : "fox.workspace",
       version: 1,
       migrate: migrateV0WorkspaceState,
       partialize: (state) => {

--- a/packages/studio-base/src/providers/WorkspaceContextProvider.tsx
+++ b/packages/studio-base/src/providers/WorkspaceContextProvider.tsx
@@ -6,11 +6,12 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import * as _ from "lodash-es";
-import { ReactNode, useState } from "react";
+import { ReactNode, useContext, useRef } from "react";
 import { DeepPartial } from "ts-essentials";
-import { StoreApi, createStore } from "zustand";
+import { StoreApi, createStore, useStore } from "zustand";
 import { persist } from "zustand/middleware";
 
+import { CoreDataContext, CoreDataStore } from "@foxglove/studio-base/context/CoreDataContext";
 import {
   WorkspaceContext,
   WorkspaceContextStore,
@@ -20,7 +21,18 @@ import {
   SHARE_MANIFEST_PANEL_DEFAULTS,
   SHARE_MANIFEST_WORKSPACE_PERSIST_KEY,
 } from "@foxglove/studio-base/context/Workspace/shareManifestWorkspaceDefaults";
-import { windowIsShareManifestMode } from "@foxglove/studio-base/util/shareManifest";
+import {
+  SHARE_MANIFEST_DATA_SOURCE_ID,
+  windowIsShareManifestMode,
+} from "@foxglove/studio-base/util/shareManifest";
+
+/**
+ * Which data-source-scoped workspace preference store to use. `coscene-share-manifest`
+ * gets its own isolated store; every other data source shares the normal store.
+ */
+type WorkspaceStoreKind = "normal" | "shareManifest";
+
+const NORMAL_WORKSPACE_PERSIST_KEY = "fox.workspace";
 
 /**
  * Creates the default initial state for the workspace store.
@@ -73,22 +85,13 @@ export function makeWorkspaceContextInitialState(): WorkspaceContextStore {
 
 function createWorkspaceContextStore(
   initialState?: DeepPartial<WorkspaceContextStore>,
-  options?: { disablePersistence?: boolean },
+  options?: { disablePersistence?: boolean; kind?: WorkspaceStoreKind },
 ): StoreApi<WorkspaceContextStore> {
-  // Share-manifest mode gets its own default panel layout (sidebars hidden, timeline
-  // at minimum height) and a separate persistence key, so the share viewer's own panel
-  // adjustments persist independently and never mutate normal-mode `fox.workspace`.
-  //
-  // Detection MUST stay in lockstep with the AppBar's share-only UI gate
-  // (`dataSource?.id === SHARE_MANIFEST_DATA_SOURCE_ID`); both derive from the same
-  // "valid share manifest" predicate (see `isShareManifestModeFromUrl`). Do not change
-  // one without the other, or the store key/defaults and the share UI can diverge.
-  //
-  // Known limitation: this reads `window.location` at mount. On the Electron desktop
-  // app, an OS-delivered `coscene://` share deeplink may not be reflected in
-  // `window.location`, so desktop share sessions fall back to the normal store. Share
-  // manifests are a web-viewer feature; revisit if desktop share support is added.
-  const shareManifestMode = windowIsShareManifestMode();
+  // The `coscene-share-manifest` store gets its own default panel layout (sidebars
+  // hidden, timeline at minimum height) and its own persistence key, so a share
+  // viewer's panel/playback adjustments persist independently and never mutate the
+  // normal-mode `fox.workspace` store (and vice versa).
+  const shareManifestMode = options?.kind === "shareManifest";
   const stateCreator = () => {
     const store: WorkspaceContextStore = _.merge(
       {},
@@ -103,12 +106,14 @@ function createWorkspaceContextStore(
   }
   return createStore<WorkspaceContextStore>()(
     persist(stateCreator, {
-      name: shareManifestMode ? SHARE_MANIFEST_WORKSPACE_PERSIST_KEY : "fox.workspace",
+      name: shareManifestMode ? SHARE_MANIFEST_WORKSPACE_PERSIST_KEY : NORMAL_WORKSPACE_PERSIST_KEY,
       version: 1,
       migrate: migrateV0WorkspaceState,
       partialize: (state) => {
         // Note that this is an opt-in list of keys from the store that we
-        // include and restore when persisting to and from localStorage.
+        // include and restore when persisting to and from localStorage. Because each
+        // data-source-scoped store persists under its own key, this whole slice
+        // (sidebars, playbackControls, featureTours) is isolated per store.
         return _.pick(state, ["featureTours", "playbackControls", "sidebars"]);
       },
       merge(persistedState, currentState) {
@@ -118,6 +123,38 @@ function createWorkspaceContextStore(
       },
     }),
   );
+}
+
+/**
+ * Reads the active data source id from CoreDataContext when present. Returns undefined
+ * when there is no CoreDataProvider ancestor (e.g. isolated unit tests / storybook), so
+ * this provider stays usable standalone.
+ */
+// Only `dataSource` is ever read from this fallback; the rest of CoreDataStore is
+// intentionally absent (this store exists solely so `useStore` has something to read
+// when there is no CoreDataProvider).
+const EMPTY_CORE_DATA_STORE = createStore<CoreDataStore>()(
+  () => ({ dataSource: undefined }) as CoreDataStore,
+);
+
+const selectDataSourceId = (state: CoreDataStore): string | undefined => state.dataSource?.id;
+
+function useActiveDataSourceId(): string | undefined {
+  const coreDataStore = useContext(CoreDataContext);
+  return useStore(coreDataStore ?? EMPTY_CORE_DATA_STORE, selectDataSourceId);
+}
+
+/**
+ * Resolves which data-source-scoped store kind is active. Prefers the resolved data
+ * source id; before a data source has been selected (startup), falls back to the URL so
+ * a share-manifest tab uses the isolated store immediately and never touches
+ * `fox.workspace`.
+ */
+function resolveStoreKind(dataSourceId: string | undefined): WorkspaceStoreKind {
+  if (dataSourceId != undefined) {
+    return dataSourceId === SHARE_MANIFEST_DATA_SOURCE_ID ? "shareManifest" : "normal";
+  }
+  return windowIsShareManifestMode() ? "shareManifest" : "normal";
 }
 
 export type WorkspaceContextProviderProps = {
@@ -135,11 +172,24 @@ export default function WorkspaceContextProvider(
 ): React.JSX.Element {
   const { children, initialState, workspaceStoreCreator, disablePersistence } = props;
 
-  const [store] = useState(() =>
-    workspaceStoreCreator
+  // Bind the workspace preference store to the ACTIVE data source type rather than
+  // choosing once at mount. `coscene-share-manifest` uses an isolated store; all other
+  // data sources share the normal store. Switching data source within the same tab
+  // swaps which cached store is active — each kind keeps its own persisted state, so a
+  // share session never inherits (or overwrites) normal-mode preferences and vice versa.
+  const kind = resolveStoreKind(useActiveDataSourceId());
+
+  // One store per kind, created lazily on first activation and cached for the lifetime
+  // of this provider. A never-activated kind is never created, so e.g. a pure
+  // share-manifest tab never reads or writes `fox.workspace`.
+  const storesRef = useRef<Map<WorkspaceStoreKind, StoreApi<WorkspaceContextStore>>>(new Map());
+  let store = storesRef.current.get(kind);
+  if (store == undefined) {
+    store = workspaceStoreCreator
       ? workspaceStoreCreator(initialState, { disablePersistence })
-      : createWorkspaceContextStore(initialState, { disablePersistence }),
-  );
+      : createWorkspaceContextStore(initialState, { disablePersistence, kind });
+    storesRef.current.set(kind, store);
+  }
 
   return <WorkspaceContext.Provider value={store}>{children}</WorkspaceContext.Provider>;
 }

--- a/packages/studio-base/src/util/shareManifest.test.ts
+++ b/packages/studio-base/src/util/shareManifest.test.ts
@@ -292,7 +292,9 @@ describe("isShareManifestModeFromUrl", () => {
   it("is false for the app-state query form with a non-http manifest URL", () => {
     expect(
       isShareManifestModeFromUrl(
-        new URL("https://example.com/viz?ds=coscene-share-manifest&ds.manifestUrl=ftp%3A%2F%2Fnope"),
+        new URL(
+          "https://example.com/viz?ds=coscene-share-manifest&ds.manifestUrl=ftp%3A%2F%2Fnope",
+        ),
         now,
       ),
     ).toBe(false);
@@ -303,10 +305,7 @@ describe("isShareManifestModeFromUrl", () => {
     // a share (DeepLinksSyncAdapter requires a valid manifest), so applying the
     // hidden-sidebar layout would be a confusing degraded state.
     expect(
-      isShareManifestModeFromUrl(
-        new URL("https://example.com/viz?ds=coscene-share-manifest"),
-        now,
-      ),
+      isShareManifestModeFromUrl(new URL("https://example.com/viz?ds=coscene-share-manifest"), now),
     ).toBe(false);
   });
 
@@ -346,10 +345,7 @@ describe("isShareManifestModeFromUrl", () => {
 
   it("is false for a normal data-platform URL", () => {
     expect(
-      isShareManifestModeFromUrl(
-        new URL("https://example.com/viz?ds=coscene-data-platform"),
-        now,
-      ),
+      isShareManifestModeFromUrl(new URL("https://example.com/viz?ds=coscene-data-platform"), now),
     ).toBe(false);
   });
 

--- a/packages/studio-base/src/util/shareManifest.test.ts
+++ b/packages/studio-base/src/util/shareManifest.test.ts
@@ -276,9 +276,7 @@ describe("isShareManifestModeFromUrl", () => {
     ).toBe(true);
   });
 
-  it("is true for the app-state query form (ds=coscene-share-manifest&ds.manifestUrl=…)", () => {
-    // DeepLinksSyncAdapter/parseAppURLState feed `ds.*` params to the factory, which
-    // accepts `manifestUrl` — so the share source loads and the store must match.
+  it("is false for the unsupported app-state query form (ds=coscene-share-manifest&ds.manifestUrl=…)", () => {
     expect(
       isShareManifestModeFromUrl(
         new URL(
@@ -286,7 +284,7 @@ describe("isShareManifestModeFromUrl", () => {
         ),
         now,
       ),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("is false for the app-state query form with a non-http manifest URL", () => {

--- a/packages/studio-base/src/util/shareManifest.test.ts
+++ b/packages/studio-base/src/util/shareManifest.test.ts
@@ -7,6 +7,7 @@
 
 import {
   SHARE_MANIFEST_DATA_SOURCE_ID,
+  isShareManifestModeFromUrl,
   isShareManifestUrl,
   parseShareManifestFromUrl,
 } from "@foxglove/studio-base/util/shareManifest";
@@ -258,5 +259,79 @@ describe("share manifest URL parsing", () => {
         now,
       ),
     ).toBe(true);
+  });
+});
+
+describe("isShareManifestModeFromUrl", () => {
+  const now = new Date("2026-06-25T00:00:00Z");
+
+  it("is true for a valid direct manifest opened with ds=coscene-share-manifest", () => {
+    expect(
+      isShareManifestModeFromUrl(
+        new URL(
+          "https://example.com/viz?ds=coscene-share-manifest#manifestUrl=https%3A%2F%2Fstorage.example.com%2Fmanifest.json",
+        ),
+        now,
+      ),
+    ).toBe(true);
+  });
+
+  it("is false for ds=coscene-share-manifest without a manifest payload", () => {
+    // The ds param alone must NOT trigger share defaults: such a URL never loads as
+    // a share (DeepLinksSyncAdapter requires a valid manifest), so applying the
+    // hidden-sidebar layout would be a confusing degraded state.
+    expect(
+      isShareManifestModeFromUrl(
+        new URL("https://example.com/viz?ds=coscene-share-manifest"),
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it("is false for ds=coscene-share-manifest with a malformed hash payload", () => {
+    expect(
+      isShareManifestModeFromUrl(
+        new URL("https://example.com/viz?ds=coscene-share-manifest#manifest=!!!not-base64!!!"),
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it("is true for a hash-based share manifest without the ds query param", () => {
+    expect(
+      isShareManifestModeFromUrl(
+        new URL(
+          "https://example.com/viz#manifestUrl=https%3A%2F%2Fstorage.example.com%2Fmanifest.json",
+        ),
+        now,
+      ),
+    ).toBe(true);
+  });
+
+  it("is false for an expired hash share manifest (would be a dead-end otherwise)", () => {
+    const expiredEncoded = encodeBase64Url({ expireTime: "2026-06-20T10:00:00Z" });
+    // isShareManifestUrl treats expired as a share URL; mode detection must not.
+    expect(
+      isShareManifestUrl(new URL(`https://example.com/viz#manifest=${expiredEncoded}`), now),
+    ).toBe(true);
+    expect(
+      isShareManifestModeFromUrl(
+        new URL(`https://example.com/viz#manifest=${expiredEncoded}`),
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it("is false for a normal data-platform URL", () => {
+    expect(
+      isShareManifestModeFromUrl(
+        new URL("https://example.com/viz?ds=coscene-data-platform"),
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it("is false when no data source is specified", () => {
+    expect(isShareManifestModeFromUrl(new URL("https://example.com/viz"), now)).toBe(false);
   });
 });

--- a/packages/studio-base/src/util/shareManifest.test.ts
+++ b/packages/studio-base/src/util/shareManifest.test.ts
@@ -276,6 +276,28 @@ describe("isShareManifestModeFromUrl", () => {
     ).toBe(true);
   });
 
+  it("is true for the app-state query form (ds=coscene-share-manifest&ds.manifestUrl=…)", () => {
+    // DeepLinksSyncAdapter/parseAppURLState feed `ds.*` params to the factory, which
+    // accepts `manifestUrl` — so the share source loads and the store must match.
+    expect(
+      isShareManifestModeFromUrl(
+        new URL(
+          "https://example.com/viz?ds=coscene-share-manifest&ds.manifestUrl=https%3A%2F%2Fstorage.example.com%2Fmanifest.json",
+        ),
+        now,
+      ),
+    ).toBe(true);
+  });
+
+  it("is false for the app-state query form with a non-http manifest URL", () => {
+    expect(
+      isShareManifestModeFromUrl(
+        new URL("https://example.com/viz?ds=coscene-share-manifest&ds.manifestUrl=ftp%3A%2F%2Fnope"),
+        now,
+      ),
+    ).toBe(false);
+  });
+
   it("is false for ds=coscene-share-manifest without a manifest payload", () => {
     // The ds param alone must NOT trigger share defaults: such a URL never loads as
     // a share (DeepLinksSyncAdapter requires a valid manifest), so applying the

--- a/packages/studio-base/src/util/shareManifest.ts
+++ b/packages/studio-base/src/util/shareManifest.ts
@@ -211,6 +211,38 @@ export function isShareManifestUrl(url: URL, now: Date = new Date()): boolean {
   return result.status === "valid" || result.status === "expired";
 }
 
+/**
+ * True when the given URL should open in share-manifest mode — i.e. when it carries
+ * a *valid* share-manifest payload (encoded hash, direct manifest URL, or the
+ * `ds=coscene-share-manifest` + manifest params combination).
+ *
+ * This predicate is deliberately identical to the condition under which
+ * `DeepLinksSyncAdapter` selects the share-manifest data source: `status === "valid"`
+ * only. It intentionally excludes both `expired` and `invalid`/`missing` payloads.
+ * If it returned true for those, the workspace store would apply the share panel
+ * defaults (both sidebars hidden) for a URL that never actually loads as a share —
+ * a confusing degraded state. Keeping this in lockstep with the data-source gate is
+ * what prevents the store key/defaults and the AppBar share-only UI from diverging.
+ */
+export function isShareManifestModeFromUrl(url: URL, now: Date = new Date()): boolean {
+  return parseShareManifestFromUrl(url, now).status === "valid";
+}
+
+/**
+ * Synchronously detect share-manifest mode from the current window location.
+ * SSR-safe: returns false when `window` is unavailable or the URL cannot be parsed.
+ */
+export function windowIsShareManifestMode(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  try {
+    return isShareManifestModeFromUrl(new URL(window.location.href));
+  } catch {
+    return false;
+  }
+}
+
 export function windowShareManifestParseResult(): ShareManifestParseResult {
   if (typeof window === "undefined") {
     return { status: "missing" };

--- a/packages/studio-base/src/util/shareManifest.ts
+++ b/packages/studio-base/src/util/shareManifest.ts
@@ -212,46 +212,21 @@ export function isShareManifestUrl(url: URL, now: Date = new Date()): boolean {
 }
 
 /**
- * Extracts the `ds.*` query params (with the `ds.` prefix stripped) that
- * `DeepLinksSyncAdapter` / `parseAppURLState` feed into a data-source factory's
- * `initialize(args.params)`.
- */
-function getDsParams(url: URL): Record<string, string> {
-  const dsParams: Record<string, string> = {};
-  url.searchParams.forEach((value, key) => {
-    if (key.startsWith("ds.") && value.length > 0) {
-      dsParams[key.replace(/^ds\./, "")] = value;
-    }
-  });
-  return dsParams;
-}
-
-/**
  * True when the given URL should open in share-manifest mode — i.e. when it carries
- * a *valid* share-manifest payload. This covers BOTH forms the app can select the
- * share-manifest data source from:
- *   - the hash form (`#manifest=...` / `#manifestUrl=...`), and
- *   - the app-state query form (`?ds=coscene-share-manifest&ds.manifestUrl=...`),
- *     which `DeepLinksSyncAdapter` resolves via `parseAppURLState` + the factory.
+ * a *valid* share-manifest payload in the URL hash (`#manifest=...` or
+ * `#manifestUrl=...`). App-state query params such as
+ * `?ds=coscene-share-manifest&ds.manifestUrl=...` are not a supported share-link
+ * format and must not opt the workspace into the isolated share store.
  *
  * The predicate is deliberately identical to the condition under which
  * `DeepLinksSyncAdapter` / `CoSceneShareManifestDataSourceFactory` actually load the
- * share source: `status === "valid"` only. It intentionally excludes `expired` and
- * `invalid`/`missing` payloads — applying the share panel defaults (sidebars hidden)
- * for a URL that never loads as a share would be a confusing degraded state, and
- * using the normal `fox.workspace` key for a URL that DOES load as a share would let
- * the share session mutate normal-mode panel settings. Keeping this in lockstep with
- * the data-source gate is what prevents the store key/defaults and the AppBar
- * share-only UI from diverging.
+ * share source from legal share links: `status === "valid"` only. It intentionally
+ * excludes `expired` and `invalid`/`missing` payloads — applying the share panel
+ * defaults (sidebars hidden) for a URL that never loads as a legal share would be a
+ * confusing degraded state.
  */
 export function isShareManifestModeFromUrl(url: URL, now: Date = new Date()): boolean {
-  if (parseShareManifestFromUrl(url, now).status === "valid") {
-    return true;
-  }
-  if (url.searchParams.get("ds") === SHARE_MANIFEST_DATA_SOURCE_ID) {
-    return parseShareManifestParams(getDsParams(url), now).status === "valid";
-  }
-  return false;
+  return parseShareManifestFromUrl(url, now).status === "valid";
 }
 
 /**

--- a/packages/studio-base/src/util/shareManifest.ts
+++ b/packages/studio-base/src/util/shareManifest.ts
@@ -212,20 +212,46 @@ export function isShareManifestUrl(url: URL, now: Date = new Date()): boolean {
 }
 
 /**
+ * Extracts the `ds.*` query params (with the `ds.` prefix stripped) that
+ * `DeepLinksSyncAdapter` / `parseAppURLState` feed into a data-source factory's
+ * `initialize(args.params)`.
+ */
+function getDsParams(url: URL): Record<string, string> {
+  const dsParams: Record<string, string> = {};
+  url.searchParams.forEach((value, key) => {
+    if (key.startsWith("ds.") && value.length > 0) {
+      dsParams[key.replace(/^ds\./, "")] = value;
+    }
+  });
+  return dsParams;
+}
+
+/**
  * True when the given URL should open in share-manifest mode — i.e. when it carries
- * a *valid* share-manifest payload (encoded hash, direct manifest URL, or the
- * `ds=coscene-share-manifest` + manifest params combination).
+ * a *valid* share-manifest payload. This covers BOTH forms the app can select the
+ * share-manifest data source from:
+ *   - the hash form (`#manifest=...` / `#manifestUrl=...`), and
+ *   - the app-state query form (`?ds=coscene-share-manifest&ds.manifestUrl=...`),
+ *     which `DeepLinksSyncAdapter` resolves via `parseAppURLState` + the factory.
  *
- * This predicate is deliberately identical to the condition under which
- * `DeepLinksSyncAdapter` selects the share-manifest data source: `status === "valid"`
- * only. It intentionally excludes both `expired` and `invalid`/`missing` payloads.
- * If it returned true for those, the workspace store would apply the share panel
- * defaults (both sidebars hidden) for a URL that never actually loads as a share —
- * a confusing degraded state. Keeping this in lockstep with the data-source gate is
- * what prevents the store key/defaults and the AppBar share-only UI from diverging.
+ * The predicate is deliberately identical to the condition under which
+ * `DeepLinksSyncAdapter` / `CoSceneShareManifestDataSourceFactory` actually load the
+ * share source: `status === "valid"` only. It intentionally excludes `expired` and
+ * `invalid`/`missing` payloads — applying the share panel defaults (sidebars hidden)
+ * for a URL that never loads as a share would be a confusing degraded state, and
+ * using the normal `fox.workspace` key for a URL that DOES load as a share would let
+ * the share session mutate normal-mode panel settings. Keeping this in lockstep with
+ * the data-source gate is what prevents the store key/defaults and the AppBar
+ * share-only UI from diverging.
  */
 export function isShareManifestModeFromUrl(url: URL, now: Date = new Date()): boolean {
-  return parseShareManifestFromUrl(url, now).status === "valid";
+  if (parseShareManifestFromUrl(url, now).status === "valid") {
+    return true;
+  }
+  if (url.searchParams.get("ds") === SHARE_MANIFEST_DATA_SOURCE_ID) {
+    return parseShareManifestParams(getDsParams(url), now).status === "valid";
+  }
+  return false;
 }
 
 /**


### PR DESCRIPTION
## What

When honeybee opens in **share-manifest mode** (`ds=coscene-share-manifest` or a valid share-manifest hash), the workspace now defaults to:

- **left + right sidebars hidden**
- **timeline panel at minimum height**

…persisted under a **separate** localStorage key (`fox.workspace.shareManifest`). The share viewer's own panel adjustments persist independently and **never mutate** the normal-mode `fox.workspace` store.

A share-only **"Reset layout"** button in the AppBar re-applies those defaults via a new `resetPanels()` workspace action.

## Why

Share links should open with a clean, focused viewer layout without disturbing a user's normal workspace preferences — and the viewer should still be able to tweak and have their tweaks remembered, with a one-click way back to the share default.

## How

- Extract timeline height constants into `PlaybackControls/constants.ts` (single source of truth for min/max).
- `SHARE_MANIFEST_PANEL_DEFAULTS` drives **both** the store's initial state and `resetPanels()` — first-load and reset can't diverge.
- `WorkspaceContextProvider` selects the persist key + share defaults at mount from the URL.
- Detection (`isShareManifestModeFromUrl`) keys on a **valid** manifest only, matching `DeepLinksSyncAdapter`, so expired/invalid links fall through to the normal workspace (no confusing hidden-sidebar state).
- Share-only Reset button gated on `dataSource.id === coscene-share-manifest`; i18n (en/zh/ja).

## Design notes

- Two detection surfaces stay in lockstep: the URL-based store gate and the async `dataSource.id` UI gate both derive from the same "valid share manifest" predicate. Comments at both sites flag the coupling.
- **Known limitation (documented in code):** detection reads `window.location` at mount. On the Electron desktop app an OS-delivered `coscene://` share deeplink may not be reflected in `window.location`; share manifests are a web-viewer feature. Revisit if desktop share support is added.

## Scope

- No change to the normal-mode `fox.workspace` store, its defaults, or its persistence.
- No panel-mosaic layout reset (owned by `ShareManifestLayoutSyncAdapter`).

## Tests

Added/updated (jest 32/32 across affected suites; `tsc -b` + eslint clean):
- `shareManifest` detection incl. valid/expired/malformed and `ds` param.
- `SHARE_MANIFEST_PANEL_DEFAULTS` shape.
- `resetPanels()` — resets a dirtied store; leaves sidebar tab selection untouched.
- `WorkspaceContextProvider` persist branch — first-visit defaults, return-visit persisted-wins, and **both-direction key isolation** (normal ↔ share).
- AppBar reset-button visibility (present in share mode, absent in normal).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785650445&installation_id=141984720&pr_number=1385&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1385&signature=8a59651bcf44621803e5e6bc0713bb54dea6622d8160d5561fb0a775c4d22445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->