### PR TITLE
[codex] Fix layout sync persistence

### DIFF
--- a/packages/studio-base/src/components/AppBar/CoSceneLayoutButton/index.test.tsx
+++ b/packages/studio-base/src/components/AppBar/CoSceneLayoutButton/index.test.tsx
@@ -1,0 +1,188 @@
+/** @jest-environment jsdom */
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import MultiProvider from "@foxglove/studio-base/components/MultiProvider";
+import StudioToastProvider from "@foxglove/studio-base/components/StudioToastProvider";
+import CoSceneLayoutManagerContext from "@foxglove/studio-base/context/CoSceneLayoutManagerContext";
+import {
+  LayoutID,
+  useCurrentLayoutActions,
+} from "@foxglove/studio-base/context/CurrentLayoutContext";
+import { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
+import MockCurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider/MockCurrentLayoutProvider";
+import DialogsProvider from "@foxglove/studio-base/providers/DialogsProvider";
+import MockCoSceneCurrentUserProvider from "@foxglove/studio-base/providers/MockCoSceneCurrentUserProvider";
+import WorkspaceContextProvider from "@foxglove/studio-base/providers/WorkspaceContextProvider";
+import {
+  ISO8601Timestamp,
+  Layout,
+  LayoutPermission,
+} from "@foxglove/studio-base/services/CoSceneILayoutStorage";
+import MockCoSceneLayoutManager from "@foxglove/studio-base/services/LayoutManager/MockCoSceneLayoutManager";
+import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
+
+import { CoSceneLayoutButton } from ".";
+
+function layoutData(value: string): LayoutData {
+  return {
+    layout: "Panel!1",
+    configById: { "Panel!1": { value } },
+    globalVariables: {},
+    userNodes: {},
+  };
+}
+
+function layoutId(value: string): LayoutID {
+  return value as LayoutID;
+}
+
+function ts(value: string): ISO8601Timestamp {
+  return value as ISO8601Timestamp;
+}
+
+function makeLayout({
+  id,
+  name,
+  data,
+  permission = "PERSONAL_WRITE",
+}: {
+  id: LayoutID;
+  name: string;
+  data: LayoutData;
+  permission?: LayoutPermission;
+}): Layout {
+  return {
+    id,
+    parent: "users/u",
+    folder: "",
+    name,
+    permission,
+    baseline: {
+      data,
+      savedAt: ts("2024-01-01T00:00:00.000Z"),
+      modifier: undefined,
+      modifierNickname: undefined,
+    },
+    working: {
+      data,
+      savedAt: ts("2024-01-01T00:00:01.000Z"),
+    },
+    syncInfo: {
+      status: "tracked",
+      lastRemoteSavedAt: ts("2024-01-01T00:00:00.000Z"),
+      lastRemoteUpdatedAt: ts("2024-01-01T00:00:00.000Z"),
+    },
+  };
+}
+
+function CaptureCurrentLayoutActions({
+  onCapture,
+}: {
+  onCapture: (actions: ReturnType<typeof useCurrentLayoutActions>) => void;
+}): ReactNull {
+  onCapture(useCurrentLayoutActions());
+  return ReactNull;
+}
+
+function Wrapper({
+  children,
+  layoutManager,
+  captureActions,
+}: React.PropsWithChildren<{
+  layoutManager: MockCoSceneLayoutManager;
+  captureActions: (actions: ReturnType<typeof useCurrentLayoutActions>) => void;
+}>): React.JSX.Element {
+  const providers = [
+    <DialogsProvider key="dialogs" />,
+    <MockCoSceneCurrentUserProvider key="current-user" />,
+    <CoSceneLayoutManagerContext.Provider key="layout-manager" value={layoutManager} />,
+    <WorkspaceContextProvider key="workspace" />,
+    <StudioToastProvider key="toast" />,
+    <MockCurrentLayoutProvider key="current-layout" initialState={layoutData("current")} />,
+    <ThemeProvider key="theme" isDark />,
+  ];
+  return (
+    <MultiProvider providers={providers}>
+      <CaptureCurrentLayoutActions onCapture={captureActions} />
+      {children}
+    </MultiProvider>
+  );
+}
+
+describe("<CoSceneLayoutButton />", () => {
+  it("does not restart a queued multi-save when the current layout changes during the save", async () => {
+    const currentId = layoutId("mock-layout");
+    const secondId = layoutId("users/u/layouts/2");
+    const layouts = [
+      makeLayout({ id: currentId, name: "Current", data: layoutData("current") }),
+      makeLayout({ id: secondId, name: "Second", data: layoutData("second") }),
+    ];
+    const layoutManager = new MockCoSceneLayoutManager();
+    layoutManager.isOnline = true;
+    layoutManager.getLayouts.mockResolvedValue(layouts);
+    const overwriteCalls: { id: LayoutID; data?: LayoutData | undefined }[] = [];
+    let resolveOverwrite: ((layout: Layout) => void) | undefined;
+    const overwriteResult = new Promise<Layout>((resolve) => {
+      resolveOverwrite = resolve;
+    });
+    layoutManager.overwriteLayout.mockImplementation(
+      async (params: { id: LayoutID; data?: LayoutData | undefined }) => {
+        overwriteCalls.push(params);
+        return await overwriteResult;
+      },
+    );
+    let currentLayoutActions: ReturnType<typeof useCurrentLayoutActions> | undefined;
+
+    render(
+      <Wrapper
+        layoutManager={layoutManager}
+        captureActions={(actions) => {
+          currentLayoutActions = actions;
+        }}
+      >
+        <CoSceneLayoutButton />
+      </Wrapper>,
+    );
+
+    fireEvent.click(await screen.findByText("Current"));
+    fireEvent.click(await screen.findByText("Second"), { shiftKey: true });
+    const secondActionsButton = screen.getAllByTestId("layout-actions")[1];
+    if (!secondActionsButton) {
+      throw new Error("Second layout action button was not rendered");
+    }
+    fireEvent.click(secondActionsButton);
+    fireEvent.click(await screen.findByText("Save"));
+
+    await waitFor(() => {
+      expect(layoutManager.overwriteLayout).toHaveBeenCalledTimes(1);
+    });
+    expect(overwriteCalls.map((call) => call.id)).toEqual([currentId]);
+
+    if (!currentLayoutActions) {
+      throw new Error("Current layout actions were not captured");
+    }
+    const actions = currentLayoutActions;
+    await act(async () => {
+      actions.setCurrentLayout({ id: currentId, data: layoutData("changed") });
+      await Promise.resolve();
+    });
+
+    expect(overwriteCalls.map((call) => call.id)).toEqual([currentId]);
+
+    const currentLayout = layouts[0];
+    if (!currentLayout) {
+      throw new Error("Current layout was not created");
+    }
+    resolveOverwrite?.(currentLayout);
+    await waitFor(() => {
+      expect(overwriteCalls.map((call) => call.id)).toEqual([currentId, secondId]);
+    });
+  });
+});

--- a/packages/studio-base/src/components/AppBar/CoSceneLayoutButton/index.tsx
+++ b/packages/studio-base/src/components/AppBar/CoSceneLayoutButton/index.tsx
@@ -170,6 +170,11 @@ export function CoSceneLayoutButton(): React.JSX.Element {
     }),
     [selectedLayout],
   );
+  const getOverwriteLayoutParamsRef = useRef(getOverwriteLayoutParams);
+
+  useEffect(() => {
+    getOverwriteLayoutParamsRef.current = getOverwriteLayoutParams;
+  }, [getOverwriteLayoutParams]);
 
   const pendingMultiAction = state.multiAction?.ids != undefined;
 
@@ -234,12 +239,15 @@ export function CoSceneLayoutButton(): React.JSX.Element {
               dispatch({ type: "shift-multi-action" });
               break;
             case "save":
-              await layoutManager.overwriteLayout(getOverwriteLayoutParams(id as LayoutID));
+              await layoutManager.overwriteLayout(
+                getOverwriteLayoutParamsRef.current(id as LayoutID),
+              );
               dispatch({ type: "shift-multi-action" });
               break;
           }
         } catch (err) {
-          enqueueSnackbar(`Error processing layouts: ${err.message}`, { variant: "error" });
+          const message = err instanceof Error ? err.message : "Unknown error";
+          enqueueSnackbar(`Error processing layouts: ${message}`, { variant: "error" });
           dispatch({ type: "clear-multi-action" });
         }
       }
@@ -248,7 +256,7 @@ export function CoSceneLayoutButton(): React.JSX.Element {
     processAction().catch((err: unknown) => {
       log.error(err);
     });
-  }, [dispatch, enqueueSnackbar, getOverwriteLayoutParams, layoutManager, state.multiAction]);
+  }, [dispatch, enqueueSnackbar, layoutManager, state.multiAction]);
 
   /**
    * Don't allow the user to switch away from a personal layout if they have unsaved changes. This

--- a/packages/studio-base/src/components/AppBar/CoSceneLayoutButton/index.tsx
+++ b/packages/studio-base/src/components/AppBar/CoSceneLayoutButton/index.tsx
@@ -59,6 +59,7 @@ import LayoutSection from "./LayoutSection";
 
 const log = Logger.getLogger(__filename);
 const selectedLayoutIdSelector = (state: LayoutState) => state.selectedLayout?.id;
+const selectedLayoutSelector = (state: LayoutState) => state.selectedLayout;
 // const selectExternalInitConfig = (state: CoreDataStore) => state.externalInitConfig;
 const selectUserRole = (store: UserStore) => store.role;
 
@@ -105,6 +106,7 @@ export function CoSceneLayoutButton(): React.JSX.Element {
   const { layoutDrawer } = useWorkspaceActions();
 
   const currentLayoutId = useCurrentLayoutSelector(selectedLayoutIdSelector);
+  const selectedLayout = useCurrentLayoutSelector(selectedLayoutSelector);
   const { enqueueSnackbar } = useSnackbar();
   const { unsavedChangesPrompt, openUnsavedChangesPrompt } = useUnsavedChangesPrompt();
   const { setSelectedLayoutId } = useCurrentLayoutActions();
@@ -160,6 +162,14 @@ export function CoSceneLayoutButton(): React.JSX.Element {
     error: layoutManager.error,
     online: layoutManager.isOnline,
   });
+
+  const getOverwriteLayoutParams = useCallback(
+    (id: LayoutID) => ({
+      id,
+      data: selectedLayout?.id === id ? selectedLayout.data : undefined,
+    }),
+    [selectedLayout],
+  );
 
   const pendingMultiAction = state.multiAction?.ids != undefined;
 
@@ -224,7 +234,7 @@ export function CoSceneLayoutButton(): React.JSX.Element {
               dispatch({ type: "shift-multi-action" });
               break;
             case "save":
-              await layoutManager.overwriteLayout({ id: id as LayoutID });
+              await layoutManager.overwriteLayout(getOverwriteLayoutParams(id as LayoutID));
               dispatch({ type: "shift-multi-action" });
               break;
           }
@@ -238,7 +248,7 @@ export function CoSceneLayoutButton(): React.JSX.Element {
     processAction().catch((err: unknown) => {
       log.error(err);
     });
-  }, [dispatch, enqueueSnackbar, layoutManager, state.multiAction]);
+  }, [dispatch, enqueueSnackbar, getOverwriteLayoutParams, layoutManager, state.multiAction]);
 
   /**
    * Don't allow the user to switch away from a personal layout if they have unsaved changes. This
@@ -268,7 +278,7 @@ export function CoSceneLayoutButton(): React.JSX.Element {
           });
           return true;
         case "overwrite":
-          await layoutManager.overwriteLayout({ id: currentLayout.id });
+          await layoutManager.overwriteLayout(getOverwriteLayoutParams(currentLayout.id));
           void analytics.logEvent(AppEvent.LAYOUT_OVERWRITE, {
             permission: currentLayout.permission,
             context: "UnsavedChangesPrompt",
@@ -289,7 +299,13 @@ export function CoSceneLayoutButton(): React.JSX.Element {
       }
     }
     return true;
-  }, [analytics, currentLayoutId, layoutManager, openUnsavedChangesPrompt]);
+  }, [
+    analytics,
+    currentLayoutId,
+    getOverwriteLayoutParams,
+    layoutManager,
+    openUnsavedChangesPrompt,
+  ]);
 
   const onSelectLayout = useCallbackWithToast(
     async (
@@ -454,10 +470,18 @@ export function CoSceneLayoutButton(): React.JSX.Element {
           return;
         }
       }
-      await layoutManager.overwriteLayout({ id: item.id });
+      await layoutManager.overwriteLayout(getOverwriteLayoutParams(item.id));
       void analytics.logEvent(AppEvent.LAYOUT_OVERWRITE, { permission: item.permission });
     },
-    [analytics, confirm, dispatch, layoutManager, state.selectedIds.length, t],
+    [
+      analytics,
+      confirm,
+      dispatch,
+      getOverwriteLayoutParams,
+      layoutManager,
+      state.selectedIds.length,
+      t,
+    ],
   );
 
   const onRevertLayout = useCallbackWithToast(

--- a/packages/studio-base/src/components/CoSceneCurrentLayoutSyncAdapter.tsx
+++ b/packages/studio-base/src/components/CoSceneCurrentLayoutSyncAdapter.tsx
@@ -6,7 +6,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { enqueueSnackbar } from "notistack";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useAsync, useMountedState } from "react-use";
 import { useDebounce } from "use-debounce";
 
@@ -39,6 +39,10 @@ export function CurrentLayoutSyncAdapter(): ReactNull {
   const layoutManager = useLayoutManager();
 
   const [unsavedLayouts, setUnsavedLayouts] = useState(EMPTY_UNSAVED_LAYOUTS);
+  const unsavedLayoutsRef = useRef(unsavedLayouts);
+  useEffect(() => {
+    unsavedLayoutsRef.current = unsavedLayouts;
+  }, [unsavedLayouts]);
 
   const analytics = useAnalytics();
 
@@ -50,6 +54,17 @@ export function CurrentLayoutSyncAdapter(): ReactNull {
         ...old,
         [selectedLayout.id]: selectedLayout,
       }));
+    } else if (selectedLayout?.id != undefined) {
+      setUnsavedLayouts((old) => {
+        if (old[selectedLayout.id] == undefined) {
+          return old;
+        }
+        const newUnsavedLayouts = { ...old };
+        delete newUnsavedLayouts[selectedLayout.id];
+        return Object.keys(newUnsavedLayouts).length === 0
+          ? EMPTY_UNSAVED_LAYOUTS
+          : newUnsavedLayouts;
+      });
     }
   }, [selectedLayout]);
 
@@ -70,12 +85,18 @@ export function CurrentLayoutSyncAdapter(): ReactNull {
   // uses useEffect so it happens after DOM updates are complete.
   useAsync(async () => {
     const unsavedLayoutsSnapshot = { ...debouncedUnsavedLayouts };
-    setUnsavedLayouts(EMPTY_UNSAVED_LAYOUTS);
+    const successIds: LayoutID[] = [];
+    const failedLayouts: UpdatedLayout[] = [];
 
     for (const params of Object.values(unsavedLayoutsSnapshot)) {
       try {
-        await layoutManager.updateLayout(params);
+        if (unsavedLayoutsRef.current[params.id] !== params) {
+          continue;
+        }
+        await layoutManager.updateLayout({ id: params.id, data: params.data });
+        successIds.push(params.id);
       } catch (error) {
+        failedLayouts.push(params);
         log.error("changes could not be saved", error);
 
         if (isMounted()) {
@@ -87,7 +108,28 @@ export function CurrentLayoutSyncAdapter(): ReactNull {
       }
     }
 
-    void analytics.logEvent(AppEvent.LAYOUT_UPDATE);
+    if (successIds.length > 0 || failedLayouts.length > 0) {
+      setUnsavedLayouts((old) => {
+        const newUnsavedLayouts = { ...old };
+        for (const id of successIds) {
+          if (newUnsavedLayouts[id] === unsavedLayoutsSnapshot[id]) {
+            delete newUnsavedLayouts[id];
+          }
+        }
+        for (const layout of failedLayouts) {
+          if (newUnsavedLayouts[layout.id] === layout) {
+            newUnsavedLayouts[layout.id] = layout;
+          }
+        }
+        return Object.keys(newUnsavedLayouts).length === 0
+          ? EMPTY_UNSAVED_LAYOUTS
+          : newUnsavedLayouts;
+      });
+    }
+
+    if (successIds.length > 0) {
+      void analytics.logEvent(AppEvent.LAYOUT_UPDATE);
+    }
   }, [analytics, debouncedUnsavedLayouts, isMounted, layoutManager]);
 
   return ReactNull;

--- a/packages/studio-base/src/components/CoSceneCurrentLayoutSyncAdapter.tsx
+++ b/packages/studio-base/src/components/CoSceneCurrentLayoutSyncAdapter.tsx
@@ -5,6 +5,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import * as _ from "lodash-es";
 import { enqueueSnackbar } from "notistack";
 import { useEffect, useRef, useState } from "react";
 import { useAsync, useMountedState } from "react-use";
@@ -56,7 +57,12 @@ export function CurrentLayoutSyncAdapter(): ReactNull {
       }));
     } else if (selectedLayout?.id != undefined) {
       setUnsavedLayouts((old) => {
-        if (old[selectedLayout.id] == undefined) {
+        const pendingLayout = old[selectedLayout.id];
+        if (
+          pendingLayout == undefined ||
+          selectedLayout.data == undefined ||
+          !_.isEqual(selectedLayout.data, pendingLayout.data)
+        ) {
           return old;
         }
         const newUnsavedLayouts = { ...old };
@@ -100,7 +106,8 @@ export function CurrentLayoutSyncAdapter(): ReactNull {
         log.error("changes could not be saved", error);
 
         if (isMounted()) {
-          enqueueSnackbar(`Your changes could not be saved. ${error.toString()}`, {
+          const message = error instanceof Error ? error.toString() : String(error);
+          enqueueSnackbar(`Your changes could not be saved. ${message}`, {
             variant: "error",
             key: "CurrentLayoutProvider.throttledSave",
           });

--- a/packages/studio-base/src/components/CoSceneLayout/CoSceneLayoutButton.test.tsx
+++ b/packages/studio-base/src/components/CoSceneLayout/CoSceneLayoutButton.test.tsx
@@ -1,0 +1,209 @@
+/** @jest-environment jsdom */
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { act, render, waitFor } from "@testing-library/react";
+
+import MultiProvider from "@foxglove/studio-base/components/MultiProvider";
+import CoSceneLayoutManagerContext from "@foxglove/studio-base/context/CoSceneLayoutManagerContext";
+import {
+  LayoutID,
+  useCurrentLayoutActions,
+} from "@foxglove/studio-base/context/CurrentLayoutContext";
+import { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
+import MockCurrentLayoutProvider from "@foxglove/studio-base/providers/CurrentLayoutProvider/MockCurrentLayoutProvider";
+import DialogsProvider from "@foxglove/studio-base/providers/DialogsProvider";
+import WorkspaceContextProvider from "@foxglove/studio-base/providers/WorkspaceContextProvider";
+import {
+  ISO8601Timestamp,
+  Layout,
+  LayoutPermission,
+} from "@foxglove/studio-base/services/CoSceneILayoutStorage";
+import MockCoSceneLayoutManager from "@foxglove/studio-base/services/LayoutManager/MockCoSceneLayoutManager";
+import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
+
+import { CoSceneLayoutButton } from "./CoSceneLayoutButton";
+
+const currentId = "mock-layout" as LayoutID;
+const secondId = "users/u/layouts/2" as LayoutID;
+const mockDispatch = jest.fn();
+const mockState = {
+  busy: false,
+  error: undefined,
+  online: true,
+  lastSelectedId: currentId,
+  selectedIds: [currentId, secondId],
+  multiAction: { action: "save" as const, ids: [currentId, secondId] },
+};
+
+jest.mock("@foxglove/studio-base/components/CoSceneLayoutBrowser/coSceneReducer", () => ({
+  useLayoutBrowserReducer: () => [mockState, mockDispatch],
+}));
+
+jest.mock("@foxglove/studio-base/context/CoSceneConsoleApiContext", () => ({
+  useConsoleApi: () => ({
+    createProjectLayout: {
+      permission: () => true,
+    },
+  }),
+}));
+
+jest.mock("./CoSceneLayoutDrawer", () => ({
+  CoSceneLayoutDrawer: () => undefined,
+}));
+
+jest.mock("./CurrentLayoutButton", () => ({
+  CurrentLayoutButton: () => undefined,
+}));
+
+jest.mock("./hooks/useCurrentLayout", () => ({
+  useCurrentLayout: () => ({
+    loading: false,
+    value: {
+      allLayouts: [],
+      personalFolders: [],
+      projectFolders: [],
+    },
+  }),
+}));
+
+function layoutData(value: string): LayoutData {
+  return {
+    layout: "Panel!1",
+    configById: { "Panel!1": { value } },
+    globalVariables: {},
+    userNodes: {},
+  };
+}
+
+function ts(value: string): ISO8601Timestamp {
+  return value as ISO8601Timestamp;
+}
+
+function makeLayout({
+  id,
+  name,
+  data,
+  permission = "PERSONAL_WRITE",
+}: {
+  id: LayoutID;
+  name: string;
+  data: LayoutData;
+  permission?: LayoutPermission;
+}): Layout {
+  return {
+    id,
+    parent: "users/u",
+    folder: "",
+    name,
+    permission,
+    baseline: {
+      data,
+      savedAt: ts("2024-01-01T00:00:00.000Z"),
+      modifier: undefined,
+      modifierNickname: undefined,
+    },
+    working: {
+      data,
+      savedAt: ts("2024-01-01T00:00:01.000Z"),
+    },
+    syncInfo: {
+      status: "tracked",
+      lastRemoteSavedAt: ts("2024-01-01T00:00:00.000Z"),
+      lastRemoteUpdatedAt: ts("2024-01-01T00:00:00.000Z"),
+    },
+  };
+}
+
+function CaptureCurrentLayoutActions({
+  onCapture,
+}: {
+  onCapture: (actions: ReturnType<typeof useCurrentLayoutActions>) => void;
+}): ReactNull {
+  onCapture(useCurrentLayoutActions());
+  return ReactNull;
+}
+
+function Wrapper({
+  children,
+  layoutManager,
+  captureActions,
+}: React.PropsWithChildren<{
+  layoutManager: MockCoSceneLayoutManager;
+  captureActions: (actions: ReturnType<typeof useCurrentLayoutActions>) => void;
+}>): React.JSX.Element {
+  const providers = [
+    <DialogsProvider key="dialogs" />,
+    <CoSceneLayoutManagerContext.Provider key="layout-manager" value={layoutManager} />,
+    <WorkspaceContextProvider key="workspace" />,
+    <MockCurrentLayoutProvider key="current-layout" initialState={layoutData("current")} />,
+    <ThemeProvider key="theme" isDark />,
+  ];
+  return (
+    <MultiProvider providers={providers}>
+      <CaptureCurrentLayoutActions onCapture={captureActions} />
+      {children}
+    </MultiProvider>
+  );
+}
+
+describe("<CoSceneLayoutButton />", () => {
+  beforeEach(() => {
+    mockDispatch.mockClear();
+  });
+
+  it("does not restart a queued multi-save when the current layout changes during the save", async () => {
+    const currentLayout = makeLayout({
+      id: currentId,
+      name: "Current",
+      data: layoutData("current"),
+    });
+    const layoutManager = new MockCoSceneLayoutManager();
+    layoutManager.isOnline = true;
+    const overwriteCalls: { id: LayoutID; data?: LayoutData | undefined }[] = [];
+    let resolveOverwrite: ((layout: Layout) => void) | undefined;
+    const overwriteResult = new Promise<Layout>((resolve) => {
+      resolveOverwrite = resolve;
+    });
+    layoutManager.overwriteLayout.mockImplementation(
+      async (params: { id: LayoutID; data?: LayoutData | undefined }) => {
+        overwriteCalls.push(params);
+        return await overwriteResult;
+      },
+    );
+    let currentLayoutActions: ReturnType<typeof useCurrentLayoutActions> | undefined;
+
+    render(
+      <Wrapper
+        layoutManager={layoutManager}
+        captureActions={(actions) => {
+          currentLayoutActions = actions;
+        }}
+      >
+        <CoSceneLayoutButton />
+      </Wrapper>,
+    );
+
+    await waitFor(() => {
+      expect(layoutManager.overwriteLayout).toHaveBeenCalledTimes(1);
+    });
+    expect(overwriteCalls.map((call) => call.id)).toEqual([currentId]);
+
+    if (!currentLayoutActions) {
+      throw new Error("Current layout actions were not captured");
+    }
+    const actions = currentLayoutActions;
+    await act(async () => {
+      actions.setCurrentLayout({ id: currentId, data: layoutData("changed") });
+      await Promise.resolve();
+    });
+
+    expect(overwriteCalls.map((call) => call.id)).toEqual([currentId]);
+
+    resolveOverwrite?.(currentLayout);
+  });
+});

--- a/packages/studio-base/src/components/CoSceneLayout/CoSceneLayoutButton.tsx
+++ b/packages/studio-base/src/components/CoSceneLayout/CoSceneLayoutButton.tsx
@@ -6,7 +6,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { useSnackbar } from "notistack";
-import { useEffect, useLayoutEffect } from "react";
+import { useCallback, useEffect, useLayoutEffect } from "react";
 import { useTranslation } from "react-i18next";
 
 import Logger from "@foxglove/log";
@@ -40,6 +40,7 @@ const log = Logger.getLogger(__filename);
 
 const layoutDrawerOpen = (store: WorkspaceContextStore) => store.layoutDrawer.open;
 const selectedLayoutIdSelector = (state: LayoutState) => state.selectedLayout?.id;
+const selectedLayoutSelector = (state: LayoutState) => state.selectedLayout;
 
 export function CoSceneLayoutButton(): React.JSX.Element {
   const open = useWorkspaceStore(layoutDrawerOpen);
@@ -49,6 +50,7 @@ export function CoSceneLayoutButton(): React.JSX.Element {
 
   const layouts = useCurrentLayout();
   const currentLayoutId = useCurrentLayoutSelector(selectedLayoutIdSelector);
+  const selectedLayout = useCurrentLayoutSelector(selectedLayoutSelector);
 
   const { enqueueSnackbar } = useSnackbar();
   const analytics = useAnalytics();
@@ -64,6 +66,14 @@ export function CoSceneLayoutButton(): React.JSX.Element {
     error: layoutManager.error,
     online: layoutManager.isOnline,
   });
+
+  const getOverwriteLayoutParams = useCallback(
+    (id: LayoutID) => ({
+      id,
+      data: selectedLayout?.id === id ? selectedLayout.data : undefined,
+    }),
+    [selectedLayout],
+  );
 
   useLayoutEffect(() => {
     const busyListener = () => {
@@ -120,7 +130,7 @@ export function CoSceneLayoutButton(): React.JSX.Element {
               dispatch({ type: "shift-multi-action" });
               break;
             case "save":
-              await layoutManager.overwriteLayout({ id: id as LayoutID });
+              await layoutManager.overwriteLayout(getOverwriteLayoutParams(id as LayoutID));
               dispatch({ type: "shift-multi-action" });
               break;
           }
@@ -134,7 +144,7 @@ export function CoSceneLayoutButton(): React.JSX.Element {
     processAction().catch((err: unknown) => {
       log.error(err);
     });
-  }, [dispatch, enqueueSnackbar, layoutManager, state.multiAction]);
+  }, [dispatch, enqueueSnackbar, getOverwriteLayoutParams, layoutManager, state.multiAction]);
 
   const onSelectLayout = useCallbackWithToast(
     async (item: Layout) => {
@@ -228,10 +238,18 @@ export function CoSceneLayoutButton(): React.JSX.Element {
           return;
         }
       }
-      await layoutManager.overwriteLayout({ id: item.id });
+      await layoutManager.overwriteLayout(getOverwriteLayoutParams(item.id));
       void analytics.logEvent(AppEvent.LAYOUT_OVERWRITE, { permission: item.permission });
     },
-    [analytics, confirm, dispatch, layoutManager, state.selectedIds.length, t],
+    [
+      analytics,
+      confirm,
+      dispatch,
+      getOverwriteLayoutParams,
+      layoutManager,
+      state.selectedIds.length,
+      t,
+    ],
   );
 
   const onRevertLayout = useCallbackWithToast(

--- a/packages/studio-base/src/components/CoSceneLayout/CoSceneLayoutButton.tsx
+++ b/packages/studio-base/src/components/CoSceneLayout/CoSceneLayoutButton.tsx
@@ -6,7 +6,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { useSnackbar } from "notistack";
-import { useCallback, useEffect, useLayoutEffect } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 
 import Logger from "@foxglove/log";
@@ -74,6 +74,11 @@ export function CoSceneLayoutButton(): React.JSX.Element {
     }),
     [selectedLayout],
   );
+  const getOverwriteLayoutParamsRef = useRef(getOverwriteLayoutParams);
+
+  useEffect(() => {
+    getOverwriteLayoutParamsRef.current = getOverwriteLayoutParams;
+  }, [getOverwriteLayoutParams]);
 
   useLayoutEffect(() => {
     const busyListener = () => {
@@ -130,12 +135,15 @@ export function CoSceneLayoutButton(): React.JSX.Element {
               dispatch({ type: "shift-multi-action" });
               break;
             case "save":
-              await layoutManager.overwriteLayout(getOverwriteLayoutParams(id as LayoutID));
+              await layoutManager.overwriteLayout(
+                getOverwriteLayoutParamsRef.current(id as LayoutID),
+              );
               dispatch({ type: "shift-multi-action" });
               break;
           }
         } catch (err) {
-          enqueueSnackbar(`Error processing layouts: ${err.message}`, { variant: "error" });
+          const message = err instanceof Error ? err.message : "Unknown error";
+          enqueueSnackbar(`Error processing layouts: ${message}`, { variant: "error" });
           dispatch({ type: "clear-multi-action" });
         }
       }
@@ -144,7 +152,7 @@ export function CoSceneLayoutButton(): React.JSX.Element {
     processAction().catch((err: unknown) => {
       log.error(err);
     });
-  }, [dispatch, enqueueSnackbar, getOverwriteLayoutParams, layoutManager, state.multiAction]);
+  }, [dispatch, enqueueSnackbar, layoutManager, state.multiAction]);
 
   const onSelectLayout = useCallbackWithToast(
     async (item: Layout) => {

--- a/packages/studio-base/src/components/CoreDataSyncAdapter.tsx
+++ b/packages/studio-base/src/components/CoreDataSyncAdapter.tsx
@@ -127,9 +127,6 @@ export function useSetExternalInitConfig(): (
 
     setExternalInitConfig(externalInitConfig);
 
-    // 设置 isReadyForSyncLayout 标志，表示可以开始同步 layout
-    setIsReadyForSyncLayout({ isReadyForSyncLayout: true });
-
     await ensureProjectAndBaseUrl({
       consoleApi,
       project,
@@ -137,6 +134,9 @@ export function useSetExternalInitConfig(): (
       setProject,
       setBaseUrl,
     });
+
+    // 设置 isReadyForSyncLayout 标志，表示项目/用户上下文已可用于 layout manager
+    setIsReadyForSyncLayout({ isReadyForSyncLayout: true });
 
     const taskName =
       externalInitConfig.warehouseId && externalInitConfig.projectId && externalInitConfig.taskId

--- a/packages/studio-base/src/hooks/useSyncLayoutFromUrl.test.ts
+++ b/packages/studio-base/src/hooks/useSyncLayoutFromUrl.test.ts
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { LayoutID } from "@foxglove/studio-base/context/CurrentLayoutContext";
+import { Layout } from "@foxglove/studio-base/services/CoSceneILayoutStorage";
+import { getFallbackLayoutIdForMissingUrlLayout } from "@foxglove/studio-base/hooks/useSyncLayoutFromUrl";
+
+function layout(id: string, permission: Layout["permission"] = "PERSONAL_WRITE"): Layout {
+  return {
+    id: id as LayoutID,
+    parent: permission === "PERSONAL_WRITE" ? "users/u" : "warehouses/w/projects/p",
+    folder: "",
+    name: id,
+    permission,
+    baseline: {
+      data: { layout: "Panel!1", configById: {}, globalVariables: {}, userNodes: {} },
+      savedAt: undefined,
+      modifier: undefined,
+      modifierNickname: undefined,
+    },
+    working: undefined,
+    syncInfo: undefined,
+  };
+}
+
+describe("getFallbackLayoutIdForMissingUrlLayout", () => {
+  it("selects the first personal layout before history", async () => {
+    const personal1 = layout("users/u/layouts/personal-1");
+    const personal2 = layout("users/u/layouts/personal-2");
+    const getHistory = jest.fn().mockResolvedValue(layout("users/u/layouts/history"));
+
+    const result = await getFallbackLayoutIdForMissingUrlLayout({
+      getLayouts: jest
+        .fn()
+        .mockResolvedValue([
+          layout("warehouses/w/projects/p/layouts/project", "PROJECT_WRITE"),
+          personal1,
+          personal2,
+        ]),
+      getHistory,
+      getLayout: jest.fn(),
+    });
+
+    expect(result).toEqual(personal1.id);
+    expect(getHistory).not.toHaveBeenCalled();
+  });
+
+  it("falls back to history when no personal layout exists", async () => {
+    const historyLayout = layout("users/u/layouts/history");
+
+    await expect(
+      getFallbackLayoutIdForMissingUrlLayout({
+        getLayouts: jest
+          .fn()
+          .mockResolvedValue([layout("warehouses/w/projects/p/layouts/project", "PROJECT_WRITE")]),
+        getHistory: jest.fn().mockResolvedValue(historyLayout),
+        getLayout: jest.fn().mockResolvedValue(historyLayout),
+      }),
+    ).resolves.toEqual(historyLayout.id);
+  });
+
+  it("returns undefined when the history layout can no longer be loaded", async () => {
+    await expect(
+      getFallbackLayoutIdForMissingUrlLayout({
+        getLayouts: jest.fn().mockResolvedValue([]),
+        getHistory: jest.fn().mockResolvedValue(layout("users/u/layouts/deleted-history")),
+        getLayout: jest.fn().mockResolvedValue(undefined),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("returns undefined when neither personal nor history layout exists", async () => {
+    await expect(
+      getFallbackLayoutIdForMissingUrlLayout({
+        getLayouts: jest.fn().mockResolvedValue([]),
+        getHistory: jest.fn().mockResolvedValue(undefined),
+        getLayout: jest.fn(),
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/studio-base/src/hooks/useSyncLayoutFromUrl.test.ts
+++ b/packages/studio-base/src/hooks/useSyncLayoutFromUrl.test.ts
@@ -1,3 +1,5 @@
+/** @jest-environment jsdom */
+
 // SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
 // SPDX-License-Identifier: MPL-2.0
 
@@ -5,9 +7,40 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { LayoutID } from "@foxglove/studio-base/context/CurrentLayoutContext";
-import { Layout } from "@foxglove/studio-base/services/CoSceneILayoutStorage";
-import { getFallbackLayoutIdForMissingUrlLayout } from "@foxglove/studio-base/hooks/useSyncLayoutFromUrl";
+import { renderHook, waitFor } from "@testing-library/react";
+
+import { useLayoutManager } from "@foxglove/studio-base/context/CoSceneLayoutManagerContext";
+import { useCoreData } from "@foxglove/studio-base/context/CoreDataContext";
+import type { CoreDataStore } from "@foxglove/studio-base/context/CoreDataContext";
+import {
+  useCurrentLayoutActions,
+  useCurrentLayoutSelector,
+} from "@foxglove/studio-base/context/CurrentLayoutContext";
+import type {
+  CurrentLayoutActions,
+  LayoutID,
+  LayoutState,
+} from "@foxglove/studio-base/context/CurrentLayoutContext";
+import { useWorkspaceActions } from "@foxglove/studio-base/context/Workspace/useWorkspaceActions";
+import type { WorkspaceActions } from "@foxglove/studio-base/context/Workspace/useWorkspaceActions";
+import { useSyncLayoutFromUrl } from "@foxglove/studio-base/hooks/useSyncLayoutFromUrl";
+import type { ILayoutManager } from "@foxglove/studio-base/services/CoSceneILayoutManager";
+import type { Layout } from "@foxglove/studio-base/services/CoSceneILayoutStorage";
+import type { AppURLState } from "@foxglove/studio-base/util/appURLState";
+
+jest.mock("@foxglove/studio-base/context/CoSceneLayoutManagerContext", () => ({
+  useLayoutManager: jest.fn(),
+}));
+jest.mock("@foxglove/studio-base/context/CoreDataContext", () => ({
+  useCoreData: jest.fn(),
+}));
+jest.mock("@foxglove/studio-base/context/CurrentLayoutContext", () => ({
+  useCurrentLayoutActions: jest.fn(),
+  useCurrentLayoutSelector: jest.fn(),
+}));
+jest.mock("@foxglove/studio-base/context/Workspace/useWorkspaceActions", () => ({
+  useWorkspaceActions: jest.fn(),
+}));
 
 function layout(id: string, permission: Layout["permission"] = "PERSONAL_WRITE"): Layout {
   return {
@@ -27,59 +60,145 @@ function layout(id: string, permission: Layout["permission"] = "PERSONAL_WRITE")
   };
 }
 
-describe("getFallbackLayoutIdForMissingUrlLayout", () => {
-  it("selects the first personal layout before history", async () => {
-    const personal1 = layout("users/u/layouts/personal-1");
-    const personal2 = layout("users/u/layouts/personal-2");
-    const getHistory = jest.fn().mockResolvedValue(layout("users/u/layouts/history"));
+function makeCurrentLayoutActions(setSelectedLayoutId: jest.Mock): CurrentLayoutActions {
+  return {
+    getCurrentLayoutState: jest.fn(() => ({ selectedLayout: undefined })),
+    setSelectedLayoutId,
+    setCurrentLayout: jest.fn(),
+    updateSharedPanelState: jest.fn(),
+    savePanelConfigs: jest.fn(),
+    updatePanelConfigs: jest.fn(),
+    createTabPanel: jest.fn(),
+    changePanelLayout: jest.fn(),
+    overwriteGlobalVariables: jest.fn(),
+    setGlobalVariables: jest.fn(),
+    setUserScripts: jest.fn(),
+    closePanel: jest.fn(),
+    splitPanel: jest.fn(),
+    swapPanel: jest.fn(),
+    moveTab: jest.fn(),
+    addPanel: jest.fn(),
+    dropPanel: jest.fn(),
+    startDrag: jest.fn(),
+    endDrag: jest.fn(),
+  };
+}
 
-    const result = await getFallbackLayoutIdForMissingUrlLayout({
-      getLayouts: jest
-        .fn()
-        .mockResolvedValue([
-          layout("warehouses/w/projects/p/layouts/project", "PROJECT_WRITE"),
-          personal1,
-          personal2,
-        ]),
-      getHistory,
+function makeWorkspaceActions(openLayoutDrawer: jest.Mock): WorkspaceActions {
+  return {
+    dialogActions: {
+      dataSource: {
+        close: jest.fn(),
+        open: jest.fn(),
+      },
+      openFile: {
+        open: jest.fn(async () => {}),
+      },
+      preferences: {
+        close: jest.fn(),
+        open: jest.fn(),
+      },
+    },
+    featureTourActions: {
+      startTour: jest.fn(),
+      finishTour: jest.fn(),
+    },
+    openPanelSettings: jest.fn(),
+    layoutDrawer: {
+      close: jest.fn(),
+      open: openLayoutDrawer,
+    },
+    playbackControlActions: {
+      setRepeat: jest.fn(),
+      setRollingEditEnabled: jest.fn(),
+      setSpeed: jest.fn(),
+      setTimelineHeight: jest.fn(),
+      setMomentSubtitleEnabled: jest.fn(),
+      setMomentSubtitleFontSize: jest.fn(),
+      setMomentSubtitlePosition: jest.fn(),
+    },
+    sidebarActions: {
+      left: {
+        selectItem: jest.fn(),
+        setOpen: jest.fn(),
+        setSize: jest.fn(),
+      },
+      right: {
+        selectItem: jest.fn(),
+        setOpen: jest.fn(),
+        setSize: jest.fn(),
+      },
+    },
+  };
+}
+
+describe("useSyncLayoutFromUrl", () => {
+  let selectedLayoutId: LayoutID | undefined;
+  let isReadyForSyncLayout: boolean;
+  let setSelectedLayoutId: jest.Mock;
+  let openLayoutDrawer: jest.Mock;
+  let layoutManager: Pick<ILayoutManager, "getLayout" | "getLayouts" | "getHistory">;
+
+  beforeEach(() => {
+    selectedLayoutId = undefined;
+    isReadyForSyncLayout = true;
+    setSelectedLayoutId = jest.fn();
+    openLayoutDrawer = jest.fn();
+    layoutManager = {
       getLayout: jest.fn(),
+      getLayouts: jest.fn(),
+      getHistory: jest.fn(),
+    };
+
+    jest.mocked(useLayoutManager).mockReturnValue(layoutManager as ILayoutManager);
+    jest
+      .mocked(useCoreData)
+      .mockImplementation((selector) => selector({ isReadyForSyncLayout } as CoreDataStore));
+    jest.mocked(useCurrentLayoutSelector).mockImplementation((selector) =>
+      selector({
+        selectedLayout: selectedLayoutId ? { id: selectedLayoutId } : undefined,
+      } as LayoutState),
+    );
+    jest
+      .mocked(useCurrentLayoutActions)
+      .mockReturnValue(makeCurrentLayoutActions(setSelectedLayoutId));
+    jest.mocked(useWorkspaceActions).mockReturnValue(makeWorkspaceActions(openLayoutDrawer));
+  });
+
+  it("restores history when the URL layout is missing", async () => {
+    const urlLayoutId = "users/u/layouts/missing-url" as LayoutID;
+    const historyLayout = layout("users/u/layouts/history");
+    jest.mocked(layoutManager.getLayout).mockResolvedValue(undefined);
+    jest.mocked(layoutManager.getHistory).mockResolvedValue(historyLayout);
+
+    renderHook(() => {
+      useSyncLayoutFromUrl({
+        layoutId: urlLayoutId,
+      } as AppURLState);
     });
 
-    expect(result).toEqual(personal1.id);
-    expect(getHistory).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(setSelectedLayoutId).toHaveBeenCalledWith(historyLayout.id);
+    });
+    expect(openLayoutDrawer).not.toHaveBeenCalled();
   });
 
-  it("falls back to history when no personal layout exists", async () => {
-    const historyLayout = layout("users/u/layouts/history");
+  it("opens the layout drawer when the URL layout and history are missing", async () => {
+    const urlLayoutId = "users/u/layouts/missing-url" as LayoutID;
+    jest.mocked(layoutManager.getLayout).mockResolvedValue(undefined);
+    jest.mocked(layoutManager.getHistory).mockResolvedValue(undefined);
+    jest.mocked(layoutManager.getLayouts).mockResolvedValue([layout("users/u/layouts/personal-1")]);
 
-    await expect(
-      getFallbackLayoutIdForMissingUrlLayout({
-        getLayouts: jest
-          .fn()
-          .mockResolvedValue([layout("warehouses/w/projects/p/layouts/project", "PROJECT_WRITE")]),
-        getHistory: jest.fn().mockResolvedValue(historyLayout),
-        getLayout: jest.fn().mockResolvedValue(historyLayout),
-      }),
-    ).resolves.toEqual(historyLayout.id);
-  });
+    renderHook(() => {
+      useSyncLayoutFromUrl({
+        layoutId: urlLayoutId,
+      } as AppURLState);
+    });
 
-  it("returns undefined when the history layout can no longer be loaded", async () => {
-    await expect(
-      getFallbackLayoutIdForMissingUrlLayout({
-        getLayouts: jest.fn().mockResolvedValue([]),
-        getHistory: jest.fn().mockResolvedValue(layout("users/u/layouts/deleted-history")),
-        getLayout: jest.fn().mockResolvedValue(undefined),
-      }),
-    ).resolves.toBeUndefined();
-  });
-
-  it("returns undefined when neither personal nor history layout exists", async () => {
-    await expect(
-      getFallbackLayoutIdForMissingUrlLayout({
-        getLayouts: jest.fn().mockResolvedValue([]),
-        getHistory: jest.fn().mockResolvedValue(undefined),
-        getLayout: jest.fn(),
-      }),
-    ).resolves.toBeUndefined();
+    await waitFor(() => {
+      expect(openLayoutDrawer).toHaveBeenCalledTimes(1);
+    });
+    expect(setSelectedLayoutId).not.toHaveBeenCalled();
+    expect(layoutManager.getLayouts).not.toHaveBeenCalled();
   });
 });

--- a/packages/studio-base/src/hooks/useSyncLayoutFromUrl.ts
+++ b/packages/studio-base/src/hooks/useSyncLayoutFromUrl.ts
@@ -12,34 +12,14 @@ import { useLayoutManager } from "@foxglove/studio-base/context/CoSceneLayoutMan
 import { CoreDataStore, useCoreData } from "@foxglove/studio-base/context/CoreDataContext";
 import {
   LayoutState,
-  LayoutID,
   useCurrentLayoutActions,
   useCurrentLayoutSelector,
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
-import { ILayoutManager } from "@foxglove/studio-base/services/CoSceneILayoutManager";
 import { useWorkspaceActions } from "@foxglove/studio-base/context/Workspace/useWorkspaceActions";
 import { AppURLState } from "@foxglove/studio-base/util/appURLState";
 
 const selectedLayoutIdSelector = (state: LayoutState) => state.selectedLayout?.id;
 const selectIsReadyForSyncLayout = (state: CoreDataStore) => state.isReadyForSyncLayout;
-
-export async function getFallbackLayoutIdForMissingUrlLayout(
-  layoutManager: Pick<ILayoutManager, "getLayouts" | "getHistory" | "getLayout">,
-): Promise<LayoutID | undefined> {
-  const personalLayout = (await layoutManager.getLayouts()).find(
-    (layout) => layout.permission === "PERSONAL_WRITE",
-  );
-  if (personalLayout) {
-    return personalLayout.id;
-  }
-
-  const historyLayout = await layoutManager.getHistory();
-  if (!historyLayout) {
-    return undefined;
-  }
-
-  return (await layoutManager.getLayout({ id: historyLayout.id }))?.id;
-}
 
 /**
  * Synchronizes the layout from URL state after isReadyForSyncLayout is true
@@ -67,7 +47,6 @@ export function useSyncLayoutFromUrl(targetUrlState: AppURLState | undefined): v
       return;
     }
 
-    // Don't restore the layout if there's one specified in the app state url.
     if (layoutId) {
       const urlLayout = await layoutManager.getLayout({ id: layoutId });
       if (urlLayout) {
@@ -76,19 +55,6 @@ export function useSyncLayoutFromUrl(targetUrlState: AppURLState | undefined): v
         isLayoutIdProcessed.current = true;
         return;
       }
-
-      const fallbackLayoutId = await getFallbackLayoutIdForMissingUrlLayout(layoutManager);
-      if (fallbackLayoutId) {
-        setSelectedLayoutId(fallbackLayoutId);
-        setUnappliedLayoutArgs({ layoutId: undefined });
-        isLayoutIdProcessed.current = true;
-        return;
-      }
-
-      layoutDrawer.open();
-      setUnappliedLayoutArgs({ layoutId: undefined });
-      isLayoutIdProcessed.current = true;
-      return;
     }
 
     // 尝试从历史记录中恢复 layout

--- a/packages/studio-base/src/hooks/useSyncLayoutFromUrl.ts
+++ b/packages/studio-base/src/hooks/useSyncLayoutFromUrl.ts
@@ -12,14 +12,34 @@ import { useLayoutManager } from "@foxglove/studio-base/context/CoSceneLayoutMan
 import { CoreDataStore, useCoreData } from "@foxglove/studio-base/context/CoreDataContext";
 import {
   LayoutState,
+  LayoutID,
   useCurrentLayoutActions,
   useCurrentLayoutSelector,
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
+import { ILayoutManager } from "@foxglove/studio-base/services/CoSceneILayoutManager";
 import { useWorkspaceActions } from "@foxglove/studio-base/context/Workspace/useWorkspaceActions";
 import { AppURLState } from "@foxglove/studio-base/util/appURLState";
 
 const selectedLayoutIdSelector = (state: LayoutState) => state.selectedLayout?.id;
 const selectIsReadyForSyncLayout = (state: CoreDataStore) => state.isReadyForSyncLayout;
+
+export async function getFallbackLayoutIdForMissingUrlLayout(
+  layoutManager: Pick<ILayoutManager, "getLayouts" | "getHistory" | "getLayout">,
+): Promise<LayoutID | undefined> {
+  const personalLayout = (await layoutManager.getLayouts()).find(
+    (layout) => layout.permission === "PERSONAL_WRITE",
+  );
+  if (personalLayout) {
+    return personalLayout.id;
+  }
+
+  const historyLayout = await layoutManager.getHistory();
+  if (!historyLayout) {
+    return undefined;
+  }
+
+  return (await layoutManager.getLayout({ id: historyLayout.id }))?.id;
+}
 
 /**
  * Synchronizes the layout from URL state after isReadyForSyncLayout is true
@@ -56,6 +76,19 @@ export function useSyncLayoutFromUrl(targetUrlState: AppURLState | undefined): v
         isLayoutIdProcessed.current = true;
         return;
       }
+
+      const fallbackLayoutId = await getFallbackLayoutIdForMissingUrlLayout(layoutManager);
+      if (fallbackLayoutId) {
+        setSelectedLayoutId(fallbackLayoutId);
+        setUnappliedLayoutArgs({ layoutId: undefined });
+        isLayoutIdProcessed.current = true;
+        return;
+      }
+
+      layoutDrawer.open();
+      setUnappliedLayoutArgs({ layoutId: undefined });
+      isLayoutIdProcessed.current = true;
+      return;
     }
 
     // 尝试从历史记录中恢复 layout

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.test.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.test.tsx
@@ -81,6 +81,16 @@ type MockLayoutManager = Omit<
 
 function makeMockLayoutManager(): MockLayoutManager {
   const listeners = new Set<LayoutManagerEventTypes["change"]>();
+  const on: ILayoutManager["on"] = (name, listener) => {
+    if (name === "change") {
+      listeners.add(listener as LayoutManagerEventTypes["change"]);
+    }
+  };
+  const off: ILayoutManager["off"] = (name, listener) => {
+    if (name === "change") {
+      listeners.delete(listener as LayoutManagerEventTypes["change"]);
+    }
+  };
   return {
     supportsSharing: false,
     isBusy: false,
@@ -88,16 +98,8 @@ function makeMockLayoutManager(): MockLayoutManager {
     error: undefined,
     projectName: undefined,
     userName: undefined,
-    on: jest.fn((name: keyof LayoutManagerEventTypes, listener: (...args: unknown[]) => void) => {
-      if (name === "change") {
-        listeners.add(listener as LayoutManagerEventTypes["change"]);
-      }
-    }) as unknown as ILayoutManager["on"],
-    off: jest.fn((name: keyof LayoutManagerEventTypes, listener: (...args: unknown[]) => void) => {
-      if (name === "change") {
-        listeners.delete(listener as LayoutManagerEventTypes["change"]);
-      }
-    }) as unknown as ILayoutManager["off"],
+    on: jest.fn(on),
+    off: jest.fn(off),
     setError: jest.fn(/*noop*/),
     setOnline: jest.fn(/*noop*/),
     getLayouts: jest.fn().mockImplementation(mockThrow("getLayouts")),
@@ -501,6 +503,63 @@ describe("CurrentLayoutProvider", () => {
     (console.warn as jest.Mock).mockClear();
   });
 
+  it("applies layout renames while preserving newer in-memory edits", async () => {
+    const mockLayoutManager = makeMockLayoutManager();
+    mockLayoutManager.getLayout.mockImplementation(async () => {
+      return {
+        id: "example",
+        name: "Test layout",
+        baseline: { data: TEST_LAYOUT, updatedAt: new Date(10).toISOString() },
+      };
+    });
+
+    const { result } = renderTest({ mockLayoutManager });
+    await act(async () => {
+      await result.current.childMounted;
+    });
+    act(() => {
+      result.current.actions.setSelectedLayoutId("example" as LayoutID);
+    });
+    await act(async () => {});
+
+    act(() => {
+      result.current.actions.savePanelConfigs({
+        configs: [{ id: "ExamplePanel!1", config: { foo: "newer" } }],
+      });
+    });
+    const editedData = result.current.layoutState.selectedLayout?.data;
+
+    act(() => {
+      mockLayoutManager.emitChange({
+        type: "change",
+        source: "update",
+        updatedLayout: {
+          id: "example" as LayoutID,
+          parent: "",
+          folder: "",
+          name: "Renamed layout",
+          permission: "PERSONAL_WRITE",
+          baseline: {
+            data: TEST_LAYOUT,
+            savedAt: new Date(11).toISOString() as ISO8601Timestamp,
+            modifier: undefined,
+            modifierNickname: undefined,
+          },
+          working: undefined,
+          syncInfo: undefined,
+        },
+      });
+    });
+
+    expect(result.current.layoutState.selectedLayout).toMatchObject({
+      id: "example",
+      name: "Renamed layout",
+      data: editedData,
+      edited: true,
+    });
+    (console.warn as jest.Mock).mockClear();
+  });
+
   it("retries pending layout updates after layoutManager.updateLayout fails", async () => {
     jest.useFakeTimers();
     const firstAttempt = new Condvar();
@@ -558,6 +617,51 @@ describe("CurrentLayoutProvider", () => {
 
     (console.error as jest.Mock).mockClear();
     expect(mockLayoutManager.updateLayout).toHaveBeenCalledTimes(2);
+    jest.useRealTimers();
+    (console.warn as jest.Mock).mockClear();
+  });
+
+  it("keeps pending layout updates while the same layout reloads", async () => {
+    jest.useFakeTimers();
+    const mockLayoutManager = makeMockLayoutManager();
+    mockLayoutManager.getLayout.mockImplementation(async () => {
+      return {
+        id: "example",
+        name: "Test layout",
+        baseline: { data: TEST_LAYOUT, updatedAt: new Date(10).toISOString() },
+      };
+    });
+    mockLayoutManager.updateLayout.mockResolvedValue(undefined);
+
+    const { result } = renderTest({ mockLayoutManager });
+
+    await act(async () => {
+      await result.current.childMounted;
+    });
+    act(() => {
+      result.current.actions.setSelectedLayoutId("example" as LayoutID);
+    });
+    await act(async () => {});
+    act(() => {
+      result.current.actions.savePanelConfigs({
+        configs: [{ id: "ExamplePanel!1", config: { foo: "pending" } }],
+      });
+    });
+    const pendingData = result.current.layoutState.selectedLayout?.data;
+
+    act(() => {
+      result.current.actions.setSelectedLayoutId("example" as LayoutID);
+    });
+    await act(async () => {});
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+    await act(async () => {});
+
+    expect(mockLayoutManager.updateLayout).toHaveBeenCalledWith({
+      id: "example",
+      data: pendingData,
+    });
     jest.useRealTimers();
     (console.warn as jest.Mock).mockClear();
   });

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.test.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.test.tsx
@@ -24,7 +24,12 @@ import { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext/a
 import CurrentLayoutProvider, {
   MAX_SUPPORTED_LAYOUT_VERSION,
 } from "@foxglove/studio-base/providers/CurrentLayoutProvider";
-import { ILayoutManager } from "@foxglove/studio-base/services/CoSceneILayoutManager";
+import {
+  ILayoutManager,
+  LayoutManagerChangeEvent,
+  LayoutManagerEventTypes,
+} from "@foxglove/studio-base/services/CoSceneILayoutManager";
+import { ISO8601Timestamp } from "@foxglove/studio-base/services/CoSceneILayoutStorage";
 
 const TEST_LAYOUT: LayoutData = {
   layout: "ExamplePanel!1",
@@ -39,7 +44,43 @@ function mockThrow(name: string) {
   };
 }
 
-function makeMockLayoutManager() {
+type MockLayoutManager = Omit<
+  ILayoutManager,
+  | "on"
+  | "off"
+  | "getLayouts"
+  | "getLayout"
+  | "saveNewLayout"
+  | "updateLayout"
+  | "deleteLayout"
+  | "overwriteLayout"
+  | "revertLayout"
+  | "makePersonalCopy"
+  | "putHistory"
+  | "getHistory"
+  | "setError"
+  | "setOnline"
+> & {
+  on: ILayoutManager["on"];
+  off: ILayoutManager["off"];
+  getLayouts: jest.Mock;
+  getLayout: jest.Mock;
+  saveNewLayout: jest.Mock;
+  updateLayout: jest.Mock;
+  deleteLayout: jest.Mock;
+  overwriteLayout: jest.Mock;
+  revertLayout: jest.Mock;
+  makePersonalCopy: jest.Mock;
+  putHistory: jest.Mock;
+  getHistory: jest.Mock;
+  setError: jest.Mock;
+  setOnline: jest.Mock;
+} & {
+  emitChange: (event: LayoutManagerChangeEvent) => void;
+};
+
+function makeMockLayoutManager(): MockLayoutManager {
+  const listeners = new Set<LayoutManagerEventTypes["change"]>();
   return {
     supportsSharing: false,
     isBusy: false,
@@ -47,8 +88,16 @@ function makeMockLayoutManager() {
     error: undefined,
     projectName: undefined,
     userName: undefined,
-    on: jest.fn(/*noop*/),
-    off: jest.fn(/*noop*/),
+    on: jest.fn((name: keyof LayoutManagerEventTypes, listener: (...args: unknown[]) => void) => {
+      if (name === "change") {
+        listeners.add(listener as LayoutManagerEventTypes["change"]);
+      }
+    }) as unknown as ILayoutManager["on"],
+    off: jest.fn((name: keyof LayoutManagerEventTypes, listener: (...args: unknown[]) => void) => {
+      if (name === "change") {
+        listeners.delete(listener as LayoutManagerEventTypes["change"]);
+      }
+    }) as unknown as ILayoutManager["off"],
     setError: jest.fn(/*noop*/),
     setOnline: jest.fn(/*noop*/),
     getLayouts: jest.fn().mockImplementation(mockThrow("getLayouts")),
@@ -61,6 +110,11 @@ function makeMockLayoutManager() {
     makePersonalCopy: jest.fn().mockImplementation(mockThrow("makePersonalCopy")),
     putHistory: jest.fn().mockResolvedValue(undefined),
     getHistory: jest.fn().mockImplementation(mockThrow("getHistory")),
+    emitChange: (event: LayoutManagerChangeEvent) => {
+      for (const listener of listeners) {
+        listener(event);
+      }
+    },
   };
 }
 
@@ -300,7 +354,7 @@ describe("CurrentLayoutProvider", () => {
     };
 
     expect(mockLayoutManager.updateLayout.mock.calls).toEqual([
-      [{ id: "example", data: newState, name: "Test layout", edited: true, loading: false }],
+      [{ id: "example", data: newState }],
     ]);
     expect(all.map((item) => (item instanceof Error ? undefined : item.layoutState))).toEqual([
       { selectedLayout: undefined },
@@ -316,6 +370,347 @@ describe("CurrentLayoutProvider", () => {
         },
       },
     ]);
+    jest.useRealTimers();
+    (console.warn as jest.Mock).mockClear();
+  });
+
+  it("ignores stale autosave change events when memory has newer edits", async () => {
+    const mockLayoutManager = makeMockLayoutManager();
+    mockLayoutManager.getLayout.mockImplementation(async () => {
+      return {
+        id: "example",
+        name: "Test layout",
+        baseline: { data: TEST_LAYOUT, updatedAt: new Date(10).toISOString() },
+      };
+    });
+
+    const { result } = renderTest({ mockLayoutManager });
+    await act(async () => {
+      await result.current.childMounted;
+    });
+    act(() => {
+      result.current.actions.setSelectedLayoutId("example" as LayoutID);
+    });
+    await act(async () => {});
+
+    act(() => {
+      result.current.actions.savePanelConfigs({
+        configs: [{ id: "ExamplePanel!1", config: { foo: "old" } }],
+      });
+    });
+    const oldData = result.current.layoutState.selectedLayout?.data;
+    act(() => {
+      result.current.actions.savePanelConfigs({
+        configs: [{ id: "ExamplePanel!1", config: { foo: "new" } }],
+      });
+    });
+    const newData = result.current.layoutState.selectedLayout?.data;
+
+    act(() => {
+      mockLayoutManager.emitChange({
+        type: "change",
+        source: "update",
+        updatedLayout: {
+          id: "example" as LayoutID,
+          parent: "",
+          folder: "",
+          name: "Test layout",
+          permission: "PERSONAL_WRITE",
+          baseline: {
+            data: TEST_LAYOUT,
+            savedAt: undefined,
+            modifier: undefined,
+            modifierNickname: undefined,
+          },
+          working: {
+            data: oldData ?? TEST_LAYOUT,
+            savedAt: new Date(11).toISOString() as ISO8601Timestamp,
+          },
+          syncInfo: undefined,
+        },
+      });
+    });
+
+    expect(result.current.layoutState.selectedLayout).toMatchObject({
+      id: "example",
+      data: newData,
+      edited: true,
+    });
+    (console.warn as jest.Mock).mockClear();
+  });
+
+  it("ignores stale explicit save change events when memory has newer edits", async () => {
+    const mockLayoutManager = makeMockLayoutManager();
+    mockLayoutManager.getLayout.mockImplementation(async () => {
+      return {
+        id: "example",
+        name: "Test layout",
+        baseline: { data: TEST_LAYOUT, updatedAt: new Date(10).toISOString() },
+      };
+    });
+
+    const { result } = renderTest({ mockLayoutManager });
+    await act(async () => {
+      await result.current.childMounted;
+    });
+    act(() => {
+      result.current.actions.setSelectedLayoutId("example" as LayoutID);
+    });
+    await act(async () => {});
+
+    act(() => {
+      result.current.actions.savePanelConfigs({
+        configs: [{ id: "ExamplePanel!1", config: { foo: "saved" } }],
+      });
+    });
+    const savedData = result.current.layoutState.selectedLayout?.data;
+    act(() => {
+      result.current.actions.savePanelConfigs({
+        configs: [{ id: "ExamplePanel!1", config: { foo: "newer" } }],
+      });
+    });
+    const newerData = result.current.layoutState.selectedLayout?.data;
+
+    act(() => {
+      mockLayoutManager.emitChange({
+        type: "change",
+        source: "overwrite",
+        updatedLayout: {
+          id: "example" as LayoutID,
+          parent: "",
+          folder: "",
+          name: "Test layout",
+          permission: "PERSONAL_WRITE",
+          baseline: {
+            data: savedData ?? TEST_LAYOUT,
+            savedAt: new Date(11).toISOString() as ISO8601Timestamp,
+            modifier: undefined,
+            modifierNickname: undefined,
+          },
+          working: undefined,
+          syncInfo: undefined,
+        },
+      });
+    });
+
+    expect(result.current.layoutState.selectedLayout).toMatchObject({
+      id: "example",
+      data: newerData,
+      edited: true,
+    });
+    (console.warn as jest.Mock).mockClear();
+  });
+
+  it("retries pending layout updates after layoutManager.updateLayout fails", async () => {
+    jest.useFakeTimers();
+    const firstAttempt = new Condvar();
+    const secondAttempt = new Condvar();
+    const firstAttemptWait = firstAttempt.wait();
+    const secondAttemptWait = secondAttempt.wait();
+    const mockLayoutManager = makeMockLayoutManager();
+    mockLayoutManager.getLayout.mockImplementation(async () => {
+      return {
+        id: "example",
+        name: "Test layout",
+        baseline: { data: TEST_LAYOUT, updatedAt: new Date(10).toISOString() },
+      };
+    });
+
+    let attempts = 0;
+    mockLayoutManager.updateLayout.mockImplementation(async () => {
+      attempts++;
+      if (attempts === 1) {
+        firstAttempt.notifyAll();
+        throw new Error("temporary failure");
+      }
+      secondAttempt.notifyAll();
+    });
+
+    const { result } = renderTest({ mockLayoutManager });
+
+    await act(async () => {
+      await result.current.childMounted;
+    });
+    act(() => {
+      result.current.actions.setSelectedLayoutId("example" as LayoutID);
+    });
+    await act(async () => {});
+    act(() => {
+      result.current.actions.savePanelConfigs({
+        configs: [{ id: "ExamplePanel!1", config: { foo: "bar" } }],
+      });
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+    await act(async () => {
+      await firstAttemptWait;
+    });
+    await act(async () => {});
+
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+    await act(async () => {
+      await secondAttemptWait;
+    });
+
+    (console.error as jest.Mock).mockClear();
+    expect(mockLayoutManager.updateLayout).toHaveBeenCalledTimes(2);
+    jest.useRealTimers();
+    (console.warn as jest.Mock).mockClear();
+  });
+
+  it("clears pending debounced updates after an explicit save uses current memory data", async () => {
+    jest.useFakeTimers();
+    const mockLayoutManager = makeMockLayoutManager();
+    mockLayoutManager.getLayout.mockImplementation(async () => {
+      return {
+        id: "example",
+        name: "Test layout",
+        baseline: { data: TEST_LAYOUT, updatedAt: new Date(10).toISOString() },
+      };
+    });
+    mockLayoutManager.updateLayout.mockResolvedValue(undefined);
+    mockLayoutManager.overwriteLayout.mockImplementation(async ({ id, data }) => {
+      const updatedLayout = {
+        id,
+        parent: "",
+        folder: "",
+        name: "Test layout",
+        permission: "PERSONAL_WRITE" as const,
+        baseline: {
+          data: data ?? TEST_LAYOUT,
+          savedAt: new Date(11).toISOString() as ISO8601Timestamp,
+          modifier: undefined,
+          modifierNickname: undefined,
+        },
+        working: undefined,
+        syncInfo: undefined,
+      };
+      mockLayoutManager.emitChange({ type: "change", updatedLayout });
+      return updatedLayout;
+    });
+
+    const { result } = renderTest({ mockLayoutManager });
+
+    await act(async () => {
+      await result.current.childMounted;
+    });
+    act(() => {
+      result.current.actions.setSelectedLayoutId("example" as LayoutID);
+    });
+    await act(async () => {});
+    act(() => {
+      result.current.actions.savePanelConfigs({
+        configs: [{ id: "ExamplePanel!1", config: { foo: "bar" } }],
+      });
+    });
+
+    const currentData = result.current.layoutState.selectedLayout?.data;
+    await act(async () => {
+      await mockLayoutManager.overwriteLayout({
+        id: "example" as LayoutID,
+        data: currentData,
+      });
+    });
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+    await act(async () => {});
+
+    expect(mockLayoutManager.overwriteLayout.mock.calls[0]?.[0]).toEqual({
+      id: "example",
+      data: {
+        ...TEST_LAYOUT,
+        configById: { "ExamplePanel!1": { foo: "bar" } },
+      },
+    });
+    expect(mockLayoutManager.updateLayout).not.toHaveBeenCalled();
+    jest.useRealTimers();
+    (console.warn as jest.Mock).mockClear();
+  });
+
+  it("does not requeue a stale autosave failure after an explicit save cleared pending edits", async () => {
+    jest.useFakeTimers();
+    const updateStarted = new Condvar();
+    const updateStartedWait = updateStarted.wait();
+    let rejectUpdate: ((error: Error) => void) | undefined;
+    const mockLayoutManager = makeMockLayoutManager();
+    mockLayoutManager.getLayout.mockImplementation(async () => {
+      return {
+        id: "example",
+        name: "Test layout",
+        baseline: { data: TEST_LAYOUT, updatedAt: new Date(10).toISOString() },
+      };
+    });
+    mockLayoutManager.updateLayout.mockImplementation(
+      async () =>
+        await new Promise((_resolve, reject) => {
+          rejectUpdate = reject;
+          updateStarted.notifyAll();
+        }),
+    );
+
+    const { result } = renderTest({ mockLayoutManager });
+    await act(async () => {
+      await result.current.childMounted;
+    });
+    act(() => {
+      result.current.actions.setSelectedLayoutId("example" as LayoutID);
+    });
+    await act(async () => {});
+    act(() => {
+      result.current.actions.savePanelConfigs({
+        configs: [{ id: "ExamplePanel!1", config: { foo: "old" } }],
+      });
+    });
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+    await act(async () => {
+      await updateStartedWait;
+    });
+
+    act(() => {
+      result.current.actions.savePanelConfigs({
+        configs: [{ id: "ExamplePanel!1", config: { foo: "saved" } }],
+      });
+    });
+    const savedData = result.current.layoutState.selectedLayout?.data;
+    act(() => {
+      mockLayoutManager.emitChange({
+        type: "change",
+        source: "overwrite",
+        updatedLayout: {
+          id: "example" as LayoutID,
+          parent: "",
+          folder: "",
+          name: "Test layout",
+          permission: "PERSONAL_WRITE",
+          baseline: {
+            data: savedData ?? TEST_LAYOUT,
+            savedAt: new Date(11).toISOString() as ISO8601Timestamp,
+            modifier: undefined,
+            modifierNickname: undefined,
+          },
+          working: undefined,
+          syncInfo: undefined,
+        },
+      });
+    });
+
+    await act(async () => {
+      rejectUpdate?.(new Error("stale autosave failed"));
+    });
+    (console.error as jest.Mock).mockClear();
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+    await act(async () => {});
+
+    expect(mockLayoutManager.updateLayout).toHaveBeenCalledTimes(1);
     jest.useRealTimers();
     (console.warn as jest.Mock).mockClear();
   });

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -149,7 +149,8 @@ export default function CurrentLayoutProvider({
         }
       } catch (error) {
         console.error(error);
-        enqueueSnackbar(`The layout could not be loaded. ${error.toString()}`, {
+        const message = error instanceof Error ? error.toString() : String(error);
+        enqueueSnackbar(`The layout could not be loaded. ${message}`, {
           variant: "error",
         });
         setIncompatibleLayoutVersionError(false);
@@ -234,16 +235,22 @@ export default function CurrentLayoutProvider({
   useEffect(() => {
     const listener: LayoutManagerEventTypes["change"] = (event) => {
       const { updatedLayout } = event;
-      if (
-        updatedLayout &&
-        layoutStateRef.current.selectedLayout &&
-        updatedLayout.id === layoutStateRef.current.selectedLayout.id
-      ) {
+      const currentSelectedLayout = layoutStateRef.current.selectedLayout;
+      if (updatedLayout && currentSelectedLayout && updatedLayout.id === currentSelectedLayout.id) {
         const updatedData = updatedLayout.working?.data ?? updatedLayout.baseline.data;
         if (
           (event.source === "update" || event.source === "overwrite") &&
-          !_.isEqual(layoutStateRef.current.selectedLayout.data, updatedData)
+          currentSelectedLayout.data != undefined &&
+          !_.isEqual(currentSelectedLayout.data, updatedData)
         ) {
+          setLayoutState({
+            selectedLayout: {
+              ...currentSelectedLayout,
+              loading: false,
+              id: updatedLayout.id,
+              name: updatedLayout.name,
+            },
+          });
           return;
         }
 

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -232,17 +232,27 @@ export default function CurrentLayoutProvider({
   // Changes to the layout storage from external user actions (such as resetting a layout to a
   // previous saved state) need to trigger setLayoutState.
   useEffect(() => {
-    const listener: LayoutManagerEventTypes["change"] = ({ updatedLayout }) => {
+    const listener: LayoutManagerEventTypes["change"] = (event) => {
+      const { updatedLayout } = event;
       if (
         updatedLayout &&
         layoutStateRef.current.selectedLayout &&
         updatedLayout.id === layoutStateRef.current.selectedLayout.id
       ) {
+        const updatedData = updatedLayout.working?.data ?? updatedLayout.baseline.data;
+        if (
+          event.type === "change" &&
+          (event.source === "update" || event.source === "overwrite") &&
+          !_.isEqual(layoutStateRef.current.selectedLayout.data, updatedData)
+        ) {
+          return;
+        }
+
         setLayoutState({
           selectedLayout: {
             loading: false,
             id: updatedLayout.id,
-            data: updatedLayout.working?.data ?? updatedLayout.baseline.data,
+            data: updatedData,
             name: updatedLayout.name,
           },
         });

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/index.tsx
@@ -241,7 +241,6 @@ export default function CurrentLayoutProvider({
       ) {
         const updatedData = updatedLayout.working?.data ?? updatedLayout.baseline.data;
         if (
-          event.type === "change" &&
           (event.source === "update" || event.source === "overwrite") &&
           !_.isEqual(layoutStateRef.current.selectedLayout.data, updatedData)
         ) {

--- a/packages/studio-base/src/services/CoSceneConsoleApiRemoteLayoutStorage.test.ts
+++ b/packages/studio-base/src/services/CoSceneConsoleApiRemoteLayoutStorage.test.ts
@@ -12,6 +12,7 @@ import { LayoutSchema } from "@coscene-io/cosceneapis-es-v2/coscene/dataplatform
 import { LayoutID } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
 import CoSceneConsoleApiRemoteLayoutStorage from "@foxglove/studio-base/services/CoSceneConsoleApiRemoteLayoutStorage";
+import type { ISO8601Timestamp } from "@foxglove/studio-base/services/CoSceneILayoutStorage";
 import ConsoleApi from "@foxglove/studio-base/services/api/CoSceneConsoleApi";
 
 const layoutData: LayoutData = {
@@ -35,6 +36,88 @@ function makeStorage(api: Partial<ConsoleApi>): CoSceneConsoleApiRemoteLayoutSto
 }
 
 describe("CoSceneConsoleApiRemoteLayoutStorage", () => {
+  it("returns conflict when update target lookup reports not found", async () => {
+    const id = layoutId("users/u/layouts/1");
+    const updateUserLayout = jest.fn();
+    const storage = makeStorage({
+      getUserLayout: jest.fn().mockRejectedValue(new ConnectError("missing", Code.NotFound)),
+      updateUserLayout,
+    });
+
+    await expect(storage.updateLayout({ id, data: layoutData })).resolves.toEqual({
+      status: "conflict",
+    });
+
+    expect(updateUserLayout).not.toHaveBeenCalled();
+  });
+
+  it("propagates non-not-found update lookup failures", async () => {
+    const id = layoutId("users/u/layouts/1");
+    const updateUserLayout = jest.fn();
+    const storage = makeStorage({
+      getUserLayout: jest
+        .fn()
+        .mockRejectedValue(new ConnectError("service unavailable", Code.Unavailable)),
+      updateUserLayout,
+    });
+
+    await expect(storage.updateLayout({ id, data: layoutData })).rejects.toThrow(
+      "service unavailable",
+    );
+
+    expect(updateUserLayout).not.toHaveBeenCalled();
+  });
+
+  it("returns conflict when update timestamps do not match", async () => {
+    const id = layoutId("users/u/layouts/1");
+    const updateUserLayout = jest.fn();
+    const storage = makeStorage({
+      getUserLayout: jest.fn().mockResolvedValue(
+        create(LayoutSchema, {
+          name: id,
+          displayName: "Layout",
+          folder: "",
+          data: layoutData as JsonObject,
+        }),
+      ),
+      updateUserLayout,
+    });
+
+    await expect(
+      storage.updateLayout({
+        id,
+        data: layoutData,
+        expectedSavedAt: "2024-01-01T00:00:00.000Z" as ISO8601Timestamp,
+      }),
+    ).resolves.toEqual({ status: "conflict" });
+
+    expect(updateUserLayout).not.toHaveBeenCalled();
+  });
+
+  it("returns conflict when a layout disappears during update", async () => {
+    const id = layoutId("users/u/layouts/1");
+    const updateUserLayout = jest
+      .fn()
+      .mockRejectedValue(new ConnectError("missing", Code.NotFound));
+    const storage = makeStorage({
+      getUserLayout: jest.fn().mockResolvedValue(
+        create(LayoutSchema, {
+          name: id,
+          displayName: "Layout",
+          folder: "",
+          data: layoutData as JsonObject,
+        }),
+      ),
+      updateUserLayout,
+    });
+
+    await expect(storage.updateLayout({ id, data: layoutData })).resolves.toEqual({
+      status: "conflict",
+    });
+
+    expect(updateUserLayout).toHaveBeenCalledTimes(1);
+  });
+
   it("returns false when delete target lookup reports not found", async () => {
     const id = layoutId("users/u/layouts/1");
     const deleteUserLayout = jest.fn();

--- a/packages/studio-base/src/services/CoSceneConsoleApiRemoteLayoutStorage.test.ts
+++ b/packages/studio-base/src/services/CoSceneConsoleApiRemoteLayoutStorage.test.ts
@@ -118,6 +118,31 @@ describe("CoSceneConsoleApiRemoteLayoutStorage", () => {
     expect(updateUserLayout).toHaveBeenCalledTimes(1);
   });
 
+  it("propagates non-not-found update failures", async () => {
+    const id = layoutId("users/u/layouts/1");
+    const updateUserLayout = jest
+      .fn()
+      .mockRejectedValue(new ConnectError("service unavailable", Code.Unavailable));
+    const storage = makeStorage({
+      getUserLayout: jest.fn().mockResolvedValue(
+        create(LayoutSchema, {
+          name: id,
+          displayName: "Layout",
+          folder: "",
+          data: layoutData as JsonObject,
+        }),
+      ),
+      updateUserLayout,
+    });
+
+    await expect(storage.updateLayout({ id, data: layoutData })).rejects.toThrow(
+      "service unavailable",
+    );
+    jest.mocked(console.error).mockClear();
+
+    expect(updateUserLayout).toHaveBeenCalledTimes(1);
+  });
+
   it("returns false when delete target lookup reports not found", async () => {
     const id = layoutId("users/u/layouts/1");
     const deleteUserLayout = jest.fn();

--- a/packages/studio-base/src/services/CoSceneConsoleApiRemoteLayoutStorage.test.ts
+++ b/packages/studio-base/src/services/CoSceneConsoleApiRemoteLayoutStorage.test.ts
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { create, JsonObject } from "@bufbuild/protobuf";
+import { Code, ConnectError } from "@connectrpc/connect";
+import { LayoutSchema } from "@coscene-io/cosceneapis-es-v2/coscene/dataplatform/v1alpha2/resources/layout_pb";
+
+import { LayoutID } from "@foxglove/studio-base/context/CurrentLayoutContext";
+import { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
+import CoSceneConsoleApiRemoteLayoutStorage from "@foxglove/studio-base/services/CoSceneConsoleApiRemoteLayoutStorage";
+import ConsoleApi from "@foxglove/studio-base/services/api/CoSceneConsoleApi";
+
+const layoutData: LayoutData = {
+  layout: "Panel!1",
+  configById: { "Panel!1": { value: "initial" } },
+  globalVariables: {},
+  userNodes: {},
+};
+
+function layoutId(value: string): LayoutID {
+  return value as LayoutID;
+}
+
+function makeStorage(api: Partial<ConsoleApi>): CoSceneConsoleApiRemoteLayoutStorage {
+  return new CoSceneConsoleApiRemoteLayoutStorage(
+    "remote-user",
+    "users/u",
+    "warehouses/w/projects/p",
+    api as ConsoleApi,
+  );
+}
+
+describe("CoSceneConsoleApiRemoteLayoutStorage", () => {
+  it("returns false when delete target lookup reports not found", async () => {
+    const id = layoutId("users/u/layouts/1");
+    const deleteUserLayout = jest.fn();
+    const storage = makeStorage({
+      getUserLayout: jest.fn().mockRejectedValue(new ConnectError("missing", Code.NotFound)),
+      deleteUserLayout,
+    });
+
+    await expect(storage.deleteLayout(id)).resolves.toBe(false);
+
+    expect(deleteUserLayout).not.toHaveBeenCalled();
+  });
+
+  it("returns false when a layout disappears during delete", async () => {
+    const id = layoutId("users/u/layouts/1");
+    const deleteUserLayout = jest
+      .fn()
+      .mockRejectedValue(new ConnectError("missing", Code.NotFound));
+    const storage = makeStorage({
+      getUserLayout: jest.fn().mockResolvedValue(
+        create(LayoutSchema, {
+          name: id,
+          displayName: "Layout",
+          folder: "",
+          data: layoutData as JsonObject,
+        }),
+      ),
+      deleteUserLayout,
+    });
+
+    await expect(storage.deleteLayout(id)).resolves.toBe(false);
+
+    expect(deleteUserLayout).toHaveBeenCalledWith({ name: id });
+  });
+
+  it("propagates non-not-found delete failures", async () => {
+    const id = layoutId("users/u/layouts/1");
+    const storage = makeStorage({
+      getUserLayout: jest.fn().mockResolvedValue(
+        create(LayoutSchema, {
+          name: id,
+          displayName: "Layout",
+          folder: "",
+          data: layoutData as JsonObject,
+        }),
+      ),
+      deleteUserLayout: jest
+        .fn()
+        .mockRejectedValue(new ConnectError("service unavailable", Code.Unavailable)),
+    });
+
+    await expect(storage.deleteLayout(id)).rejects.toThrow("service unavailable");
+  });
+});

--- a/packages/studio-base/src/services/CoSceneConsoleApiRemoteLayoutStorage.ts
+++ b/packages/studio-base/src/services/CoSceneConsoleApiRemoteLayoutStorage.ts
@@ -7,6 +7,7 @@
 
 import { create, JsonObject } from "@bufbuild/protobuf";
 import { FieldMaskSchema, timestampDate, TimestampSchema } from "@bufbuild/protobuf/wkt";
+import { Code, ConnectError } from "@connectrpc/connect";
 import { User as CoUser } from "@coscene-io/cosceneapis-es-v2/coscene/dataplatform/v1alpha1/resources/user_pb";
 import { LayoutScopeEnum_LayoutScope } from "@coscene-io/cosceneapis-es-v2/coscene/dataplatform/v1alpha2/enums/layout_scope_pb";
 import { LayoutSchema } from "@coscene-io/cosceneapis-es-v2/coscene/dataplatform/v1alpha2/resources/layout_pb";
@@ -28,6 +29,10 @@ import { ISO8601Timestamp } from "./CoSceneILayoutStorage";
 const log = Logger.getLogger(__filename);
 
 type LayoutPermission = "PERSONAL_WRITE" | "PROJECT_READ" | "PROJECT_WRITE";
+
+function isNotFoundError(err: unknown): boolean {
+  return ConnectError.from(err).code === Code.NotFound;
+}
 
 function convertGrpcLayoutToRemoteLayout({
   layout,
@@ -96,31 +101,46 @@ export default class CoSceneConsoleApiRemoteLayoutStorage implements IRemoteLayo
     private api: ConsoleApi,
   ) {}
 
+  async #getLayout(name: LayoutID): Promise<RemoteLayout | undefined> {
+    let layout;
+    if (name.startsWith("users/")) {
+      layout = await this.api.getUserLayout({ name });
+    } else if (name.startsWith("warehouses/")) {
+      layout = await this.api.getProjectLayout({ name });
+    }
+
+    if (layout == undefined) {
+      return undefined;
+    }
+
+    const users = layout.modifier ? await this.api.batchGetUsers([layout.modifier]) : { users: [] };
+    return convertGrpcLayoutToRemoteLayout({
+      layout,
+      users: users.users,
+    });
+  }
+
   public async getLayouts(): Promise<readonly RemoteLayout[]> {
     if (isAuthlessDataSource()) {
       return [];
     }
 
-    try {
-      const parents = [this.userName];
-      if (this.projectName) {
-        parents.push(this.projectName);
-      }
-      if (parents.length === 0) {
-        return [];
-      }
+    const parents = [this.userName];
+    if (this.projectName) {
+      parents.push(this.projectName);
+    }
+    if (parents.length === 0) {
+      return [];
+    }
 
+    try {
       const layouts = await Promise.all(
         parents.map(async (parent) => {
           let allLayouts: Layout[] = [];
-          try {
-            if (parent.startsWith("users/")) {
-              allLayouts = (await this.api.listUserLayouts({ parent })).userLayouts;
-            } else if (parent.startsWith("warehouses/")) {
-              allLayouts = (await this.api.listProjectLayouts({ parent })).projectLayouts;
-            }
-          } catch (err) {
-            log.error("Failed to get layouts for parent:", parent, err);
+          if (parent.startsWith("users/")) {
+            allLayouts = (await this.api.listUserLayouts({ parent })).userLayouts;
+          } else if (parent.startsWith("warehouses/")) {
+            allLayouts = (await this.api.listProjectLayouts({ parent })).projectLayouts;
           }
 
           const modifiers: string[] = allLayouts
@@ -135,30 +155,13 @@ export default class CoSceneConsoleApiRemoteLayoutStorage implements IRemoteLayo
       return layouts.flat();
     } catch (err) {
       log.error("Failed to get layouts:", err);
-      return [];
+      throw err;
     }
   }
 
   public async getLayout(name: LayoutID): Promise<RemoteLayout | undefined> {
     try {
-      let layout;
-      if (name.startsWith("users/")) {
-        layout = await this.api.getUserLayout({ name });
-      } else if (name.startsWith("warehouses/")) {
-        layout = await this.api.getProjectLayout({ name });
-      }
-
-      if (layout == undefined) {
-        return undefined;
-      }
-
-      const users = layout.modifier
-        ? await this.api.batchGetUsers([layout.modifier])
-        : { users: [] };
-      return convertGrpcLayoutToRemoteLayout({
-        layout,
-        users: users.users,
-      });
+      return await this.#getLayout(name);
     } catch (err) {
       log.error("Failed to get layout:", err);
       return undefined;
@@ -204,23 +207,34 @@ export default class CoSceneConsoleApiRemoteLayoutStorage implements IRemoteLayo
     });
   }
 
-  public async updateLayout({
-    id,
-    name,
-    folder,
-    data,
-    permission: _permission,
-  }: {
+  public async updateLayout(params: {
     id: LayoutID;
     name?: string;
     folder?: string;
     data?: LayoutData;
     permission?: LayoutPermission;
+    expectedSavedAt?: ISO8601Timestamp | undefined;
+    expectedUpdatedAt?: ISO8601Timestamp | undefined;
   }): Promise<{ status: "success"; newLayout: RemoteLayout } | { status: "conflict" }> {
+    const { id, name, folder, data, expectedSavedAt, expectedUpdatedAt } = params;
+
     try {
       // First get the existing layout to determine its current resource name
       const existingLayout = await this.getLayout(id);
       if (!existingLayout) {
+        return { status: "conflict" };
+      }
+
+      if (
+        ("expectedSavedAt" in params || expectedSavedAt !== undefined) &&
+        existingLayout.savedAt !== expectedSavedAt
+      ) {
+        return { status: "conflict" };
+      }
+      if (
+        ("expectedUpdatedAt" in params || expectedUpdatedAt !== undefined) &&
+        existingLayout.updatedAt !== expectedUpdatedAt
+      ) {
         return { status: "conflict" };
       }
 
@@ -266,25 +280,55 @@ export default class CoSceneConsoleApiRemoteLayoutStorage implements IRemoteLayo
     }
   }
 
-  public async deleteLayout(name: LayoutID): Promise<boolean> {
+  public async deleteLayout(
+    name: LayoutID,
+    options: {
+      expectedSavedAt?: ISO8601Timestamp | undefined;
+      expectedUpdatedAt?: ISO8601Timestamp | undefined;
+    } = {},
+  ): Promise<boolean> {
+    // First get the existing layout to determine its type. Return false only when the server says
+    // the layout is absent; propagate conflicts and request failures so local tombstones are kept.
+    let existingLayout;
     try {
-      // First get the existing layout to determine its type
-      const existingLayout = await this.getLayout(name);
-      if (!existingLayout) {
+      existingLayout = await this.#getLayout(name);
+    } catch (err) {
+      if (isNotFoundError(err)) {
         return false;
       }
+      throw err;
+    }
+    if (!existingLayout) {
+      return false;
+    }
 
-      // Use appropriate API based on layout's permission
+    if (
+      ("expectedSavedAt" in options || options.expectedSavedAt !== undefined) &&
+      existingLayout.savedAt !== options.expectedSavedAt
+    ) {
+      throw new Error(`Layout ${name} has changed on the server; local changes were not saved.`);
+    }
+    if (
+      ("expectedUpdatedAt" in options || options.expectedUpdatedAt !== undefined) &&
+      existingLayout.updatedAt !== options.expectedUpdatedAt
+    ) {
+      throw new Error(`Layout ${name} has changed on the server; local changes were not saved.`);
+    }
+
+    // Use appropriate API based on layout's permission
+    try {
       if (existingLayout.permission === "PERSONAL_WRITE") {
         await this.api.deleteUserLayout({ name });
       } else {
         await this.api.deleteProjectLayout({ name });
       }
-
-      return true;
     } catch (err) {
-      log.error("Failed to delete layout:", err);
-      return false;
+      if (isNotFoundError(err)) {
+        return false;
+      }
+      throw err;
     }
+
+    return true;
   }
 }

--- a/packages/studio-base/src/services/CoSceneConsoleApiRemoteLayoutStorage.ts
+++ b/packages/studio-base/src/services/CoSceneConsoleApiRemoteLayoutStorage.ts
@@ -218,49 +218,58 @@ export default class CoSceneConsoleApiRemoteLayoutStorage implements IRemoteLayo
   }): Promise<{ status: "success"; newLayout: RemoteLayout } | { status: "conflict" }> {
     const { id, name, folder, data, expectedSavedAt, expectedUpdatedAt } = params;
 
+    let existingLayout;
     try {
-      // First get the existing layout to determine its current resource name
-      const existingLayout = await this.getLayout(id);
-      if (!existingLayout) {
+      // The backend does not provide an atomic compare-and-set update. These timestamp checks are
+      // only a best-effort conflict hint before issuing the write.
+      existingLayout = await this.#getLayout(id);
+    } catch (err) {
+      if (isNotFoundError(err)) {
         return { status: "conflict" };
       }
+      throw err;
+    }
+    if (!existingLayout) {
+      return { status: "conflict" };
+    }
 
-      if (
-        ("expectedSavedAt" in params || expectedSavedAt !== undefined) &&
-        existingLayout.savedAt !== expectedSavedAt
-      ) {
-        return { status: "conflict" };
-      }
-      if (
-        ("expectedUpdatedAt" in params || expectedUpdatedAt !== undefined) &&
-        existingLayout.updatedAt !== expectedUpdatedAt
-      ) {
-        return { status: "conflict" };
-      }
+    if (
+      ("expectedSavedAt" in params || expectedSavedAt != undefined) &&
+      existingLayout.savedAt !== expectedSavedAt
+    ) {
+      return { status: "conflict" };
+    }
+    if (
+      ("expectedUpdatedAt" in params || expectedUpdatedAt != undefined) &&
+      existingLayout.updatedAt !== expectedUpdatedAt
+    ) {
+      return { status: "conflict" };
+    }
 
-      // Create updated layout
-      const updatedLayout = create(LayoutSchema, {
-        name: id,
-      });
+    // Create updated layout
+    const updatedLayout = create(LayoutSchema, {
+      name: id,
+    });
 
-      // Create update mask for the fields we're updating
-      const updateMask = create(FieldMaskSchema);
-      const paths: string[] = [];
-      updateMask.paths = paths;
+    // Create update mask for the fields we're updating
+    const updateMask = create(FieldMaskSchema);
+    const paths: string[] = [];
+    updateMask.paths = paths;
 
-      if (name != undefined && name) {
-        updatedLayout.displayName = name;
-        paths.push("displayName");
-      }
-      if (folder != undefined) {
-        updatedLayout.folder = folder;
-        paths.push("folder");
-      }
-      if (data != undefined) {
-        updatedLayout.data = data as JsonObject;
-        paths.push("data");
-      }
+    if (name != undefined && name) {
+      updatedLayout.displayName = name;
+      paths.push("displayName");
+    }
+    if (folder != undefined) {
+      updatedLayout.folder = folder;
+      paths.push("folder");
+    }
+    if (data != undefined) {
+      updatedLayout.data = data as JsonObject;
+      paths.push("data");
+    }
 
+    try {
       const result =
         existingLayout.permission === "PERSONAL_WRITE"
           ? await this.api.updateUserLayout({ layout: updatedLayout, updateMask })
@@ -275,8 +284,11 @@ export default class CoSceneConsoleApiRemoteLayoutStorage implements IRemoteLayo
         }),
       };
     } catch (err) {
+      if (isNotFoundError(err)) {
+        return { status: "conflict" };
+      }
       log.error("Failed to update layout:", err);
-      return { status: "conflict" };
+      throw err;
     }
   }
 
@@ -288,7 +300,8 @@ export default class CoSceneConsoleApiRemoteLayoutStorage implements IRemoteLayo
     } = {},
   ): Promise<boolean> {
     // First get the existing layout to determine its type. Return false only when the server says
-    // the layout is absent; propagate conflicts and request failures so local tombstones are kept.
+    // the layout is absent; propagate request failures so local tombstones are kept. Timestamp
+    // checks are a best-effort hint only; the backend delete is not an atomic compare-and-set.
     let existingLayout;
     try {
       existingLayout = await this.#getLayout(name);
@@ -303,13 +316,13 @@ export default class CoSceneConsoleApiRemoteLayoutStorage implements IRemoteLayo
     }
 
     if (
-      ("expectedSavedAt" in options || options.expectedSavedAt !== undefined) &&
+      ("expectedSavedAt" in options || options.expectedSavedAt != undefined) &&
       existingLayout.savedAt !== options.expectedSavedAt
     ) {
       throw new Error(`Layout ${name} has changed on the server; local changes were not saved.`);
     }
     if (
-      ("expectedUpdatedAt" in options || options.expectedUpdatedAt !== undefined) &&
+      ("expectedUpdatedAt" in options || options.expectedUpdatedAt != undefined) &&
       existingLayout.updatedAt !== options.expectedUpdatedAt
     ) {
       throw new Error(`Layout ${name} has changed on the server; local changes were not saved.`);

--- a/packages/studio-base/src/services/CoSceneILayoutManager.ts
+++ b/packages/studio-base/src/services/CoSceneILayoutManager.ts
@@ -13,7 +13,7 @@ import { Layout, LayoutPermission } from "@foxglove/studio-base/services/CoScene
 
 export type LayoutManagerChangeEvent =
   | { type: "delete"; updatedLayout?: undefined; layoutId: LayoutID }
-  | { type: "change"; updatedLayout: Layout | undefined };
+  | { type: "change"; updatedLayout: Layout | undefined; source?: "update" | "overwrite" };
 
 export type LayoutManagerEventTypes = {
   /**
@@ -113,7 +113,7 @@ export interface ILayoutManager {
   deleteLayout(params: { id: LayoutID }): Promise<void>;
 
   /** Save the local changes so they override the baseline. */
-  overwriteLayout(params: { id: LayoutID }): Promise<Layout>;
+  overwriteLayout(params: { id: LayoutID; data?: LayoutData }): Promise<Layout>;
 
   /** Revert this layout to the baseline. */
   revertLayout(params: { id: LayoutID }): Promise<Layout>;

--- a/packages/studio-base/src/services/CoSceneIRemoteLayoutStorage.ts
+++ b/packages/studio-base/src/services/CoSceneIRemoteLayoutStorage.ts
@@ -59,8 +59,16 @@ export interface IRemoteLayoutStorage {
     folder?: string;
     data?: LayoutData;
     permission?: LayoutPermission;
+    expectedSavedAt?: ISO8601Timestamp | undefined;
+    expectedUpdatedAt?: ISO8601Timestamp | undefined;
   }) => Promise<{ status: "success"; newLayout: RemoteLayout } | { status: "conflict" }>;
 
   /** Returns true if the layout existed and was deleted, false if the layout did not exist. */
-  deleteLayout: (id: LayoutID) => Promise<boolean>;
+  deleteLayout: (
+    id: LayoutID,
+    options?: {
+      expectedSavedAt?: ISO8601Timestamp | undefined;
+      expectedUpdatedAt?: ISO8601Timestamp | undefined;
+    },
+  ) => Promise<boolean>;
 }

--- a/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.projectConcurrency.test.ts
+++ b/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.projectConcurrency.test.ts
@@ -1,0 +1,223 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import type { LayoutID } from "@foxglove/studio-base/context/CurrentLayoutContext";
+import type { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
+import type {
+  ILayoutStorage,
+  ISO8601Timestamp,
+  Layout,
+  LayoutHistory,
+} from "@foxglove/studio-base/services/CoSceneILayoutStorage";
+import type {
+  IRemoteLayoutStorage,
+  RemoteLayout,
+} from "@foxglove/studio-base/services/CoSceneIRemoteLayoutStorage";
+import CoSceneLayoutManager from "@foxglove/studio-base/services/LayoutManager/CoSceneLayoutManager";
+
+function clone<T>(value: T): T {
+  return structuredClone(value);
+}
+
+function layoutData(value: string): LayoutData {
+  return {
+    layout: "Panel!1",
+    configById: { "Panel!1": { value } },
+    globalVariables: {},
+    userNodes: {},
+  };
+}
+
+function layoutId(value: string): LayoutID {
+  return value as LayoutID;
+}
+
+function ts(value: string): ISO8601Timestamp {
+  return value as ISO8601Timestamp;
+}
+
+class MemoryLayoutStorage implements ILayoutStorage {
+  public layouts = new Map<string, Layout>();
+  public history = new Map<string, LayoutHistory>();
+
+  #layoutKey(namespace: string, id: LayoutID): string {
+    return `${namespace}:${id}`;
+  }
+
+  #historyKey(namespace: string, parent: string): string {
+    return `${namespace}:${parent}`;
+  }
+
+  public async list(namespace: string): Promise<readonly Layout[]> {
+    const prefix = `${namespace}:`;
+    return [...this.layouts.entries()]
+      .filter(([key]) => key.startsWith(prefix))
+      .map(([, layout]) => clone(layout));
+  }
+
+  public async listByParent(namespace: string, parent: string): Promise<readonly Layout[]> {
+    return (await this.list(namespace)).filter((layout) => layout.parent === parent);
+  }
+
+  public async get(namespace: string, id: LayoutID): Promise<Layout | undefined> {
+    const layout = this.layouts.get(this.#layoutKey(namespace, id));
+    return layout == undefined ? undefined : clone(layout);
+  }
+
+  public async put(namespace: string, layout: Layout): Promise<Layout> {
+    this.layouts.set(this.#layoutKey(namespace, layout.id), clone(layout));
+    return clone(layout);
+  }
+
+  public async delete(namespace: string, id: LayoutID): Promise<void> {
+    this.layouts.delete(this.#layoutKey(namespace, id));
+  }
+
+  public async importLayouts({
+    fromNamespace,
+    toNamespace,
+  }: {
+    fromNamespace: string;
+    toNamespace: string;
+  }): Promise<void> {
+    for (const layout of await this.list(fromNamespace)) {
+      await this.put(toNamespace, layout);
+      await this.delete(fromNamespace, layout.id);
+    }
+  }
+
+  public async getHistory(namespace: string, parent: string): Promise<Layout | undefined> {
+    const history = this.history.get(this.#historyKey(namespace, parent));
+    return history == undefined ? undefined : await this.get(namespace, history.id);
+  }
+
+  public async putHistory(namespace: string, history: LayoutHistory): Promise<LayoutHistory> {
+    this.history.set(this.#historyKey(namespace, history.parent), clone(history));
+    return clone(history);
+  }
+}
+
+type RemoteStore = {
+  readonly layouts: Map<LayoutID, RemoteLayout>;
+};
+
+type UpdateLayoutParams = Parameters<IRemoteLayoutStorage["updateLayout"]>[0];
+
+async function applyRemoteUpdate(
+  storage: RemoteStore,
+  { id, name, folder, data, expectedSavedAt, expectedUpdatedAt }: UpdateLayoutParams,
+): ReturnType<IRemoteLayoutStorage["updateLayout"]> {
+  const existing = storage.layouts.get(id);
+  if (!existing) {
+    return { status: "conflict" as const };
+  }
+  if (existing.savedAt !== expectedSavedAt || existing.updatedAt !== expectedUpdatedAt) {
+    return { status: "conflict" as const };
+  }
+
+  const updated = {
+    ...existing,
+    name: name ?? existing.name,
+    folder: folder ?? existing.folder,
+    data: data ?? existing.data,
+    savedAt: ts("2024-01-01T00:00:20.000Z"),
+    updatedAt: ts("2024-01-01T00:00:20.000Z"),
+  };
+  storage.layouts.set(id, clone(updated));
+  return { status: "success" as const, newLayout: clone(updated) };
+}
+
+class MemoryRemoteLayoutStorage implements IRemoteLayoutStorage {
+  public namespace = "remote-user";
+  public projectName = "warehouses/w/projects/p";
+  public userName = "users/u";
+  public layouts = new Map<LayoutID, RemoteLayout>();
+
+  public getLayouts = jest.fn(async () => [...this.layouts.values()].map(clone));
+  public getLayout = jest.fn(async (id: LayoutID) => {
+    const layout = this.layouts.get(id);
+    return layout == undefined ? undefined : clone(layout);
+  });
+  public saveNewLayout = jest.fn(async (): Promise<RemoteLayout> => {
+    throw new Error("Unexpected saveNewLayout call");
+  });
+  public updateLayout = jest.fn(async (params: UpdateLayoutParams) => {
+    return await applyRemoteUpdate(this, params);
+  });
+  public deleteLayout = jest.fn(async (): Promise<boolean> => {
+    throw new Error("Unexpected deleteLayout call");
+  });
+}
+
+function makeProjectLayout(id: LayoutID): Layout {
+  return {
+    id,
+    parent: "warehouses/w/projects/p",
+    folder: "",
+    name: "Layout",
+    permission: "PROJECT_WRITE",
+    baseline: {
+      data: layoutData("baseline"),
+      savedAt: ts("2024-01-01T00:00:00.000Z"),
+      modifier: undefined,
+      modifierNickname: undefined,
+    },
+    working: undefined,
+    syncInfo: {
+      status: "tracked",
+      lastRemoteSavedAt: ts("2024-01-01T00:00:00.000Z"),
+      lastRemoteUpdatedAt: ts("2024-01-01T00:00:00.000Z"),
+    },
+  };
+}
+
+function makeRemoteProjectLayout(id: LayoutID): RemoteLayout {
+  return {
+    id,
+    parent: "warehouses/w/projects/p",
+    folder: "",
+    name: "Layout",
+    permission: "PROJECT_WRITE",
+    data: layoutData("baseline"),
+    savedAt: ts("2024-01-01T00:00:00.000Z"),
+    updatedAt: ts("2024-01-01T00:00:00.000Z"),
+    modifier: undefined,
+    modifierNickname: undefined,
+  };
+}
+
+describe("CoSceneLayoutManager project concurrency", () => {
+  it("preserves newer working data when it changes during metadata update", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const manager = new CoSceneLayoutManager({
+      local: localStorage,
+      remote: remoteStorage,
+      currentUser: undefined,
+    });
+    manager.setOnline(true);
+
+    const id = layoutId("warehouses/w/projects/p/layouts/1");
+    await localStorage.put(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      makeProjectLayout(id),
+    );
+    remoteStorage.layouts.set(id, makeRemoteProjectLayout(id));
+    remoteStorage.updateLayout.mockImplementationOnce(async (params: UpdateLayoutParams) => {
+      await manager.updateLayout({ id, data: layoutData("newer-working") });
+      return await applyRemoteUpdate(remoteStorage, params);
+    });
+
+    const result = await manager.updateLayout({ id, name: "Renamed" });
+
+    expect(result?.name).toEqual("Renamed");
+    expect(result?.baseline.data).toEqual(layoutData("baseline"));
+    expect(result?.working?.data).toEqual(layoutData("newer-working"));
+    expect(result?.syncInfo?.status).toEqual("tracked");
+    expect(remoteStorage.layouts.get(id)?.name).toEqual("Renamed");
+  });
+});

--- a/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.test.ts
+++ b/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.test.ts
@@ -1005,6 +1005,34 @@ describe("CoSceneLayoutManager", () => {
     expect(localLayout?.syncInfo?.lastRemoteUpdatedAt).toEqual(ts("2024-01-01T00:00:02.000Z"));
   });
 
+  it("notifies delete when reverting the draft of a remotely deleted layout", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const manager = makeManager({ localStorage, remoteStorage });
+    const id = layoutId("users/u/layouts/1");
+    await localStorage.put(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      makeLocalLayout({
+        id,
+        syncStatus: "remotely-deleted",
+        working: {
+          data: layoutData("local-draft"),
+          savedAt: ts("2024-01-01T00:00:01.000Z"),
+        },
+      }),
+    );
+    const events: LayoutManagerChangeEvent[] = [];
+    manager.on("change", (event) => {
+      events.push(event);
+    });
+
+    await manager.revertLayout({ id });
+    await Promise.resolve();
+
+    expect(events).toContainEqual({ type: "delete", layoutId: id });
+    expect(await manager.getLayout({ id })).toBeUndefined();
+  });
+
   it("does not emit delete events for backup-only personal layout cleanup", async () => {
     const localStorage = new MemoryLayoutStorage();
     const remoteStorage = new MemoryRemoteLayoutStorage();
@@ -1055,6 +1083,57 @@ describe("CoSceneLayoutManager", () => {
         updatedAt: ts("2024-01-01T00:00:00.000Z"),
       }),
     );
+    remoteStorage.layouts.set(
+      id,
+      makeRemoteLayout({
+        id,
+        name: "Remote current",
+        data: layoutData("remote-current"),
+        savedAt: ts("2024-01-01T00:00:10.000Z"),
+        updatedAt: ts("2024-01-01T00:00:10.000Z"),
+      }),
+    );
+
+    await manager.syncWithRemote(new AbortController().signal);
+
+    const backupLayout = await localStorage.get(CoSceneLayoutManager.LOCAL_STORAGE_NAMESPACE, id);
+    expect(backupLayout?.name).toEqual("Remote current");
+    expect(backupLayout?.baseline.data).toEqual(layoutData("remote-current"));
+    expect(backupLayout?.syncInfo).toEqual({
+      status: "tracked",
+      lastRemoteSavedAt: ts("2024-01-01T00:00:10.000Z"),
+      lastRemoteUpdatedAt: ts("2024-01-01T00:00:10.000Z"),
+    });
+  });
+
+  it("refreshes existing offline backups when a remote personal layout baseline changes", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const id = layoutId("users/u/layouts/1");
+    remoteStorage.layouts.set(
+      id,
+      makeRemoteLayout({
+        id,
+        name: "Primary old",
+        data: layoutData("primary-old"),
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:00.000Z"),
+      }),
+    );
+    const manager = makeManager({ localStorage, remoteStorage });
+    const cachedPrimary = await manager.getLayout({ id });
+    expect(cachedPrimary?.baseline.data).toEqual(layoutData("primary-old"));
+    await localStorage.put(
+      CoSceneLayoutManager.LOCAL_STORAGE_NAMESPACE,
+      makeLocalLayout({
+        id,
+        name: "Backup older",
+        data: layoutData("backup-older"),
+        savedAt: ts("2023-12-31T00:00:00.000Z"),
+        updatedAt: ts("2023-12-31T00:00:00.000Z"),
+      }),
+    );
+    remoteStorage.layouts.clear();
     remoteStorage.layouts.set(
       id,
       makeRemoteLayout({

--- a/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.test.ts
+++ b/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.test.ts
@@ -519,6 +519,36 @@ describe("CoSceneLayoutManager", () => {
     expect(remoteStorage.layouts.has(id)).toBe(false);
   });
 
+  it("deletes a stale project layout locally when the remote layout is already absent", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const manager = makeManager({ localStorage, remoteStorage });
+    const id = layoutId("warehouses/w/projects/p/layouts/1");
+    await localStorage.put(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      makeLocalLayout({
+        id,
+        parent: "warehouses/w/projects/p",
+        permission: "PROJECT_WRITE",
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:00.000Z"),
+      }),
+    );
+
+    await manager.deleteLayout({ id });
+
+    expect(
+      await localStorage.get(
+        `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+        id,
+      ),
+    ).toBeUndefined();
+    expect(remoteStorage.deleteLayout).toHaveBeenCalledWith(id, {
+      expectedSavedAt: ts("2024-01-01T00:00:00.000Z"),
+      expectedUpdatedAt: ts("2024-01-01T00:00:00.000Z"),
+    });
+  });
+
   it("does not delete local layouts when remote list fails", async () => {
     const localStorage = new MemoryLayoutStorage();
     const remoteStorage = new MemoryRemoteLayoutStorage();
@@ -803,6 +833,60 @@ describe("CoSceneLayoutManager", () => {
     expect(remoteStorage.saveNewLayout).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps later personal saves queued after an updated layout finishes uploading", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const manager = makeManager({ localStorage, remoteStorage });
+    const id = layoutId("users/u/layouts/1");
+    await localStorage.put(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      makeLocalLayout({
+        id,
+        data: layoutData("first-save"),
+        syncStatus: "updated",
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:00.000Z"),
+      }),
+    );
+    remoteStorage.layouts.set(
+      id,
+      makeRemoteLayout({
+        id,
+        data: layoutData("remote-before"),
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:00.000Z"),
+      }),
+    );
+    remoteStorage.updateLayout.mockImplementationOnce(async (params) => {
+      await manager.overwriteLayout({ id, data: layoutData("second-save") });
+      const existing = remoteStorage.layouts.get(id);
+      if (!existing) {
+        return { status: "conflict" as const };
+      }
+      const updated = {
+        ...existing,
+        name: params.name ?? existing.name,
+        folder: params.folder ?? existing.folder,
+        data: params.data ?? existing.data,
+        savedAt: ts("2024-01-01T00:00:20.000Z"),
+        updatedAt: ts("2024-01-01T00:00:20.000Z"),
+      };
+      remoteStorage.layouts.set(id, clone(updated));
+      return { status: "success" as const, newLayout: clone(updated) };
+    });
+
+    await manager.syncWithRemote(new AbortController().signal);
+
+    const localLayout = await manager.getLayout({ id });
+    expect(remoteStorage.layouts.get(id)?.data).toEqual(layoutData("first-save"));
+    expect(localLayout?.baseline.data).toEqual(layoutData("second-save"));
+    expect(localLayout?.syncInfo).toEqual({
+      status: "updated",
+      lastRemoteSavedAt: ts("2024-01-01T00:00:20.000Z"),
+      lastRemoteUpdatedAt: ts("2024-01-01T00:00:20.000Z"),
+    });
+  });
+
   it("applies successful remote sync cleanup even when another remote operation fails", async () => {
     const localStorage = new MemoryLayoutStorage();
     const remoteStorage = new MemoryRemoteLayoutStorage();
@@ -955,6 +1039,45 @@ describe("CoSceneLayoutManager", () => {
     ).toBeUndefined();
   });
 
+  it("refreshes existing offline backups when caching a remote personal layout", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const manager = makeManager({ localStorage, remoteStorage });
+    const id = layoutId("users/u/layouts/1");
+    await manager.getLayouts();
+    await localStorage.put(
+      CoSceneLayoutManager.LOCAL_STORAGE_NAMESPACE,
+      makeLocalLayout({
+        id,
+        name: "Stale backup",
+        data: layoutData("stale-backup"),
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:00.000Z"),
+      }),
+    );
+    remoteStorage.layouts.set(
+      id,
+      makeRemoteLayout({
+        id,
+        name: "Remote current",
+        data: layoutData("remote-current"),
+        savedAt: ts("2024-01-01T00:00:10.000Z"),
+        updatedAt: ts("2024-01-01T00:00:10.000Z"),
+      }),
+    );
+
+    await manager.syncWithRemote(new AbortController().signal);
+
+    const backupLayout = await localStorage.get(CoSceneLayoutManager.LOCAL_STORAGE_NAMESPACE, id);
+    expect(backupLayout?.name).toEqual("Remote current");
+    expect(backupLayout?.baseline.data).toEqual(layoutData("remote-current"));
+    expect(backupLayout?.syncInfo).toEqual({
+      status: "tracked",
+      lastRemoteSavedAt: ts("2024-01-01T00:00:10.000Z"),
+      lastRemoteUpdatedAt: ts("2024-01-01T00:00:10.000Z"),
+    });
+  });
+
   it("marks a remotely deleted project layout with working data and preserves the draft", async () => {
     const localStorage = new MemoryLayoutStorage();
     const remoteStorage = new MemoryRemoteLayoutStorage();
@@ -1019,6 +1142,61 @@ describe("CoSceneLayoutManager", () => {
     await manager.syncWithRemote(new AbortController().signal);
 
     expect(remoteStorage.updateLayout).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps local metadata changes queued after refreshing a conflicted personal layout", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const manager = makeManager({ localStorage, remoteStorage });
+    const id = layoutId("users/u/layouts/1");
+    const localLayout = makeLocalLayout({
+      id,
+      name: "Local rename",
+      folder: "Local folder",
+      data: layoutData("shared-data"),
+      syncStatus: "updated",
+      savedAt: ts("2024-01-01T00:00:01.000Z"),
+      updatedAt: ts("2024-01-01T00:00:00.000Z"),
+    });
+    await localStorage.put(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      {
+        ...localLayout,
+        syncInfo: {
+          status: "updated",
+          lastRemoteSavedAt: ts("2024-01-01T00:00:00.000Z"),
+          lastRemoteUpdatedAt: ts("2024-01-01T00:00:00.000Z"),
+        },
+      },
+    );
+    remoteStorage.layouts.set(
+      id,
+      makeRemoteLayout({
+        id,
+        name: "Remote name",
+        folder: "",
+        data: layoutData("shared-data"),
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:02.000Z"),
+      }),
+    );
+
+    await manager.syncWithRemote(new AbortController().signal);
+
+    const localAfterConflict = await manager.getLayout({ id });
+    expect(localAfterConflict?.name).toEqual("Local rename");
+    expect(localAfterConflict?.folder).toEqual("Local folder");
+    expect(localAfterConflict?.baseline.data).toEqual(layoutData("shared-data"));
+    expect(localAfterConflict?.syncInfo).toEqual({
+      status: "updated",
+      lastRemoteSavedAt: ts("2024-01-01T00:00:00.000Z"),
+      lastRemoteUpdatedAt: ts("2024-01-01T00:00:02.000Z"),
+    });
+
+    await manager.syncWithRemote(new AbortController().signal);
+
+    expect(remoteStorage.layouts.get(id)?.name).toEqual("Local rename");
+    expect(remoteStorage.layouts.get(id)?.folder).toEqual("Local folder");
   });
 
   it("does not delete a project layout when remote timestamps changed", async () => {

--- a/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.test.ts
+++ b/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.test.ts
@@ -1157,6 +1157,42 @@ describe("CoSceneLayoutManager", () => {
     });
   });
 
+  it("deletes stale offline backups when a remote personal layout is deleted", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const id = layoutId("users/u/layouts/1");
+    remoteStorage.layouts.set(
+      id,
+      makeRemoteLayout({
+        id,
+        name: "Primary old",
+        data: layoutData("primary-old"),
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:00.000Z"),
+      }),
+    );
+    const manager = makeManager({ localStorage, remoteStorage });
+    const cachedPrimary = await manager.getLayout({ id });
+    expect(cachedPrimary?.baseline.data).toEqual(layoutData("primary-old"));
+    await localStorage.put(
+      CoSceneLayoutManager.LOCAL_STORAGE_NAMESPACE,
+      makeLocalLayout({
+        id,
+        name: "Backup older",
+        data: layoutData("backup-older"),
+        savedAt: ts("2023-12-31T00:00:00.000Z"),
+        updatedAt: ts("2023-12-31T00:00:00.000Z"),
+      }),
+    );
+    remoteStorage.layouts.clear();
+
+    await manager.syncWithRemote(new AbortController().signal);
+
+    expect(
+      await localStorage.get(CoSceneLayoutManager.LOCAL_STORAGE_NAMESPACE, id),
+    ).toBeUndefined();
+  });
+
   it("marks a remotely deleted project layout with working data and preserves the draft", async () => {
     const localStorage = new MemoryLayoutStorage();
     const remoteStorage = new MemoryRemoteLayoutStorage();

--- a/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.test.ts
+++ b/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.test.ts
@@ -366,7 +366,7 @@ describe("CoSceneLayoutManager", () => {
     const localLayout = await manager.getLayout({ id });
     expect(localLayout?.baseline.data).toEqual(layoutData("baseline"));
     expect(localLayout?.working?.data).toEqual(layoutData("local-working"));
-    expect(remoteStorage.updateLayout).not.toHaveBeenCalled();
+    expect(remoteStorage.updateLayout).toHaveBeenCalledTimes(1);
   });
 
   it("persists explicit project overwrite data as working before reporting a remote conflict", async () => {
@@ -404,7 +404,7 @@ describe("CoSceneLayoutManager", () => {
     const localLayout = await manager.getLayout({ id });
     expect(localLayout?.baseline.data).toEqual(layoutData("baseline"));
     expect(localLayout?.working?.data).toEqual(layoutData("current-memory"));
-    expect(remoteStorage.updateLayout).not.toHaveBeenCalled();
+    expect(remoteStorage.updateLayout).toHaveBeenCalledTimes(1);
   });
 
   it("keeps project data autosave local instead of updating remote metadata", async () => {
@@ -425,6 +425,97 @@ describe("CoSceneLayoutManager", () => {
 
     expect(result?.working?.data).toEqual(layoutData("draft"));
     expect(remoteStorage.updateLayout).not.toHaveBeenCalled();
+  });
+
+  it("preserves newer project working data when it changes during overwrite", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const manager = makeManager({ localStorage, remoteStorage });
+    const id = layoutId("warehouses/w/projects/p/layouts/1");
+    await localStorage.put(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      makeLocalLayout({
+        id,
+        parent: "warehouses/w/projects/p",
+        permission: "PROJECT_WRITE",
+        data: layoutData("baseline"),
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:00.000Z"),
+      }),
+    );
+    remoteStorage.layouts.set(
+      id,
+      makeRemoteLayout({
+        id,
+        parent: "warehouses/w/projects/p",
+        permission: "PROJECT_WRITE",
+        data: layoutData("baseline"),
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:00.000Z"),
+      }),
+    );
+    remoteStorage.updateLayout.mockImplementationOnce(async (params) => {
+      await manager.updateLayout({ id, data: layoutData("newer-working") });
+      const existing = remoteStorage.layouts.get(id);
+      if (!existing) {
+        return { status: "conflict" as const };
+      }
+      const updated = {
+        ...existing,
+        data: params.data ?? existing.data,
+        savedAt: ts("2024-01-01T00:00:20.000Z"),
+        updatedAt: ts("2024-01-01T00:00:20.000Z"),
+      };
+      remoteStorage.layouts.set(id, clone(updated));
+      return { status: "success" as const, newLayout: clone(updated) };
+    });
+
+    const result = await manager.overwriteLayout({ id, data: layoutData("save-request") });
+
+    expect(result.baseline.data).toEqual(layoutData("save-request"));
+    expect(result.working?.data).toEqual(layoutData("newer-working"));
+    expect(result.syncInfo?.status).toEqual("tracked");
+  });
+
+  it("does not delete a project layout when local data changes during remote delete", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const manager = makeManager({ localStorage, remoteStorage });
+    const id = layoutId("warehouses/w/projects/p/layouts/1");
+    await localStorage.put(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      makeLocalLayout({
+        id,
+        parent: "warehouses/w/projects/p",
+        permission: "PROJECT_WRITE",
+        data: layoutData("baseline"),
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:00.000Z"),
+      }),
+    );
+    remoteStorage.layouts.set(
+      id,
+      makeRemoteLayout({
+        id,
+        parent: "warehouses/w/projects/p",
+        permission: "PROJECT_WRITE",
+        data: layoutData("baseline"),
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:00.000Z"),
+      }),
+    );
+    remoteStorage.deleteLayout.mockImplementationOnce(async (deleteId) => {
+      await manager.updateLayout({ id, data: layoutData("newer-working") });
+      remoteStorage.layouts.delete(deleteId);
+      return true;
+    });
+
+    await manager.deleteLayout({ id });
+
+    const localLayout = await manager.getLayout({ id });
+    expect(localLayout?.baseline.data).toEqual(layoutData("baseline"));
+    expect(localLayout?.working?.data).toEqual(layoutData("newer-working"));
+    expect(remoteStorage.layouts.has(id)).toBe(false);
   });
 
   it("does not delete local layouts when remote list fails", async () => {
@@ -462,7 +553,71 @@ describe("CoSceneLayoutManager", () => {
     await manager.syncWithRemote(new AbortController().signal);
 
     const localLayout = await manager.getLayout({ id });
+    expect(localLayout?.syncInfo?.status).toEqual("remotely-deleted");
     expect(localLayout?.working?.data).toEqual(layoutData("draft-during-sync"));
+  });
+
+  it("recreates a remotely deleted personal layout after the user saves its draft", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const manager = makeManager({ localStorage, remoteStorage });
+    const id = layoutId("users/u/layouts/1");
+    await localStorage.put(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      makeLocalLayout({
+        id,
+        working: {
+          data: layoutData("local-draft"),
+          savedAt: ts("2024-01-01T00:00:01.000Z"),
+        },
+      }),
+    );
+
+    await manager.syncWithRemote(new AbortController().signal);
+    await manager.overwriteLayout({ id, data: layoutData("local-draft") });
+    await manager.syncWithRemote(new AbortController().signal);
+
+    const localLayout = await manager.getLayout({ id });
+    expect(remoteStorage.saveNewLayout).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id,
+        data: layoutData("local-draft"),
+        permission: "PERSONAL_WRITE",
+      }),
+    );
+    expect(remoteStorage.layouts.get(id)?.data).toEqual(layoutData("local-draft"));
+    expect(localLayout?.syncInfo?.status).toEqual("tracked");
+    expect(localLayout?.working).toBeUndefined();
+  });
+
+  it("reuploads an updated personal layout when the remote copy is missing", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const manager = makeManager({ localStorage, remoteStorage });
+    const id = layoutId("users/u/layouts/1");
+    await localStorage.put(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      makeLocalLayout({
+        id,
+        data: layoutData("locally-saved"),
+        syncStatus: "updated",
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:00.000Z"),
+      }),
+    );
+
+    await manager.syncWithRemote(new AbortController().signal);
+
+    const localLayout = await manager.getLayout({ id });
+    expect(remoteStorage.saveNewLayout).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id,
+        data: layoutData("locally-saved"),
+        permission: "PERSONAL_WRITE",
+      }),
+    );
+    expect(remoteStorage.layouts.get(id)?.data).toEqual(layoutData("locally-saved"));
+    expect(localLayout?.syncInfo?.status).toEqual("tracked");
   });
 
   it("does not overwrite a locally updated baseline with a stale sync update-baseline operation", async () => {
@@ -711,7 +866,7 @@ describe("CoSceneLayoutManager", () => {
     await expect(manager.deleteLayout({ id })).rejects.toThrow("changed on the server");
 
     expect(await manager.getLayout({ id })).toBeDefined();
-    expect(remoteStorage.deleteLayout).not.toHaveBeenCalled();
+    expect(remoteStorage.deleteLayout).toHaveBeenCalledTimes(1);
   });
 
   it("passes expected remote timestamps when deleting a project layout", async () => {

--- a/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.test.ts
+++ b/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.test.ts
@@ -7,6 +7,7 @@
 
 import { LayoutID } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
+import { LayoutManagerChangeEvent } from "@foxglove/studio-base/services/CoSceneILayoutManager";
 import {
   ILayoutStorage,
   ISO8601Timestamp,
@@ -620,6 +621,60 @@ describe("CoSceneLayoutManager", () => {
     expect(localLayout?.syncInfo?.status).toEqual("tracked");
   });
 
+  it("preserves remote timestamps when a new personal layout is deleted during upload", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const manager = makeManager({ localStorage, remoteStorage });
+    const id = layoutId("users/u/layouts/1");
+    await localStorage.put(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      makeLocalLayout({
+        id,
+        data: layoutData("new-layout"),
+        syncStatus: "new",
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: undefined,
+      }),
+    );
+    remoteStorage.saveNewLayout.mockImplementationOnce(async (params) => {
+      await manager.deleteLayout({ id });
+      const remoteLayout = makeRemoteLayout({
+        id: params.id ?? id,
+        parent: params.parent,
+        folder: params.folder,
+        name: params.name,
+        permission: params.permission,
+        data: params.data,
+        savedAt: ts("2024-01-01T00:00:10.000Z"),
+        updatedAt: ts("2024-01-01T00:00:10.000Z"),
+      });
+      remoteStorage.layouts.set(remoteLayout.id, clone(remoteLayout));
+      return clone(remoteLayout);
+    });
+
+    await manager.syncWithRemote(new AbortController().signal);
+
+    const tombstone = await localStorage.get(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      id,
+    );
+    expect(tombstone?.syncInfo).toEqual({
+      status: "locally-deleted",
+      lastRemoteSavedAt: ts("2024-01-01T00:00:10.000Z"),
+      lastRemoteUpdatedAt: ts("2024-01-01T00:00:10.000Z"),
+    });
+
+    await manager.syncWithRemote(new AbortController().signal);
+
+    expect(remoteStorage.layouts.has(id)).toBe(false);
+    expect(
+      await localStorage.get(
+        `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+        id,
+      ),
+    ).toBeUndefined();
+  });
+
   it("does not overwrite a locally updated baseline with a stale sync update-baseline operation", async () => {
     const localStorage = new MemoryLayoutStorage();
     const remoteStorage = new MemoryRemoteLayoutStorage();
@@ -653,6 +708,59 @@ describe("CoSceneLayoutManager", () => {
     const localLayout = await manager.getLayout({ id });
     expect(localLayout?.baseline.data).toEqual(layoutData("local-saved-during-sync"));
     expect(localLayout?.syncInfo?.status).toEqual("updated");
+  });
+
+  it("notifies listeners after partial remote sync cleanup before reporting a conflict", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const manager = makeManager({ localStorage, remoteStorage });
+    const uploadedId = layoutId("users/u/layouts/uploaded");
+    const conflictId = layoutId("users/u/layouts/conflict");
+    await localStorage.put(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      makeLocalLayout({
+        id: uploadedId,
+        data: layoutData("new-local"),
+        syncStatus: "new",
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: undefined,
+      }),
+    );
+    await localStorage.put(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      makeLocalLayout({
+        id: conflictId,
+        data: layoutData("local-update"),
+        syncStatus: "updated",
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:00.000Z"),
+      }),
+    );
+    remoteStorage.layouts.set(
+      conflictId,
+      makeRemoteLayout({
+        id: conflictId,
+        data: layoutData("remote-update"),
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:02.000Z"),
+      }),
+    );
+    remoteStorage.updateLayout.mockRejectedValueOnce(new Error("remote down"));
+    const events: LayoutManagerChangeEvent[] = [];
+    manager.on("change", (event) => {
+      events.push(event);
+    });
+
+    await expect(manager.syncWithRemote(new AbortController().signal)).rejects.toThrow(
+      "remote down",
+    );
+    await Promise.resolve();
+
+    const uploadedLayout = await manager.getLayout({ id: uploadedId });
+    expect(uploadedLayout?.syncInfo?.status).toEqual("tracked");
+    expect(
+      events.some((event) => event.type === "change" && event.updatedLayout == undefined),
+    ).toBe(true);
   });
 
   it("marks newly uploaded layouts as updated when local metadata changes during upload", async () => {
@@ -728,9 +836,10 @@ describe("CoSceneLayoutManager", () => {
         updatedAt: ts("2024-01-01T00:00:02.000Z"),
       }),
     );
+    remoteStorage.updateLayout.mockRejectedValueOnce(new Error("remote down"));
 
     await expect(manager.syncWithRemote(new AbortController().signal)).rejects.toThrow(
-      "changed on the server",
+      "remote down",
     );
 
     const uploadedLayout = await manager.getLayout({ id: newId });
@@ -812,6 +921,40 @@ describe("CoSceneLayoutManager", () => {
     expect(localLayout?.syncInfo?.lastRemoteUpdatedAt).toEqual(ts("2024-01-01T00:00:02.000Z"));
   });
 
+  it("does not emit delete events for backup-only personal layout cleanup", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const manager = makeManager({ localStorage, remoteStorage });
+    const id = layoutId("users/u/layouts/1");
+    const layout = makeLocalLayout({ id });
+    await localStorage.put(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      layout,
+    );
+    await localStorage.put(CoSceneLayoutManager.LOCAL_STORAGE_NAMESPACE, layout);
+    remoteStorage.getLayouts.mockImplementationOnce(async () => {
+      await manager.updateLayout({ id, data: layoutData("draft-during-sync") });
+      return [];
+    });
+    const deleteEvents: LayoutManagerChangeEvent[] = [];
+    manager.on("change", (event) => {
+      if (event.type === "delete") {
+        deleteEvents.push(event);
+      }
+    });
+
+    await manager.syncWithRemote(new AbortController().signal);
+    await Promise.resolve();
+
+    const primaryLayout = await manager.getLayout({ id });
+    expect(primaryLayout?.syncInfo?.status).toEqual("remotely-deleted");
+    expect(primaryLayout?.working?.data).toEqual(layoutData("draft-during-sync"));
+    expect(deleteEvents).toEqual([]);
+    expect(
+      await localStorage.get(CoSceneLayoutManager.LOCAL_STORAGE_NAMESPACE, id),
+    ).toBeUndefined();
+  });
+
   it("marks a remotely deleted project layout with working data and preserves the draft", async () => {
     const localStorage = new MemoryLayoutStorage();
     const remoteStorage = new MemoryRemoteLayoutStorage();
@@ -835,6 +978,47 @@ describe("CoSceneLayoutManager", () => {
     const localLayout = await manager.getLayout({ id });
     expect(localLayout?.syncInfo?.status).toEqual("remotely-deleted");
     expect(localLayout?.working?.data).toEqual(layoutData("local-draft"));
+  });
+
+  it("refreshes a conflicted personal layout and keeps the local save as a draft", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const manager = makeManager({ localStorage, remoteStorage });
+    const id = layoutId("users/u/layouts/1");
+    await localStorage.put(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      makeLocalLayout({
+        id,
+        data: layoutData("local-saved"),
+        syncStatus: "updated",
+        savedAt: ts("2024-01-01T00:00:01.000Z"),
+        updatedAt: ts("2024-01-01T00:00:00.000Z"),
+      }),
+    );
+    remoteStorage.layouts.set(
+      id,
+      makeRemoteLayout({
+        id,
+        data: layoutData("remote-saved"),
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:02.000Z"),
+      }),
+    );
+
+    await manager.syncWithRemote(new AbortController().signal);
+
+    const localLayout = await manager.getLayout({ id });
+    expect(localLayout?.baseline.data).toEqual(layoutData("remote-saved"));
+    expect(localLayout?.working?.data).toEqual(layoutData("local-saved"));
+    expect(localLayout?.syncInfo).toEqual({
+      status: "tracked",
+      lastRemoteSavedAt: ts("2024-01-01T00:00:00.000Z"),
+      lastRemoteUpdatedAt: ts("2024-01-01T00:00:02.000Z"),
+    });
+
+    await manager.syncWithRemote(new AbortController().signal);
+
+    expect(remoteStorage.updateLayout).toHaveBeenCalledTimes(1);
   });
 
   it("does not delete a project layout when remote timestamps changed", async () => {

--- a/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.test.ts
+++ b/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.test.ts
@@ -1,0 +1,816 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { LayoutID } from "@foxglove/studio-base/context/CurrentLayoutContext";
+import { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
+import {
+  ILayoutStorage,
+  ISO8601Timestamp,
+  Layout,
+  LayoutHistory,
+  LayoutPermission,
+} from "@foxglove/studio-base/services/CoSceneILayoutStorage";
+import {
+  IRemoteLayoutStorage,
+  RemoteLayout,
+} from "@foxglove/studio-base/services/CoSceneIRemoteLayoutStorage";
+import CoSceneLayoutManager from "@foxglove/studio-base/services/LayoutManager/CoSceneLayoutManager";
+
+function clone<T>(value: T): T {
+  return structuredClone(value);
+}
+
+const initialData: LayoutData = {
+  layout: "Panel!1",
+  configById: { "Panel!1": { value: "initial" } },
+  globalVariables: {},
+  userNodes: {},
+};
+
+function layoutData(value: string): LayoutData {
+  return {
+    layout: "Panel!1",
+    configById: { "Panel!1": { value } },
+    globalVariables: {},
+    userNodes: {},
+  };
+}
+
+function ts(value: string): ISO8601Timestamp {
+  return value as ISO8601Timestamp;
+}
+
+function layoutId(value: string): LayoutID {
+  return value as LayoutID;
+}
+
+class MemoryLayoutStorage implements ILayoutStorage {
+  public layouts = new Map<string, Layout>();
+  public history = new Map<string, LayoutHistory>();
+
+  #layoutKey(namespace: string, id: LayoutID): string {
+    return `${namespace}:${id}`;
+  }
+
+  #historyKey(namespace: string, parent: string): string {
+    return `${namespace}:${parent}`;
+  }
+
+  public async list(namespace: string): Promise<readonly Layout[]> {
+    const prefix = `${namespace}:`;
+    return [...this.layouts.entries()]
+      .filter(([key]) => key.startsWith(prefix))
+      .map(([, layout]) => clone(layout));
+  }
+
+  public async listByParent(namespace: string, parent: string): Promise<readonly Layout[]> {
+    return (await this.list(namespace)).filter((layout) => layout.parent === parent);
+  }
+
+  public async get(namespace: string, id: LayoutID): Promise<Layout | undefined> {
+    const layout = this.layouts.get(this.#layoutKey(namespace, id));
+    return layout == undefined ? undefined : clone(layout);
+  }
+
+  public async put(namespace: string, layout: Layout): Promise<Layout> {
+    this.layouts.set(this.#layoutKey(namespace, layout.id), clone(layout));
+    return clone(layout);
+  }
+
+  public async delete(namespace: string, id: LayoutID): Promise<void> {
+    this.layouts.delete(this.#layoutKey(namespace, id));
+  }
+
+  public async importLayouts({
+    fromNamespace,
+    toNamespace,
+  }: {
+    fromNamespace: string;
+    toNamespace: string;
+  }): Promise<void> {
+    for (const layout of await this.list(fromNamespace)) {
+      await this.put(toNamespace, layout);
+      await this.delete(fromNamespace, layout.id);
+    }
+  }
+
+  public async getHistory(namespace: string, parent: string): Promise<Layout | undefined> {
+    const history = this.history.get(this.#historyKey(namespace, parent));
+    return history == undefined ? undefined : await this.get(namespace, history.id);
+  }
+
+  public async putHistory(namespace: string, history: LayoutHistory): Promise<LayoutHistory> {
+    this.history.set(this.#historyKey(namespace, history.parent), clone(history));
+    return clone(history);
+  }
+}
+
+class MemoryRemoteLayoutStorage implements IRemoteLayoutStorage {
+  public namespace = "remote-user";
+  public projectName = "warehouses/w/projects/p";
+  public userName = "users/u";
+  public layouts = new Map<LayoutID, RemoteLayout>();
+
+  public getLayouts = jest.fn(async () => [...this.layouts.values()].map(clone));
+  public getLayout = jest.fn(async (id: LayoutID) => {
+    const layout = this.layouts.get(id);
+    return layout == undefined ? undefined : clone(layout);
+  });
+  public saveNewLayout = jest.fn(
+    async ({
+      id,
+      parent,
+      folder,
+      name,
+      data,
+      permission,
+    }: {
+      id: LayoutID | undefined;
+      parent: string;
+      folder: string;
+      name: string;
+      data: LayoutData;
+      permission: LayoutPermission;
+    }) => {
+      const remoteLayout = makeRemoteLayout({
+        id: id ?? layoutId(`${parent}/layouts/new`),
+        parent,
+        folder,
+        name,
+        permission,
+        data,
+        savedAt: ts("2024-01-01T00:00:10.000Z"),
+        updatedAt: ts("2024-01-01T00:00:10.000Z"),
+      });
+      this.layouts.set(remoteLayout.id, clone(remoteLayout));
+      return clone(remoteLayout);
+    },
+  );
+  public updateLayout = jest.fn(
+    async ({
+      id,
+      name,
+      folder,
+      data,
+      expectedSavedAt,
+      expectedUpdatedAt,
+    }: {
+      id: LayoutID;
+      parent: string;
+      name?: string;
+      folder?: string;
+      data?: LayoutData;
+      permission?: LayoutPermission;
+      expectedSavedAt?: ISO8601Timestamp | undefined;
+      expectedUpdatedAt?: ISO8601Timestamp | undefined;
+    }) => {
+      const existing = this.layouts.get(id);
+      if (!existing) {
+        return { status: "conflict" as const };
+      }
+      if (existing.savedAt !== expectedSavedAt || existing.updatedAt !== expectedUpdatedAt) {
+        return { status: "conflict" as const };
+      }
+
+      const updated = {
+        ...existing,
+        name: name ?? existing.name,
+        folder: folder ?? existing.folder,
+        data: data ?? existing.data,
+        savedAt: ts("2024-01-01T00:00:20.000Z"),
+        updatedAt: ts("2024-01-01T00:00:20.000Z"),
+      };
+      this.layouts.set(id, clone(updated));
+      return { status: "success" as const, newLayout: clone(updated) };
+    },
+  );
+  public deleteLayout = jest.fn(
+    async (
+      id: LayoutID,
+      options?: {
+        expectedSavedAt?: ISO8601Timestamp | undefined;
+        expectedUpdatedAt?: ISO8601Timestamp | undefined;
+      },
+    ) => {
+      const existing = this.layouts.get(id);
+      if (!existing) {
+        return false;
+      }
+      if (
+        options &&
+        (existing.savedAt !== options.expectedSavedAt ||
+          existing.updatedAt !== options.expectedUpdatedAt)
+      ) {
+        throw new Error(`Layout ${id} has changed on the server; local changes were not saved.`);
+      }
+      return this.layouts.delete(id);
+    },
+  );
+}
+
+function makeLocalLayout({
+  id = layoutId("users/u/layouts/1"),
+  parent = "users/u",
+  folder = "",
+  name = "Layout",
+  permission = "PERSONAL_WRITE",
+  data = initialData,
+  savedAt = ts("2024-01-01T00:00:00.000Z"),
+  updatedAt = ts("2024-01-01T00:00:00.000Z"),
+  working,
+  syncStatus = "tracked",
+}: {
+  id?: LayoutID;
+  parent?: string;
+  folder?: string;
+  name?: string;
+  permission?: LayoutPermission;
+  data?: LayoutData;
+  savedAt?: ISO8601Timestamp;
+  updatedAt?: ISO8601Timestamp;
+  working?: Layout["working"];
+  syncStatus?: NonNullable<Layout["syncInfo"]>["status"];
+} = {}): Layout {
+  return {
+    id,
+    parent,
+    folder,
+    name,
+    permission,
+    baseline: {
+      data,
+      savedAt,
+      modifier: undefined,
+      modifierNickname: undefined,
+    },
+    working,
+    syncInfo: {
+      status: syncStatus,
+      lastRemoteSavedAt: savedAt,
+      lastRemoteUpdatedAt: updatedAt,
+    },
+  };
+}
+
+function makeRemoteLayout({
+  id = layoutId("users/u/layouts/1"),
+  parent = "users/u",
+  permission = "PERSONAL_WRITE",
+  data = initialData,
+  savedAt = ts("2024-01-01T00:00:00.000Z"),
+  updatedAt = ts("2024-01-01T00:00:00.000Z"),
+  folder = "",
+  name = "Layout",
+}: {
+  id?: LayoutID;
+  parent?: string;
+  permission?: LayoutPermission;
+  data?: LayoutData;
+  savedAt?: ISO8601Timestamp;
+  updatedAt?: ISO8601Timestamp;
+  folder?: string;
+  name?: string;
+} = {}): RemoteLayout {
+  return {
+    id,
+    parent,
+    folder,
+    name,
+    permission,
+    data,
+    savedAt,
+    updatedAt,
+    modifier: undefined,
+    modifierNickname: undefined,
+  };
+}
+
+function makeManager({
+  localStorage,
+  remoteStorage,
+}: {
+  localStorage: MemoryLayoutStorage;
+  remoteStorage?: MemoryRemoteLayoutStorage;
+}): CoSceneLayoutManager {
+  const manager = new CoSceneLayoutManager({
+    local: localStorage,
+    remote: remoteStorage,
+    currentUser: undefined,
+  });
+  manager.setOnline(true);
+  return manager;
+}
+
+describe("CoSceneLayoutManager", () => {
+  it("overwrites with explicit in-memory data instead of stale working data", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const manager = makeManager({ localStorage });
+    const id = layoutId("layouts/1");
+    await localStorage.put(
+      CoSceneLayoutManager.LOCAL_STORAGE_NAMESPACE,
+      makeLocalLayout({
+        id,
+        parent: "",
+        working: {
+          data: layoutData("stale-working"),
+          savedAt: ts("2024-01-01T00:00:01.000Z"),
+        },
+        syncStatus: "new",
+      }),
+    );
+
+    const result = await manager.overwriteLayout({ id, data: layoutData("current-memory") });
+
+    expect(result.baseline.data).toEqual(layoutData("current-memory"));
+    expect(result.working).toBeUndefined();
+  });
+
+  it("keeps local working data when project overwrite sees a remote timestamp conflict", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const manager = makeManager({ localStorage, remoteStorage });
+    const id = layoutId("warehouses/w/projects/p/layouts/1");
+    await localStorage.put(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      makeLocalLayout({
+        id,
+        parent: "warehouses/w/projects/p",
+        permission: "PROJECT_WRITE",
+        data: layoutData("baseline"),
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:00.000Z"),
+        working: {
+          data: layoutData("local-working"),
+          savedAt: ts("2024-01-01T00:00:01.000Z"),
+        },
+      }),
+    );
+    remoteStorage.layouts.set(
+      id,
+      makeRemoteLayout({
+        id,
+        parent: "warehouses/w/projects/p",
+        permission: "PROJECT_WRITE",
+        data: layoutData("remote-changed"),
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:02.000Z"),
+      }),
+    );
+
+    await expect(manager.overwriteLayout({ id })).rejects.toThrow("changed on the server");
+
+    const localLayout = await manager.getLayout({ id });
+    expect(localLayout?.baseline.data).toEqual(layoutData("baseline"));
+    expect(localLayout?.working?.data).toEqual(layoutData("local-working"));
+    expect(remoteStorage.updateLayout).not.toHaveBeenCalled();
+  });
+
+  it("persists explicit project overwrite data as working before reporting a remote conflict", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const manager = makeManager({ localStorage, remoteStorage });
+    const id = layoutId("warehouses/w/projects/p/layouts/1");
+    await localStorage.put(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      makeLocalLayout({
+        id,
+        parent: "warehouses/w/projects/p",
+        permission: "PROJECT_WRITE",
+        data: layoutData("baseline"),
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:00.000Z"),
+      }),
+    );
+    remoteStorage.layouts.set(
+      id,
+      makeRemoteLayout({
+        id,
+        parent: "warehouses/w/projects/p",
+        permission: "PROJECT_WRITE",
+        data: layoutData("remote-changed"),
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:02.000Z"),
+      }),
+    );
+
+    await expect(
+      manager.overwriteLayout({ id, data: layoutData("current-memory") }),
+    ).rejects.toThrow("changed on the server");
+
+    const localLayout = await manager.getLayout({ id });
+    expect(localLayout?.baseline.data).toEqual(layoutData("baseline"));
+    expect(localLayout?.working?.data).toEqual(layoutData("current-memory"));
+    expect(remoteStorage.updateLayout).not.toHaveBeenCalled();
+  });
+
+  it("keeps project data autosave local instead of updating remote metadata", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const manager = makeManager({ localStorage, remoteStorage });
+    const id = layoutId("warehouses/w/projects/p/layouts/1");
+    await localStorage.put(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      makeLocalLayout({
+        id,
+        parent: "warehouses/w/projects/p",
+        permission: "PROJECT_WRITE",
+      }),
+    );
+
+    const result = await manager.updateLayout({ id, data: layoutData("draft") });
+
+    expect(result?.working?.data).toEqual(layoutData("draft"));
+    expect(remoteStorage.updateLayout).not.toHaveBeenCalled();
+  });
+
+  it("does not delete local layouts when remote list fails", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const manager = makeManager({ localStorage, remoteStorage });
+    const id = layoutId("users/u/layouts/1");
+    await localStorage.put(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      makeLocalLayout({ id }),
+    );
+    remoteStorage.getLayouts.mockRejectedValueOnce(new Error("network down"));
+
+    await expect(manager.syncWithRemote(new AbortController().signal)).rejects.toThrow(
+      "network down",
+    );
+
+    expect(await manager.getLayout({ id })).toBeDefined();
+  });
+
+  it("does not delete a personal layout that gained working data during sync", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const manager = makeManager({ localStorage, remoteStorage });
+    const id = layoutId("users/u/layouts/1");
+    await localStorage.put(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      makeLocalLayout({ id }),
+    );
+    remoteStorage.getLayouts.mockImplementationOnce(async () => {
+      await manager.updateLayout({ id, data: layoutData("draft-during-sync") });
+      return [];
+    });
+
+    await manager.syncWithRemote(new AbortController().signal);
+
+    const localLayout = await manager.getLayout({ id });
+    expect(localLayout?.working?.data).toEqual(layoutData("draft-during-sync"));
+  });
+
+  it("does not overwrite a locally updated baseline with a stale sync update-baseline operation", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const manager = makeManager({ localStorage, remoteStorage });
+    const id = layoutId("users/u/layouts/1");
+    await localStorage.put(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      makeLocalLayout({
+        id,
+        data: layoutData("baseline"),
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:00.000Z"),
+      }),
+    );
+    remoteStorage.layouts.set(
+      id,
+      makeRemoteLayout({
+        id,
+        data: layoutData("remote"),
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:02.000Z"),
+      }),
+    );
+    remoteStorage.getLayouts.mockImplementationOnce(async () => {
+      await manager.overwriteLayout({ id, data: layoutData("local-saved-during-sync") });
+      return [...remoteStorage.layouts.values()].map(clone);
+    });
+
+    await manager.syncWithRemote(new AbortController().signal);
+
+    const localLayout = await manager.getLayout({ id });
+    expect(localLayout?.baseline.data).toEqual(layoutData("local-saved-during-sync"));
+    expect(localLayout?.syncInfo?.status).toEqual("updated");
+  });
+
+  it("marks newly uploaded layouts as updated when local metadata changes during upload", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const manager = makeManager({ localStorage, remoteStorage });
+    const id = layoutId("users/u/layouts/1");
+    await localStorage.put(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      makeLocalLayout({
+        id,
+        name: "Original",
+        syncStatus: "new",
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:00.000Z"),
+      }),
+    );
+    remoteStorage.saveNewLayout.mockImplementationOnce(async (params) => {
+      await manager.updateLayout({ id, name: "Renamed while uploading" });
+      const remoteLayout = makeRemoteLayout({
+        id: params.id ?? id,
+        parent: params.parent,
+        folder: params.folder,
+        name: params.name,
+        permission: params.permission,
+        data: params.data,
+        savedAt: ts("2024-01-01T00:00:10.000Z"),
+        updatedAt: ts("2024-01-01T00:00:10.000Z"),
+      });
+      remoteStorage.layouts.set(remoteLayout.id, clone(remoteLayout));
+      return clone(remoteLayout);
+    });
+
+    await manager.syncWithRemote(new AbortController().signal);
+
+    const localLayout = await manager.getLayout({ id });
+    expect(localLayout?.name).toEqual("Renamed while uploading");
+    expect(localLayout?.syncInfo?.status).toEqual("updated");
+    expect(localLayout?.syncInfo?.lastRemoteSavedAt).toEqual(ts("2024-01-01T00:00:10.000Z"));
+    expect(remoteStorage.saveNewLayout).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies successful remote sync cleanup even when another remote operation fails", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const manager = makeManager({ localStorage, remoteStorage });
+    const newId = layoutId("users/u/layouts/new");
+    const updatedId = layoutId("users/u/layouts/updated");
+    await localStorage.put(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      makeLocalLayout({
+        id: newId,
+        syncStatus: "new",
+        data: layoutData("new"),
+      }),
+    );
+    await localStorage.put(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      makeLocalLayout({
+        id: updatedId,
+        syncStatus: "updated",
+        data: layoutData("updated"),
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:00.000Z"),
+      }),
+    );
+    remoteStorage.layouts.set(
+      updatedId,
+      makeRemoteLayout({
+        id: updatedId,
+        data: layoutData("remote-updated"),
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:02.000Z"),
+      }),
+    );
+
+    await expect(manager.syncWithRemote(new AbortController().signal)).rejects.toThrow(
+      "changed on the server",
+    );
+
+    const uploadedLayout = await manager.getLayout({ id: newId });
+    const failedLayout = await manager.getLayout({ id: updatedId });
+    expect(uploadedLayout?.syncInfo?.status).toEqual("tracked");
+    expect(remoteStorage.saveNewLayout).toHaveBeenCalledTimes(1);
+    expect(failedLayout?.syncInfo?.status).toEqual("updated");
+  });
+
+  it("uploads folder changes for updated personal layouts", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const manager = makeManager({ localStorage, remoteStorage });
+    const id = layoutId("users/u/layouts/1");
+    await localStorage.put(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      makeLocalLayout({
+        id,
+        folder: "Moved",
+        syncStatus: "updated",
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:00.000Z"),
+      }),
+    );
+    remoteStorage.layouts.set(
+      id,
+      makeRemoteLayout({
+        id,
+        folder: "",
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:00.000Z"),
+      }),
+    );
+
+    await manager.syncWithRemote(new AbortController().signal);
+
+    const localLayout = await manager.getLayout({ id });
+    expect(remoteStorage.updateLayout).toHaveBeenCalledWith(
+      expect.objectContaining({ id, folder: "Moved" }),
+    );
+    expect(remoteStorage.layouts.get(id)?.folder).toEqual("Moved");
+    expect(localLayout?.folder).toEqual("Moved");
+    expect(localLayout?.syncInfo?.status).toEqual("tracked");
+  });
+
+  it("updates baseline when only remote updatedAt changes and preserves working data", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const manager = makeManager({ localStorage, remoteStorage });
+    const id = layoutId("users/u/layouts/1");
+    await localStorage.put(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      makeLocalLayout({
+        id,
+        data: layoutData("baseline"),
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:00.000Z"),
+        working: {
+          data: layoutData("draft"),
+          savedAt: ts("2024-01-01T00:00:01.000Z"),
+        },
+      }),
+    );
+    remoteStorage.layouts.set(
+      id,
+      makeRemoteLayout({
+        id,
+        data: layoutData("remote"),
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:02.000Z"),
+      }),
+    );
+
+    await manager.syncWithRemote(new AbortController().signal);
+
+    const localLayout = await manager.getLayout({ id });
+    expect(localLayout?.baseline.data).toEqual(layoutData("remote"));
+    expect(localLayout?.working?.data).toEqual(layoutData("draft"));
+    expect(localLayout?.syncInfo?.lastRemoteUpdatedAt).toEqual(ts("2024-01-01T00:00:02.000Z"));
+  });
+
+  it("marks a remotely deleted project layout with working data and preserves the draft", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const manager = makeManager({ localStorage, remoteStorage });
+    const id = layoutId("warehouses/w/projects/p/layouts/1");
+    await localStorage.put(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      makeLocalLayout({
+        id,
+        parent: "warehouses/w/projects/p",
+        permission: "PROJECT_WRITE",
+        working: {
+          data: layoutData("local-draft"),
+          savedAt: ts("2024-01-01T00:00:01.000Z"),
+        },
+      }),
+    );
+
+    await manager.syncWithRemote(new AbortController().signal);
+
+    const localLayout = await manager.getLayout({ id });
+    expect(localLayout?.syncInfo?.status).toEqual("remotely-deleted");
+    expect(localLayout?.working?.data).toEqual(layoutData("local-draft"));
+  });
+
+  it("does not delete a project layout when remote timestamps changed", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const manager = makeManager({ localStorage, remoteStorage });
+    const id = layoutId("warehouses/w/projects/p/layouts/1");
+    await localStorage.put(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      makeLocalLayout({
+        id,
+        parent: "warehouses/w/projects/p",
+        permission: "PROJECT_WRITE",
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:00.000Z"),
+      }),
+    );
+    remoteStorage.layouts.set(
+      id,
+      makeRemoteLayout({
+        id,
+        parent: "warehouses/w/projects/p",
+        permission: "PROJECT_WRITE",
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:02.000Z"),
+      }),
+    );
+
+    await expect(manager.deleteLayout({ id })).rejects.toThrow("changed on the server");
+
+    expect(await manager.getLayout({ id })).toBeDefined();
+    expect(remoteStorage.deleteLayout).not.toHaveBeenCalled();
+  });
+
+  it("passes expected remote timestamps when deleting a project layout", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const manager = makeManager({ localStorage, remoteStorage });
+    const id = layoutId("warehouses/w/projects/p/layouts/1");
+    await localStorage.put(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      makeLocalLayout({
+        id,
+        parent: "warehouses/w/projects/p",
+        permission: "PROJECT_WRITE",
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:01.000Z"),
+      }),
+    );
+    remoteStorage.layouts.set(
+      id,
+      makeRemoteLayout({
+        id,
+        parent: "warehouses/w/projects/p",
+        permission: "PROJECT_WRITE",
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:01.000Z"),
+      }),
+    );
+
+    await manager.deleteLayout({ id });
+
+    expect(remoteStorage.deleteLayout).toHaveBeenCalledWith(id, {
+      expectedSavedAt: ts("2024-01-01T00:00:00.000Z"),
+      expectedUpdatedAt: ts("2024-01-01T00:00:01.000Z"),
+    });
+  });
+
+  it("keeps a locally-deleted personal tombstone when remote delete detects a conflict", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const manager = makeManager({ localStorage, remoteStorage });
+    const id = layoutId("users/u/layouts/1");
+    await localStorage.put(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      makeLocalLayout({
+        id,
+        syncStatus: "locally-deleted",
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:00.000Z"),
+        working: {
+          data: layoutData("deleted-local-copy"),
+          savedAt: ts("2024-01-01T00:00:01.000Z"),
+        },
+      }),
+    );
+    remoteStorage.layouts.set(
+      id,
+      makeRemoteLayout({
+        id,
+        savedAt: ts("2024-01-01T00:00:00.000Z"),
+        updatedAt: ts("2024-01-01T00:00:02.000Z"),
+      }),
+    );
+
+    await expect(manager.syncWithRemote(new AbortController().signal)).rejects.toThrow(
+      "changed on the server",
+    );
+
+    const rawLayout = await localStorage.get(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      id,
+    );
+    expect(rawLayout?.syncInfo?.status).toEqual("locally-deleted");
+    expect(rawLayout?.working?.data).toEqual(layoutData("deleted-local-copy"));
+  });
+
+  it("cleans a locally-deleted personal tombstone when remote is already absent", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const manager = makeManager({ localStorage, remoteStorage });
+    const id = layoutId("users/u/layouts/1");
+    await localStorage.put(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      makeLocalLayout({
+        id,
+        syncStatus: "locally-deleted",
+        working: {
+          data: layoutData("deleted-local-copy"),
+          savedAt: ts("2024-01-01T00:00:01.000Z"),
+        },
+      }),
+    );
+
+    await manager.syncWithRemote(new AbortController().signal);
+
+    expect(
+      await localStorage.get(
+        `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+        id,
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.ts
+++ b/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.ts
@@ -900,7 +900,8 @@ export default class CoSceneLayoutManager implements ILayoutManager {
               break;
             }
             if (
-              !localLayoutSyncSnapshotMatches(localLayout, operation.localLayout) ||
+              (options.backupPersonalOnly !== true &&
+                !localLayoutSyncSnapshotMatches(localLayout, operation.localLayout)) ||
               localLayout.syncInfo?.status === "updated"
             ) {
               break;

--- a/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.ts
+++ b/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.ts
@@ -741,13 +741,22 @@ export default class CoSceneLayoutManager implements ILayoutManager {
         if (!layout) {
           throw new Error(`Cannot revert layout id ${id} because it does not exist`);
         }
-        return await local.put({
+        const revertedLayout = await local.put({
           ...layout,
           working: undefined,
         });
+        if (layoutAppearsDeleted(revertedLayout)) {
+          await local.delete(id);
+          return { layout: revertedLayout, deleted: true };
+        }
+        return { layout: revertedLayout, deleted: false };
       });
-      this.#notifyChangeListeners({ type: "change", updatedLayout: result });
-      return result;
+      if (result.deleted) {
+        this.#notifyChangeListeners({ type: "delete", layoutId: id });
+      } else {
+        this.#notifyChangeListeners({ type: "change", updatedLayout: result.layout });
+      }
+      return result.layout;
     });
   }
 
@@ -968,7 +977,8 @@ export default class CoSceneLayoutManager implements ILayoutManager {
               break;
             }
             if (
-              !localLayoutSyncSnapshotMatches(localLayout, operation.localLayout) ||
+              (options.backupPersonalOnly !== true &&
+                !localLayoutSyncSnapshotMatches(localLayout, operation.localLayout)) ||
               localLayout.syncInfo.status === "updated"
             ) {
               break;

--- a/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.ts
+++ b/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.ts
@@ -50,19 +50,13 @@ function expectedRemoteTimestamps(layout: Layout): {
   expectedSavedAt?: ISO8601Timestamp | undefined;
   expectedUpdatedAt?: ISO8601Timestamp | undefined;
 } {
+  // Backend writes are not atomic compare-and-set; these timestamps are only a best-effort hint.
   return layout.syncInfo
     ? {
         expectedSavedAt: layout.syncInfo.lastRemoteSavedAt,
         expectedUpdatedAt: layout.syncInfo.lastRemoteUpdatedAt,
       }
     : {};
-}
-
-function remoteTimestampsMatch(localLayout: Layout, remoteLayout: RemoteLayout): boolean {
-  return (
-    localLayout.syncInfo?.lastRemoteSavedAt === remoteLayout.savedAt &&
-    localLayout.syncInfo?.lastRemoteUpdatedAt === remoteLayout.updatedAt
-  );
 }
 
 function localLayoutSyncSnapshotMatches(currentLayout: Layout, operationLayout: Layout): boolean {
@@ -76,14 +70,11 @@ function localLayoutSyncSnapshotMatches(currentLayout: Layout, operationLayout: 
   );
 }
 
-async function assertRemoteLayoutUnchanged(
-  remote: IRemoteLayoutStorage,
-  localLayout: Layout,
-): Promise<void> {
-  const remoteLayout = await remote.getLayout(localLayout.id);
-  if (!remoteLayout || !remoteTimestampsMatch(localLayout, remoteLayout)) {
-    throw remoteConflictError(localLayout.id);
+function workingDataEqual(left: Layout["working"], right: Layout["working"]): boolean {
+  if (left == undefined || right == undefined) {
+    return left === right;
   }
+  return isLayoutEqual(left.data, right.data);
 }
 
 async function updateRemoteLayout(
@@ -425,7 +416,7 @@ export default class CoSceneLayoutManager implements ILayoutManager {
       const now = new Date().toISOString() as ISO8601Timestamp;
       const data = unmigratedData == undefined ? undefined : migratePanelsState(unmigratedData);
 
-      const result = await this.#local.runExclusive(async (local) => {
+      const snapshot = await this.#local.runExclusive(async (local) => {
         const localLayout = await local.get(id);
         if (!localLayout) {
           // if this layout is record recommended layout, this error is expected
@@ -447,37 +438,7 @@ export default class CoSceneLayoutManager implements ILayoutManager {
 
         // Renames of shared layouts go directly to the server.
         if (metadataChanged && layoutIsProject(localLayout)) {
-          if (!this.#remote) {
-            throw new Error("Shared layouts are not supported without remote layout storage");
-          }
-          if (!this.isOnline) {
-            throw new Error("Cannot update a shared layout while offline");
-          }
-          const updatedBaseline = await updateRemoteLayout(this.#remote, {
-            id,
-            name,
-            folder,
-            parent: localLayout.parent,
-            ...expectedRemoteTimestamps(localLayout),
-          });
-          return await local.put({
-            ...localLayout,
-            parent: updatedBaseline.parent,
-            name: updatedBaseline.name,
-            folder: updatedBaseline.folder,
-            baseline: {
-              data: updatedBaseline.data,
-              savedAt: updatedBaseline.savedAt,
-              modifier: updatedBaseline.modifier,
-              modifierNickname: updatedBaseline.modifierNickname,
-            },
-            working: newWorking,
-            syncInfo: {
-              status: "tracked",
-              lastRemoteSavedAt: updatedBaseline.savedAt,
-              lastRemoteUpdatedAt: updatedBaseline.updatedAt,
-            },
-          });
+          return { type: "project-metadata" as const, localLayout, newWorking };
         }
 
         const isUpdateSavedAt =
@@ -486,7 +447,7 @@ export default class CoSceneLayoutManager implements ILayoutManager {
           localLayout.syncInfo != undefined &&
           localLayout.syncInfo.status !== "new";
 
-        return await local.put({
+        const updatedLayout = await local.put({
           ...localLayout,
           name: name ?? localLayout.name,
           folder: folder ?? localLayout.folder,
@@ -509,57 +470,134 @@ export default class CoSceneLayoutManager implements ILayoutManager {
               }
             : localLayout.syncInfo,
         });
+
+        return { type: "local" as const, layout: updatedLayout };
       });
 
-      if (result) {
-        this.#notifyChangeListeners({ type: "change", updatedLayout: result, source: "update" });
+      if (!snapshot) {
+        return undefined;
       }
+
+      if (snapshot.type === "local") {
+        this.#notifyChangeListeners({
+          type: "change",
+          updatedLayout: snapshot.layout,
+          source: "update",
+        });
+        return snapshot.layout;
+      }
+
+      const remote = this.#remote;
+      if (!remote) {
+        throw new Error("Shared layouts are not supported without remote layout storage");
+      }
+      if (!this.isOnline) {
+        throw new Error("Cannot update a shared layout while offline");
+      }
+
+      const updatedBaseline = await updateRemoteLayout(remote, {
+        id,
+        name,
+        folder,
+        parent: snapshot.localLayout.parent,
+        ...expectedRemoteTimestamps(snapshot.localLayout),
+      });
+
+      const result = await this.#local.runExclusive(async (local) => {
+        const latestLayout = await local.get(id);
+        if (!latestLayout) {
+          throw new Error(`Cannot update layout ${id} because it does not exist`);
+        }
+        if (!localLayoutSyncSnapshotMatches(latestLayout, snapshot.localLayout)) {
+          return latestLayout;
+        }
+
+        const working = workingDataEqual(latestLayout.working, snapshot.localLayout.working)
+          ? snapshot.newWorking
+          : latestLayout.working;
+        return await local.put({
+          ...latestLayout,
+          parent: updatedBaseline.parent,
+          name: updatedBaseline.name,
+          folder: updatedBaseline.folder,
+          baseline: {
+            data: updatedBaseline.data,
+            savedAt: updatedBaseline.savedAt,
+            modifier: updatedBaseline.modifier,
+            modifierNickname: updatedBaseline.modifierNickname,
+          },
+          working,
+          syncInfo: {
+            status: "tracked",
+            lastRemoteSavedAt: updatedBaseline.savedAt,
+            lastRemoteUpdatedAt: updatedBaseline.updatedAt,
+          },
+        });
+      });
+
+      this.#notifyChangeListeners({ type: "change", updatedLayout: result, source: "update" });
       return result;
     });
   }
 
   public async deleteLayout({ id }: { id: LayoutID }): Promise<void> {
     await this.#runWithBusyStatus(async () => {
-      await this.#local.runExclusive(async (local) => {
-        const localLayout = await local.get(id);
-        if (!localLayout) {
-          throw new Error(`Cannot update layout ${id} because it does not exist`);
+      const snapshot = await this.#local.runExclusive(async (local) => await local.get(id));
+      if (!snapshot) {
+        throw new Error(`Cannot update layout ${id} because it does not exist`);
+      }
+
+      const shouldDeleteRemote =
+        layoutIsProject(snapshot) && snapshot.syncInfo?.status !== "remotely-deleted";
+      if (shouldDeleteRemote) {
+        const remote = this.#remote;
+        if (!remote) {
+          throw new Error("Shared layouts are not supported without remote layout storage");
+        }
+        if (!this.isOnline) {
+          throw new Error("Cannot delete a shared layout while offline");
+        }
+        if (!(await remote.deleteLayout(id, expectedRemoteTimestamps(snapshot)))) {
+          throw remoteConflictError(id);
+        }
+      }
+
+      const didDelete = await this.#local.runExclusive(async (local) => {
+        const currentLayout = await local.get(id);
+        if (!currentLayout) {
+          return false;
         }
 
-        if (layoutIsProject(localLayout)) {
-          if (!this.#remote) {
-            throw new Error("Shared layouts are not supported without remote layout storage");
-          }
-          if (localLayout.syncInfo?.status !== "remotely-deleted") {
-            if (!this.isOnline) {
-              throw new Error("Cannot delete a shared layout while offline");
-            }
-            await assertRemoteLayoutUnchanged(this.#remote, localLayout);
-            if (!(await this.#remote.deleteLayout(id, expectedRemoteTimestamps(localLayout)))) {
-              throw remoteConflictError(id);
-            }
-          }
+        if (
+          shouldDeleteRemote &&
+          (!localLayoutSyncSnapshotMatches(currentLayout, snapshot) ||
+            !workingDataEqual(currentLayout.working, snapshot.working))
+        ) {
+          return false;
         }
 
-        if (this.#remote && !layoutIsProject(localLayout)) {
+        if (this.#remote && !layoutIsProject(currentLayout)) {
           await local.put({
-            ...localLayout,
+            ...currentLayout,
             working: {
-              data: localLayout.working?.data ?? localLayout.baseline.data,
+              data: currentLayout.working?.data ?? currentLayout.baseline.data,
               savedAt: new Date().toISOString() as ISO8601Timestamp,
             },
             syncInfo: {
               status: "locally-deleted",
-              lastRemoteSavedAt: localLayout.syncInfo?.lastRemoteSavedAt,
-              lastRemoteUpdatedAt: localLayout.syncInfo?.lastRemoteUpdatedAt,
+              lastRemoteSavedAt: currentLayout.syncInfo?.lastRemoteSavedAt,
+              lastRemoteUpdatedAt: currentLayout.syncInfo?.lastRemoteUpdatedAt,
             },
           });
         } else {
-          // Don't have remote storage, or already deleted on remote
           await local.delete(id);
         }
+        return true;
       });
-      this.#notifyChangeListeners({ type: "delete", layoutId: id });
+
+      if (didDelete) {
+        this.#notifyChangeListeners({ type: "delete", layoutId: id });
+      }
     });
   }
 
@@ -574,7 +612,7 @@ export default class CoSceneLayoutManager implements ILayoutManager {
       const now = new Date().toISOString() as ISO8601Timestamp;
       const data = unmigratedData == undefined ? undefined : migratePanelsState(unmigratedData);
 
-      const result = await this.#local.runExclusive(async (local) => {
+      const snapshot = await this.#local.runExclusive(async (local) => {
         const localLayout = await local.get(id);
         if (!localLayout) {
           throw new Error(`Cannot overwrite layout ${id} because it does not exist`);
@@ -597,40 +635,14 @@ export default class CoSceneLayoutManager implements ILayoutManager {
               : { data: dataToSave, savedAt: now },
           });
 
-          await assertRemoteLayoutUnchanged(this.#remote, layoutForSave);
-          const updatedBaseline = await updateRemoteLayout(this.#remote, {
-            id,
-            parent: layoutForSave.parent,
-            data: dataToSave,
-            ...expectedRemoteTimestamps(layoutForSave),
-          });
-
-          const latestLayout = await local.get(id);
-          if (!latestLayout) {
-            throw new Error(`Cannot overwrite layout ${id} because it does not exist`);
-          }
-          return await local.put({
-            ...latestLayout,
-            baseline: {
-              data: updatedBaseline.data,
-              savedAt: updatedBaseline.savedAt,
-              modifier: updatedBaseline.modifier,
-              modifierNickname: updatedBaseline.modifierNickname,
-            },
-            working: undefined,
-            syncInfo: {
-              status: "tracked",
-              lastRemoteSavedAt: updatedBaseline.savedAt,
-              lastRemoteUpdatedAt: updatedBaseline.updatedAt,
-            },
-          });
+          return { type: "project" as const, dataToSave, layoutForSave };
         }
 
         const latestLayout = await local.get(id);
         if (!latestLayout) {
           throw new Error(`Cannot overwrite layout ${id} because it does not exist`);
         }
-        return await local.put({
+        const layout = await local.put({
           ...latestLayout,
           baseline: {
             data: dataToSave,
@@ -648,7 +660,65 @@ export default class CoSceneLayoutManager implements ILayoutManager {
                 }
               : latestLayout.syncInfo,
         });
+
+        return { type: "local" as const, layout };
       });
+
+      if (snapshot.type === "local") {
+        this.#notifyChangeListeners({
+          type: "change",
+          updatedLayout: snapshot.layout,
+          source: "overwrite",
+        });
+        return snapshot.layout;
+      }
+
+      const remote = this.#remote;
+      if (!remote) {
+        throw new Error("Shared layouts are not supported without remote layout storage");
+      }
+      if (!this.isOnline) {
+        throw new Error("Cannot save a shared layout while offline");
+      }
+
+      const updatedBaseline = await updateRemoteLayout(remote, {
+        id,
+        parent: snapshot.layoutForSave.parent,
+        data: snapshot.dataToSave,
+        ...expectedRemoteTimestamps(snapshot.layoutForSave),
+      });
+
+      const result = await this.#local.runExclusive(async (local) => {
+        const latestLayout = await local.get(id);
+        if (!latestLayout) {
+          throw new Error(`Cannot overwrite layout ${id} because it does not exist`);
+        }
+        if (!localLayoutSyncSnapshotMatches(latestLayout, snapshot.layoutForSave)) {
+          return latestLayout;
+        }
+
+        const working =
+          latestLayout.working == undefined ||
+          isLayoutEqual(latestLayout.working.data, snapshot.dataToSave)
+            ? undefined
+            : latestLayout.working;
+        return await local.put({
+          ...latestLayout,
+          baseline: {
+            data: updatedBaseline.data,
+            savedAt: updatedBaseline.savedAt,
+            modifier: updatedBaseline.modifier,
+            modifierNickname: updatedBaseline.modifierNickname,
+          },
+          working,
+          syncInfo: {
+            status: "tracked",
+            lastRemoteSavedAt: updatedBaseline.savedAt,
+            lastRemoteUpdatedAt: updatedBaseline.updatedAt,
+          },
+        });
+      });
+
       this.#notifyChangeListeners({ type: "change", updatedLayout: result, source: "overwrite" });
       return result;
     });
@@ -770,7 +840,16 @@ export default class CoSceneLayoutManager implements ILayoutManager {
     operations: readonly (SyncOperation & { local: true })[],
     abortSignal: AbortSignal,
   ): Promise<void> {
-    await this.#local.runExclusive(async (local) => {
+    await this.#performLocalSyncOperationsInStorage(this.#local, operations, abortSignal);
+  }
+
+  async #performLocalSyncOperationsInStorage(
+    storage: MutexLocked<NamespacedLayoutStorage>,
+    operations: readonly (SyncOperation & { local: true })[],
+    abortSignal: AbortSignal,
+    options: { backupPersonalOnly?: boolean } = {},
+  ): Promise<void> {
+    await storage.runExclusive(async (local) => {
       for (const operation of operations) {
         if (abortSignal.aborted) {
           return;
@@ -811,16 +890,14 @@ export default class CoSceneLayoutManager implements ILayoutManager {
               localLayout.working != undefined &&
               localLayout.syncInfo?.status !== "locally-deleted"
             ) {
-              if (layoutIsProject(localLayout)) {
-                await local.put({
-                  ...localLayout,
-                  syncInfo: {
-                    status: "remotely-deleted",
-                    lastRemoteSavedAt: undefined,
-                    lastRemoteUpdatedAt: undefined,
-                  },
-                });
-              }
+              await local.put({
+                ...localLayout,
+                syncInfo: {
+                  status: "remotely-deleted",
+                  lastRemoteSavedAt: undefined,
+                  lastRemoteUpdatedAt: undefined,
+                },
+              });
               break;
             }
             log.debug(
@@ -833,6 +910,12 @@ export default class CoSceneLayoutManager implements ILayoutManager {
 
           case "add-to-cache": {
             const { remoteLayout } = operation;
+            if (
+              options.backupPersonalOnly === true &&
+              remoteLayout.permission !== "PERSONAL_WRITE"
+            ) {
+              break;
+            }
             if ((await local.get(remoteLayout.id)) != undefined) {
               break;
             }
@@ -861,6 +944,12 @@ export default class CoSceneLayoutManager implements ILayoutManager {
 
           case "update-baseline": {
             const { remoteLayout } = operation;
+            if (
+              options.backupPersonalOnly === true &&
+              remoteLayout.permission !== "PERSONAL_WRITE"
+            ) {
+              break;
+            }
             const localLayout = await local.get(operation.localLayout.id);
             if (!localLayout?.syncInfo) {
               break;
@@ -1043,140 +1132,8 @@ export default class CoSceneLayoutManager implements ILayoutManager {
     if (!this.#backupLocal) {
       return;
     }
-    await this.#backupLocal.runExclusive(async (local) => {
-      for (const operation of operations) {
-        if (abortSignal.aborted) {
-          return;
-        }
-
-        switch (operation.type) {
-          case "mark-deleted": {
-            const localLayout = await local.get(operation.localLayout.id);
-            if (!localLayout) {
-              break;
-            }
-            if (!localLayoutSyncSnapshotMatches(localLayout, operation.localLayout)) {
-              break;
-            }
-            log.debug(`Marking layout as remotely deleted: ${localLayout.id}`);
-            await local.put({
-              ...localLayout,
-              syncInfo: {
-                status: "remotely-deleted",
-                lastRemoteSavedAt: undefined,
-                lastRemoteUpdatedAt: undefined,
-              },
-            });
-            break;
-          }
-
-          case "delete-local": {
-            const localLayout = await local.get(operation.localLayout.id);
-            if (!localLayout) {
-              break;
-            }
-            if (
-              !localLayoutSyncSnapshotMatches(localLayout, operation.localLayout) ||
-              localLayout.syncInfo?.status === "updated"
-            ) {
-              break;
-            }
-            if (
-              localLayout.working != undefined &&
-              localLayout.syncInfo?.status !== "locally-deleted"
-            ) {
-              if (layoutIsProject(localLayout)) {
-                await local.put({
-                  ...localLayout,
-                  syncInfo: {
-                    status: "remotely-deleted",
-                    lastRemoteSavedAt: undefined,
-                    lastRemoteUpdatedAt: undefined,
-                  },
-                });
-              }
-              break;
-            }
-            log.debug(
-              `Deleting local layout ${localLayout.id}, whose sync status was ${localLayout.syncInfo?.status}`,
-            );
-            await local.delete(localLayout.id);
-            this.#notifyChangeListeners({ type: "delete", layoutId: localLayout.id });
-            break;
-          }
-
-          case "add-to-cache": {
-            const { remoteLayout } = operation;
-            log.debug(`Adding layout to cache: ${remoteLayout.id}`);
-
-            // only backup layouts with personal layout
-            if (
-              remoteLayout.permission === "PERSONAL_WRITE" &&
-              (await local.get(remoteLayout.id)) == undefined
-            ) {
-              await local.put({
-                id: remoteLayout.id,
-                parent: remoteLayout.parent,
-                folder: remoteLayout.folder,
-                name: remoteLayout.name,
-                permission: remoteLayout.permission,
-                baseline: {
-                  data: remoteLayout.data,
-                  savedAt: remoteLayout.savedAt,
-                  modifier: remoteLayout.modifier,
-                  modifierNickname: remoteLayout.modifierNickname,
-                },
-                working: undefined,
-                syncInfo: {
-                  status: "tracked",
-                  lastRemoteSavedAt: remoteLayout.savedAt,
-                  lastRemoteUpdatedAt: remoteLayout.updatedAt,
-                },
-              });
-            }
-            break;
-          }
-
-          case "update-baseline": {
-            const { remoteLayout } = operation;
-            const localLayout = await local.get(operation.localLayout.id);
-            if (!localLayout?.syncInfo) {
-              break;
-            }
-            if (
-              !localLayoutSyncSnapshotMatches(localLayout, operation.localLayout) ||
-              localLayout.syncInfo.status === "updated"
-            ) {
-              break;
-            }
-            log.debug(`Updating baseline for ${localLayout.id}`);
-
-            // only backup layouts with personal layout
-            if (remoteLayout.permission === "PERSONAL_WRITE") {
-              await local.put({
-                id: remoteLayout.id,
-                parent: remoteLayout.parent,
-                folder: remoteLayout.folder,
-                name: remoteLayout.name,
-                permission: remoteLayout.permission,
-                baseline: {
-                  data: remoteLayout.data,
-                  savedAt: remoteLayout.savedAt,
-                  modifier: remoteLayout.modifier,
-                  modifierNickname: remoteLayout.modifierNickname,
-                },
-                working: localLayout.working,
-                syncInfo: {
-                  status: localLayout.syncInfo.status,
-                  lastRemoteSavedAt: remoteLayout.savedAt,
-                  lastRemoteUpdatedAt: remoteLayout.updatedAt,
-                },
-              });
-            }
-            break;
-          }
-        }
-      }
+    await this.#performLocalSyncOperationsInStorage(this.#backupLocal, operations, abortSignal, {
+      backupPersonalOnly: true,
     });
   }
 

--- a/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.ts
+++ b/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.ts
@@ -42,11 +42,51 @@ import { migratePanelsState } from "../migrateLayout";
 
 const log = Logger.getLogger(__filename);
 
-/**
- * Try to perform the given updateLayout operation on remote storage. If a conflict is returned,
- * fetch the most recent version of the layout and return that instead.
- */
-async function updateOrFetchLayout(
+function remoteConflictError(id: LayoutID): Error {
+  return new Error(`Layout ${id} has changed on the server; local changes were not saved.`);
+}
+
+function expectedRemoteTimestamps(layout: Layout): {
+  expectedSavedAt?: ISO8601Timestamp | undefined;
+  expectedUpdatedAt?: ISO8601Timestamp | undefined;
+} {
+  return layout.syncInfo
+    ? {
+        expectedSavedAt: layout.syncInfo.lastRemoteSavedAt,
+        expectedUpdatedAt: layout.syncInfo.lastRemoteUpdatedAt,
+      }
+    : {};
+}
+
+function remoteTimestampsMatch(localLayout: Layout, remoteLayout: RemoteLayout): boolean {
+  return (
+    localLayout.syncInfo?.lastRemoteSavedAt === remoteLayout.savedAt &&
+    localLayout.syncInfo?.lastRemoteUpdatedAt === remoteLayout.updatedAt
+  );
+}
+
+function localLayoutSyncSnapshotMatches(currentLayout: Layout, operationLayout: Layout): boolean {
+  return (
+    currentLayout.syncInfo?.status === operationLayout.syncInfo?.status &&
+    currentLayout.syncInfo?.lastRemoteSavedAt === operationLayout.syncInfo?.lastRemoteSavedAt &&
+    currentLayout.syncInfo?.lastRemoteUpdatedAt === operationLayout.syncInfo?.lastRemoteUpdatedAt &&
+    currentLayout.name === operationLayout.name &&
+    currentLayout.folder === operationLayout.folder &&
+    isLayoutEqual(currentLayout.baseline.data, operationLayout.baseline.data)
+  );
+}
+
+async function assertRemoteLayoutUnchanged(
+  remote: IRemoteLayoutStorage,
+  localLayout: Layout,
+): Promise<void> {
+  const remoteLayout = await remote.getLayout(localLayout.id);
+  if (!remoteLayout || !remoteTimestampsMatch(localLayout, remoteLayout)) {
+    throw remoteConflictError(localLayout.id);
+  }
+}
+
+async function updateRemoteLayout(
   remote: IRemoteLayoutStorage,
   params: Parameters<IRemoteLayoutStorage["updateLayout"]>[0],
 ): Promise<RemoteLayout> {
@@ -55,14 +95,8 @@ async function updateOrFetchLayout(
   switch (response.status) {
     case "success":
       return response.newLayout;
-    case "conflict": {
-      const remoteLayout = await remote.getLayout(params.id);
-      if (!remoteLayout) {
-        throw new Error(`Update rejected but layout is not present on server: ${params.id}`);
-      }
-      log.info(`Layout update rejected, using server version: ${params.id}`);
-      return remoteLayout;
-    }
+    case "conflict":
+      throw remoteConflictError(params.id);
   }
 }
 
@@ -88,28 +122,15 @@ export default class CoSceneLayoutManager implements ILayoutManager {
 
   #busyCount = 0;
 
-  /**
-   * A decorator to emit busy events before and after an async operation so the UI can show that the
-   * operation is in progress.
-   */
-  static #withBusyStatus<Args extends unknown[], Ret>(
-    _prototype: typeof CoSceneLayoutManager.prototype,
-    _propertyKey: string,
-    descriptor: TypedPropertyDescriptor<
-      (this: CoSceneLayoutManager, ...args: Args) => Promise<Ret>
-    >,
-  ) {
-    const method = descriptor.value!;
-    descriptor.value = async function (...args) {
-      try {
-        this.#busyCount++;
-        this.#emitter.emit("busychange");
-        return await method.apply(this, args);
-      } finally {
-        this.#busyCount--;
-        this.#emitter.emit("busychange");
-      }
-    };
+  async #runWithBusyStatus<Ret>(body: () => Promise<Ret>): Promise<Ret> {
+    try {
+      this.#busyCount++;
+      this.#emitter.emit("busychange");
+      return await body();
+    } finally {
+      this.#busyCount--;
+      this.#emitter.emit("busychange");
+    }
   }
 
   // eslint-disable-next-line no-restricted-syntax
@@ -301,7 +322,6 @@ export default class CoSceneLayoutManager implements ILayoutManager {
     });
   }
 
-  @(CoSceneLayoutManager.#withBusyStatus)
   public async saveNewLayout({
     folder,
     name,
@@ -313,128 +333,134 @@ export default class CoSceneLayoutManager implements ILayoutManager {
     data: LayoutData;
     permission: LayoutPermission;
   }): Promise<Layout> {
-    const parent =
-      permission === "PERSONAL_WRITE" ? (this.userName ?? "") : (this.projectName ?? "");
+    return await this.#runWithBusyStatus(async () => {
+      const parent =
+        permission === "PERSONAL_WRITE" ? (this.userName ?? "") : (this.projectName ?? "");
 
-    const data = migratePanelsState(unmigratedData);
-    if (layoutPermissionIsProject(permission)) {
-      if (!this.#remote) {
-        throw new Error("Shared layouts are not supported without remote layout storage");
-      }
-      if (!this.isOnline) {
-        throw new Error("Cannot share a layout while offline");
-      }
+      const data = migratePanelsState(unmigratedData);
+      if (layoutPermissionIsProject(permission)) {
+        if (!this.#remote) {
+          throw new Error("Shared layouts are not supported without remote layout storage");
+        }
+        if (!this.isOnline) {
+          throw new Error("Cannot share a layout while offline");
+        }
 
-      const newLayout = await this.#remote.saveNewLayout({
-        id: `${parent}/layouts/${uuidv4()}` as LayoutID,
-        parent,
-        folder,
-        name,
-        data,
-        permission,
-      });
-
-      const result = await this.#local.runExclusive(
-        async (local) =>
-          await local.put({
-            id: newLayout.id,
-            parent: newLayout.parent,
-            folder: newLayout.folder,
-            name: newLayout.name,
-            permission: newLayout.permission,
-            baseline: {
-              data: newLayout.data,
-              savedAt: newLayout.savedAt,
-              modifier: newLayout.modifier,
-              modifierNickname: newLayout.modifierNickname,
-            },
-            working: undefined,
-            syncInfo: {
-              status: "tracked",
-              lastRemoteSavedAt: newLayout.savedAt,
-              lastRemoteUpdatedAt: newLayout.updatedAt,
-            },
-          }),
-      );
-      this.#notifyChangeListeners({ type: "change", updatedLayout: undefined });
-      return result;
-    }
-
-    const newLayout = await this.#local.runExclusive(
-      async (local) =>
-        await local.put({
+        const newLayout = await this.#remote.saveNewLayout({
           id: `${parent}/layouts/${uuidv4()}` as LayoutID,
           parent,
           folder,
           name,
+          data,
           permission,
-          baseline: {
-            data,
-            savedAt: new Date().toISOString() as ISO8601Timestamp,
-            modifier: this.#currentUser?.userId ? `users/${this.#currentUser.userId}` : undefined,
-            modifierNickname: this.#currentUser?.nickName,
-          },
-          working: undefined,
-          syncInfo: this.#remote
-            ? {
-                status: "new",
-                lastRemoteSavedAt: undefined,
-                lastRemoteUpdatedAt: undefined,
-              }
-            : undefined,
-        }),
-    );
-    this.#notifyChangeListeners({ type: "change", updatedLayout: newLayout });
-    return newLayout;
+        });
+
+        const result = await this.#local.runExclusive(
+          async (local) =>
+            await local.put({
+              id: newLayout.id,
+              parent: newLayout.parent,
+              folder: newLayout.folder,
+              name: newLayout.name,
+              permission: newLayout.permission,
+              baseline: {
+                data: newLayout.data,
+                savedAt: newLayout.savedAt,
+                modifier: newLayout.modifier,
+                modifierNickname: newLayout.modifierNickname,
+              },
+              working: undefined,
+              syncInfo: {
+                status: "tracked",
+                lastRemoteSavedAt: newLayout.savedAt,
+                lastRemoteUpdatedAt: newLayout.updatedAt,
+              },
+            }),
+        );
+        this.#notifyChangeListeners({ type: "change", updatedLayout: undefined });
+        return result;
+      }
+
+      const newLayout = await this.#local.runExclusive(
+        async (local) =>
+          await local.put({
+            id: `${parent}/layouts/${uuidv4()}` as LayoutID,
+            parent,
+            folder,
+            name,
+            permission,
+            baseline: {
+              data,
+              savedAt: new Date().toISOString() as ISO8601Timestamp,
+              modifier: this.#currentUser?.userId ? `users/${this.#currentUser.userId}` : undefined,
+              modifierNickname: this.#currentUser?.nickName,
+            },
+            working: undefined,
+            syncInfo: this.#remote
+              ? {
+                  status: "new",
+                  lastRemoteSavedAt: undefined,
+                  lastRemoteUpdatedAt: undefined,
+                }
+              : undefined,
+          }),
+      );
+      this.#notifyChangeListeners({ type: "change", updatedLayout: newLayout });
+      return newLayout;
+    });
   }
 
-  @(CoSceneLayoutManager.#withBusyStatus)
   public async updateLayout({
     id,
     name,
     folder,
-    data,
+    data: unmigratedData,
   }: {
     id: LayoutID;
-    name: string | undefined;
-    folder: string | undefined;
-    data: LayoutData | undefined;
+    name?: string | undefined;
+    folder?: string | undefined;
+    data?: LayoutData | undefined;
   }): Promise<Layout | undefined> {
-    const now = new Date().toISOString() as ISO8601Timestamp;
+    return await this.#runWithBusyStatus(async () => {
+      const now = new Date().toISOString() as ISO8601Timestamp;
+      const data = unmigratedData == undefined ? undefined : migratePanelsState(unmigratedData);
 
-    const localLayout = await this.#local.runExclusive(async (local) => await local.get(id));
-    if (!localLayout) {
-      // if this layout is record recommended layout, this error is expected
-      // because the layout will be deleted when the user plays another record
-      return undefined;
-    }
+      const result = await this.#local.runExclusive(async (local) => {
+        const localLayout = await local.get(id);
+        if (!localLayout) {
+          // if this layout is record recommended layout, this error is expected
+          // because the layout will be deleted when the user plays another record
+          return undefined;
+        }
 
-    // If the modifications result in the same layout data, set the working copy to undefined so the
-    // layout appears unmodified.
-    const newWorking =
-      data == undefined
-        ? localLayout.working
-        : isLayoutEqual(localLayout.baseline.data, data)
-          ? undefined
-          : { data, savedAt: now };
+        // If the modifications result in the same layout data, set the working copy to undefined so
+        // the layout appears unmodified.
+        const newWorking =
+          data == undefined
+            ? localLayout.working
+            : isLayoutEqual(localLayout.baseline.data, data)
+              ? undefined
+              : { data, savedAt: now };
+        const nameChanged = name != undefined && name !== localLayout.name;
+        const folderChanged = folder != undefined && folder !== localLayout.folder;
+        const metadataChanged = nameChanged || folderChanged;
 
-    // Renames of shared layouts go directly to the server
-    if ((folder != undefined || name != undefined) && layoutIsProject(localLayout)) {
-      if (!this.#remote) {
-        throw new Error("Shared layouts are not supported without remote layout storage");
-      }
-      if (!this.isOnline) {
-        throw new Error("Cannot update a shared layout while offline");
-      }
-      const updatedBaseline = await updateOrFetchLayout(this.#remote, {
-        id,
-        name,
-        folder,
-        parent: localLayout.parent,
-      });
-      const result = await this.#local.runExclusive(
-        async (local) =>
-          await local.put({
+        // Renames of shared layouts go directly to the server.
+        if (metadataChanged && layoutIsProject(localLayout)) {
+          if (!this.#remote) {
+            throw new Error("Shared layouts are not supported without remote layout storage");
+          }
+          if (!this.isOnline) {
+            throw new Error("Cannot update a shared layout while offline");
+          }
+          const updatedBaseline = await updateRemoteLayout(this.#remote, {
+            id,
+            name,
+            folder,
+            parent: localLayout.parent,
+            ...expectedRemoteTimestamps(localLayout),
+          });
+          return await local.put({
             ...localLayout,
             parent: updatedBaseline.parent,
             name: updatedBaseline.name,
@@ -451,116 +477,140 @@ export default class CoSceneLayoutManager implements ILayoutManager {
               lastRemoteSavedAt: updatedBaseline.savedAt,
               lastRemoteUpdatedAt: updatedBaseline.updatedAt,
             },
-          }),
-      );
-      // 当 busyCount > 1 时，代表着有多个更新 layout 的任务在排队，这时不应该触发 change 事件，否则会导致 layout 跳回上一个版本
-      if (this.#busyCount === 1) {
-        this.#notifyChangeListeners({ type: "change", updatedLayout: result });
-      }
-      return result;
-    } else {
-      const isUpdateSavedAt =
-        this.#remote != undefined &&
-        (name != undefined || folder != undefined) &&
-        localLayout.syncInfo != undefined &&
-        localLayout.syncInfo.status !== "new";
-
-      const result = await this.#local.runExclusive(
-        async (local) =>
-          await local.put({
-            ...localLayout,
-            name: name ?? localLayout.name,
-            folder: folder ?? localLayout.folder,
-            working: newWorking,
-
-            // If the name is being changed, we will need to upload to the server with a new savedAt
-            baseline: isUpdateSavedAt
-              ? {
-                  ...localLayout.baseline,
-                  savedAt: now,
-                  modifier: localLayout.baseline.modifier,
-                  modifierNickname: localLayout.baseline.modifierNickname,
-                }
-              : localLayout.baseline,
-            syncInfo: isUpdateSavedAt
-              ? {
-                  status: "updated",
-                  lastRemoteSavedAt: localLayout.syncInfo?.lastRemoteSavedAt,
-                  lastRemoteUpdatedAt: localLayout.syncInfo?.lastRemoteUpdatedAt,
-                }
-              : localLayout.syncInfo,
-          }),
-      );
-      this.#notifyChangeListeners({ type: "change", updatedLayout: result });
-      return result;
-    }
-  }
-
-  @(CoSceneLayoutManager.#withBusyStatus)
-  public async deleteLayout({ id }: { id: LayoutID }): Promise<void> {
-    const localLayout = await this.#local.runExclusive(async (local) => await local.get(id));
-    if (!localLayout) {
-      throw new Error(`Cannot update layout ${id} because it does not exist`);
-    }
-    if (layoutIsProject(localLayout)) {
-      if (!this.#remote) {
-        throw new Error("Shared layouts are not supported without remote layout storage");
-      }
-      if (localLayout.syncInfo?.status !== "remotely-deleted") {
-        if (!this.isOnline) {
-          throw new Error("Cannot delete a shared layout while offline");
+          });
         }
-        await this.#remote.deleteLayout(id);
-      }
-    }
-    await this.#local.runExclusive(async (local) => {
-      if (this.#remote && !layoutIsProject(localLayout)) {
-        await local.put({
+
+        const isUpdateSavedAt =
+          this.#remote != undefined &&
+          metadataChanged &&
+          localLayout.syncInfo != undefined &&
+          localLayout.syncInfo.status !== "new";
+
+        return await local.put({
           ...localLayout,
-          working: {
-            data: localLayout.working?.data ?? localLayout.baseline.data,
-            savedAt: new Date().toISOString() as ISO8601Timestamp,
-          },
-          syncInfo: {
-            status: "locally-deleted",
-            lastRemoteSavedAt: localLayout.syncInfo?.lastRemoteSavedAt,
-            lastRemoteUpdatedAt: localLayout.syncInfo?.lastRemoteUpdatedAt,
-          },
+          name: name ?? localLayout.name,
+          folder: folder ?? localLayout.folder,
+          working: newWorking,
+
+          // If the name is being changed, we will need to upload to the server with a new savedAt
+          baseline: isUpdateSavedAt
+            ? {
+                ...localLayout.baseline,
+                savedAt: now,
+                modifier: localLayout.baseline.modifier,
+                modifierNickname: localLayout.baseline.modifierNickname,
+              }
+            : localLayout.baseline,
+          syncInfo: isUpdateSavedAt
+            ? {
+                status: "updated",
+                lastRemoteSavedAt: localLayout.syncInfo?.lastRemoteSavedAt,
+                lastRemoteUpdatedAt: localLayout.syncInfo?.lastRemoteUpdatedAt,
+              }
+            : localLayout.syncInfo,
         });
-      } else {
-        // Don't have remote storage, or already deleted on remote
-        await local.delete(id);
+      });
+
+      if (result) {
+        this.#notifyChangeListeners({ type: "change", updatedLayout: result, source: "update" });
       }
+      return result;
     });
-    this.#notifyChangeListeners({ type: "delete", layoutId: id });
   }
 
-  @(CoSceneLayoutManager.#withBusyStatus)
-  public async overwriteLayout({ id }: { id: LayoutID }): Promise<Layout> {
-    const localLayout = await this.#local.runExclusive(async (local) => await local.get(id));
-    if (!localLayout) {
-      throw new Error(`Cannot overwrite layout ${id} because it does not exist`);
-    }
+  public async deleteLayout({ id }: { id: LayoutID }): Promise<void> {
+    await this.#runWithBusyStatus(async () => {
+      await this.#local.runExclusive(async (local) => {
+        const localLayout = await local.get(id);
+        if (!localLayout) {
+          throw new Error(`Cannot update layout ${id} because it does not exist`);
+        }
 
-    const now = new Date().toISOString() as ISO8601Timestamp;
+        if (layoutIsProject(localLayout)) {
+          if (!this.#remote) {
+            throw new Error("Shared layouts are not supported without remote layout storage");
+          }
+          if (localLayout.syncInfo?.status !== "remotely-deleted") {
+            if (!this.isOnline) {
+              throw new Error("Cannot delete a shared layout while offline");
+            }
+            await assertRemoteLayoutUnchanged(this.#remote, localLayout);
+            if (!(await this.#remote.deleteLayout(id, expectedRemoteTimestamps(localLayout)))) {
+              throw remoteConflictError(id);
+            }
+          }
+        }
 
-    if (layoutIsProject(localLayout)) {
-      if (!this.#remote) {
-        throw new Error("Shared layouts are not supported without remote layout storage");
-      }
-      if (!this.isOnline) {
-        throw new Error("Cannot save a shared layout while offline");
-      }
-      const updatedBaseline = await updateOrFetchLayout(this.#remote, {
-        id,
-        parent: localLayout.parent,
-        data: localLayout.working?.data ?? localLayout.baseline.data,
-        // savedAt: now,
-      });
-      const result = await this.#local.runExclusive(
-        async (local) =>
+        if (this.#remote && !layoutIsProject(localLayout)) {
           await local.put({
             ...localLayout,
+            working: {
+              data: localLayout.working?.data ?? localLayout.baseline.data,
+              savedAt: new Date().toISOString() as ISO8601Timestamp,
+            },
+            syncInfo: {
+              status: "locally-deleted",
+              lastRemoteSavedAt: localLayout.syncInfo?.lastRemoteSavedAt,
+              lastRemoteUpdatedAt: localLayout.syncInfo?.lastRemoteUpdatedAt,
+            },
+          });
+        } else {
+          // Don't have remote storage, or already deleted on remote
+          await local.delete(id);
+        }
+      });
+      this.#notifyChangeListeners({ type: "delete", layoutId: id });
+    });
+  }
+
+  public async overwriteLayout({
+    id,
+    data: unmigratedData,
+  }: {
+    id: LayoutID;
+    data?: LayoutData;
+  }): Promise<Layout> {
+    return await this.#runWithBusyStatus(async () => {
+      const now = new Date().toISOString() as ISO8601Timestamp;
+      const data = unmigratedData == undefined ? undefined : migratePanelsState(unmigratedData);
+
+      const result = await this.#local.runExclusive(async (local) => {
+        const localLayout = await local.get(id);
+        if (!localLayout) {
+          throw new Error(`Cannot overwrite layout ${id} because it does not exist`);
+        }
+
+        const dataToSave = data ?? localLayout.working?.data ?? localLayout.baseline.data;
+
+        if (layoutIsProject(localLayout)) {
+          if (!this.#remote) {
+            throw new Error("Shared layouts are not supported without remote layout storage");
+          }
+          if (!this.isOnline) {
+            throw new Error("Cannot save a shared layout while offline");
+          }
+
+          const layoutForSave = await local.put({
+            ...localLayout,
+            working: isLayoutEqual(localLayout.baseline.data, dataToSave)
+              ? undefined
+              : { data: dataToSave, savedAt: now },
+          });
+
+          await assertRemoteLayoutUnchanged(this.#remote, layoutForSave);
+          const updatedBaseline = await updateRemoteLayout(this.#remote, {
+            id,
+            parent: layoutForSave.parent,
+            data: dataToSave,
+            ...expectedRemoteTimestamps(layoutForSave),
+          });
+
+          const latestLayout = await local.get(id);
+          if (!latestLayout) {
+            throw new Error(`Cannot overwrite layout ${id} because it does not exist`);
+          }
+          return await local.put({
+            ...latestLayout,
             baseline: {
               data: updatedBaseline.data,
               savedAt: updatedBaseline.savedAt,
@@ -573,84 +623,88 @@ export default class CoSceneLayoutManager implements ILayoutManager {
               lastRemoteSavedAt: updatedBaseline.savedAt,
               lastRemoteUpdatedAt: updatedBaseline.updatedAt,
             },
-          }),
-      );
-      this.#notifyChangeListeners({ type: "change", updatedLayout: result });
+          });
+        }
+
+        const latestLayout = await local.get(id);
+        if (!latestLayout) {
+          throw new Error(`Cannot overwrite layout ${id} because it does not exist`);
+        }
+        return await local.put({
+          ...latestLayout,
+          baseline: {
+            data: dataToSave,
+            savedAt: now,
+            modifier: latestLayout.baseline.modifier,
+            modifierNickname: latestLayout.baseline.modifierNickname,
+          },
+          working: undefined,
+          syncInfo:
+            this.#remote && latestLayout.syncInfo?.status !== "new"
+              ? {
+                  status: "updated",
+                  lastRemoteSavedAt: latestLayout.syncInfo?.lastRemoteSavedAt,
+                  lastRemoteUpdatedAt: latestLayout.syncInfo?.lastRemoteUpdatedAt,
+                }
+              : latestLayout.syncInfo,
+        });
+      });
+      this.#notifyChangeListeners({ type: "change", updatedLayout: result, source: "overwrite" });
       return result;
-    } else {
-      const result = await this.#local.runExclusive(
-        async (local) =>
-          await local.put({
-            ...localLayout,
-            baseline: {
-              data: localLayout.working?.data ?? localLayout.baseline.data,
-              savedAt: now,
-              modifier: localLayout.baseline.modifier,
-              modifierNickname: localLayout.baseline.modifierNickname,
-            },
-            working: undefined,
-            syncInfo:
-              this.#remote && localLayout.syncInfo?.status !== "new"
-                ? {
-                    status: "updated",
-                    lastRemoteSavedAt: localLayout.syncInfo?.lastRemoteSavedAt,
-                    lastRemoteUpdatedAt: localLayout.syncInfo?.lastRemoteUpdatedAt,
-                  }
-                : localLayout.syncInfo,
-          }),
-      );
-      this.#notifyChangeListeners({ type: "change", updatedLayout: result });
-      return result;
-    }
+    });
   }
 
-  @(CoSceneLayoutManager.#withBusyStatus)
   public async revertLayout({ id }: { id: LayoutID }): Promise<Layout> {
-    const result = await this.#local.runExclusive(async (local) => {
-      const layout = await local.get(id);
-      if (!layout) {
-        throw new Error(`Cannot revert layout id ${id} because it does not exist`);
-      }
-      return await local.put({
-        ...layout,
-        working: undefined,
+    return await this.#runWithBusyStatus(async () => {
+      const result = await this.#local.runExclusive(async (local) => {
+        const layout = await local.get(id);
+        if (!layout) {
+          throw new Error(`Cannot revert layout id ${id} because it does not exist`);
+        }
+        return await local.put({
+          ...layout,
+          working: undefined,
+        });
       });
+      this.#notifyChangeListeners({ type: "change", updatedLayout: result });
+      return result;
     });
-    this.#notifyChangeListeners({ type: "change", updatedLayout: result });
-    return result;
   }
 
-  @(CoSceneLayoutManager.#withBusyStatus)
   public async makePersonalCopy({ id, name }: { id: LayoutID; name: string }): Promise<Layout> {
-    const now = new Date().toISOString() as ISO8601Timestamp;
+    return await this.#runWithBusyStatus(async () => {
+      const now = new Date().toISOString() as ISO8601Timestamp;
 
-    const result = await this.#local.runExclusive(async (local) => {
-      const layout = await local.get(id);
-      if (!layout) {
-        throw new Error(`Cannot make a personal copy of layout id ${id} because it does not exist`);
-      }
+      const result = await this.#local.runExclusive(async (local) => {
+        const layout = await local.get(id);
+        if (!layout) {
+          throw new Error(
+            `Cannot make a personal copy of layout id ${id} because it does not exist`,
+          );
+        }
 
-      const parent = this.userName ?? "";
-      const newLayout = await local.put({
-        id: `${parent}/layouts/${uuidv4()}` as LayoutID,
-        parent,
-        folder: layout.folder,
-        name,
-        permission: "PERSONAL_WRITE",
-        baseline: {
-          data: layout.working?.data ?? layout.baseline.data,
-          savedAt: now,
-          modifier: layout.baseline.modifier,
-          modifierNickname: layout.baseline.modifierNickname,
-        },
-        working: undefined,
-        syncInfo: { status: "new", lastRemoteSavedAt: now, lastRemoteUpdatedAt: now },
+        const parent = this.userName ?? "";
+        const newLayout = await local.put({
+          id: `${parent}/layouts/${uuidv4()}` as LayoutID,
+          parent,
+          folder: layout.folder,
+          name,
+          permission: "PERSONAL_WRITE",
+          baseline: {
+            data: layout.working?.data ?? layout.baseline.data,
+            savedAt: now,
+            modifier: layout.baseline.modifier,
+            modifierNickname: layout.baseline.modifierNickname,
+          },
+          working: undefined,
+          syncInfo: { status: "new", lastRemoteSavedAt: now, lastRemoteUpdatedAt: now },
+        });
+        await local.put({ ...layout, working: undefined });
+        return newLayout;
       });
-      await local.put({ ...layout, working: undefined });
-      return newLayout;
+      this.#notifyChangeListeners({ type: "change", updatedLayout: undefined });
+      return result;
     });
-    this.#notifyChangeListeners({ type: "change", updatedLayout: undefined });
-    return result;
   }
 
   /** Ensures at most one sync operation is in progress at a time */
@@ -661,29 +715,30 @@ export default class CoSceneLayoutManager implements ILayoutManager {
    * the cached and remote layout lists; it may also involve modifications to the cache, remote
    * storage, or both.
    */
-  @(CoSceneLayoutManager.#withBusyStatus)
   public async syncWithRemote(abortSignal: AbortSignal): Promise<void> {
-    if (this.#currentSync) {
-      log.debug("Layout sync is already in progress");
-      await this.#currentSync;
-      return;
-    }
-    const start = performance.now();
-    try {
-      log.debug("Starting layout sync");
-      this.#currentSync = this.#syncWithRemoteImpl(abortSignal);
-      await this.#currentSync;
-      this.#notifyChangeListeners({ type: "change", updatedLayout: undefined });
-      if (this.error) {
-        this.setError(undefined);
+    await this.#runWithBusyStatus(async () => {
+      if (this.#currentSync) {
+        log.debug("Layout sync is already in progress");
+        await this.#currentSync;
+        return;
       }
-    } catch (error) {
-      this.setError(error);
-      throw error;
-    } finally {
-      this.#currentSync = undefined;
-      log.debug(`Completed sync in ${((performance.now() - start) / 1000).toFixed(2)}s`);
-    }
+      const start = performance.now();
+      try {
+        log.debug("Starting layout sync");
+        this.#currentSync = this.#syncWithRemoteImpl(abortSignal);
+        await this.#currentSync;
+        this.#notifyChangeListeners({ type: "change", updatedLayout: undefined });
+        if (this.error) {
+          this.setError(undefined);
+        }
+      } catch (error) {
+        this.setError(error);
+        throw error;
+      } finally {
+        this.#currentSync = undefined;
+        log.debug(`Completed sync in ${((performance.now() - start) / 1000).toFixed(2)}s`);
+      }
+    });
   }
 
   async #syncWithRemoteImpl(abortSignal: AbortSignal): Promise<void> {
@@ -722,7 +777,13 @@ export default class CoSceneLayoutManager implements ILayoutManager {
         }
         switch (operation.type) {
           case "mark-deleted": {
-            const { localLayout } = operation;
+            const localLayout = await local.get(operation.localLayout.id);
+            if (!localLayout) {
+              break;
+            }
+            if (!localLayoutSyncSnapshotMatches(localLayout, operation.localLayout)) {
+              break;
+            }
             log.debug(`Marking layout as remotely deleted: ${localLayout.id}`);
             await local.put({
               ...localLayout,
@@ -735,16 +796,46 @@ export default class CoSceneLayoutManager implements ILayoutManager {
             break;
           }
 
-          case "delete-local":
+          case "delete-local": {
+            const localLayout = await local.get(operation.localLayout.id);
+            if (!localLayout) {
+              break;
+            }
+            if (
+              !localLayoutSyncSnapshotMatches(localLayout, operation.localLayout) ||
+              localLayout.syncInfo?.status === "updated"
+            ) {
+              break;
+            }
+            if (
+              localLayout.working != undefined &&
+              localLayout.syncInfo?.status !== "locally-deleted"
+            ) {
+              if (layoutIsProject(localLayout)) {
+                await local.put({
+                  ...localLayout,
+                  syncInfo: {
+                    status: "remotely-deleted",
+                    lastRemoteSavedAt: undefined,
+                    lastRemoteUpdatedAt: undefined,
+                  },
+                });
+              }
+              break;
+            }
             log.debug(
-              `Deleting local layout ${operation.localLayout.id}, whose sync status was ${operation.localLayout.syncInfo?.status}`,
+              `Deleting local layout ${localLayout.id}, whose sync status was ${localLayout.syncInfo?.status}`,
             );
-            await local.delete(operation.localLayout.id);
-            this.#notifyChangeListeners({ type: "delete", layoutId: operation.localLayout.id });
+            await local.delete(localLayout.id);
+            this.#notifyChangeListeners({ type: "delete", layoutId: localLayout.id });
             break;
+          }
 
           case "add-to-cache": {
             const { remoteLayout } = operation;
+            if ((await local.get(remoteLayout.id)) != undefined) {
+              break;
+            }
             log.debug(`Adding layout to cache: ${remoteLayout.id}`);
             await local.put({
               id: remoteLayout.id,
@@ -769,7 +860,17 @@ export default class CoSceneLayoutManager implements ILayoutManager {
           }
 
           case "update-baseline": {
-            const { localLayout, remoteLayout } = operation;
+            const { remoteLayout } = operation;
+            const localLayout = await local.get(operation.localLayout.id);
+            if (!localLayout?.syncInfo) {
+              break;
+            }
+            if (
+              !localLayoutSyncSnapshotMatches(localLayout, operation.localLayout) ||
+              localLayout.syncInfo.status === "updated"
+            ) {
+              break;
+            }
             log.debug(`Updating baseline for ${localLayout.id}`);
             await local.put({
               id: remoteLayout.id,
@@ -810,20 +911,25 @@ export default class CoSceneLayoutManager implements ILayoutManager {
     // server ops can be done without blocking other local sync operations.
     type CleanupFunction = (local: NamespacedLayoutStorage) => Promise<void>;
 
-    const cleanups = await Promise.all(
+    const cleanupResults = await Promise.allSettled(
       operations.map(async (operation): Promise<CleanupFunction> => {
         switch (operation.type) {
           case "delete-remote": {
             const { localLayout } = operation;
             log.debug(`Deleting remote layout ${localLayout.id}`);
-            if (!(await remote.deleteLayout(localLayout.id))) {
+            if (
+              !(await remote.deleteLayout(localLayout.id, expectedRemoteTimestamps(localLayout)))
+            ) {
               log.warn(`Deleting layout ${localLayout.id} which was not present in remote storage`);
             }
             return async (local) => {
               if (abortSignal.aborted) {
                 return;
               }
-              await local.delete(localLayout.id);
+              const currentLayout = await local.get(localLayout.id);
+              if (currentLayout?.syncInfo?.status === localLayout.syncInfo?.status) {
+                await local.delete(localLayout.id);
+              }
             };
           }
 
@@ -840,11 +946,22 @@ export default class CoSceneLayoutManager implements ILayoutManager {
             });
             return async (local) => {
               // Don't check abortSignal; we need the cache to be updated to show the layout is tracked
+              const currentLayout = await local.get(localLayout.id);
+              if (!currentLayout) {
+                return;
+              }
+              if (currentLayout.syncInfo?.status !== localLayout.syncInfo?.status) {
+                return;
+              }
+              const changedSinceUpload =
+                currentLayout.name !== localLayout.name ||
+                currentLayout.folder !== localLayout.folder ||
+                !isLayoutEqual(currentLayout.baseline.data, localLayout.baseline.data);
               await local.put({
-                ...localLayout,
-                baseline: { ...localLayout.baseline, savedAt: newBaseline.savedAt },
+                ...currentLayout,
+                baseline: { ...currentLayout.baseline, savedAt: newBaseline.savedAt },
                 syncInfo: {
-                  status: "tracked",
+                  status: changedSinceUpload ? "updated" : "tracked",
                   lastRemoteSavedAt: newBaseline.savedAt,
                   lastRemoteUpdatedAt: newBaseline.updatedAt,
                 },
@@ -855,20 +972,35 @@ export default class CoSceneLayoutManager implements ILayoutManager {
           case "upload-updated": {
             const { localLayout } = operation;
             log.debug(`Uploading updated layout ${localLayout.id}`);
-            const newBaseline = await updateOrFetchLayout(remote, {
+            const newBaseline = await updateRemoteLayout(remote, {
               id: localLayout.id,
               parent: localLayout.parent,
               name: localLayout.name,
+              folder: localLayout.folder,
               data: localLayout.baseline.data,
+              ...expectedRemoteTimestamps(localLayout),
               // savedAt:
               //   localLayout.baseline.savedAt ?? (new Date().toISOString() as ISO8601Timestamp),
             });
             return async (local) => {
               // Don't check abortSignal; we need the cache to be updated to show the layout is tracked
+              const currentLayout = await local.get(localLayout.id);
+              if (!currentLayout) {
+                return;
+              }
+              if (
+                currentLayout.syncInfo?.status !== localLayout.syncInfo?.status ||
+                currentLayout.name !== localLayout.name ||
+                currentLayout.folder !== localLayout.folder ||
+                !isLayoutEqual(currentLayout.baseline.data, localLayout.baseline.data)
+              ) {
+                return;
+              }
               await local.put({
-                ...localLayout,
+                ...currentLayout,
                 name: newBaseline.name,
-                baseline: { ...localLayout.baseline, savedAt: newBaseline.savedAt },
+                folder: newBaseline.folder,
+                baseline: { ...currentLayout.baseline, savedAt: newBaseline.savedAt },
                 syncInfo: {
                   status: "tracked",
                   lastRemoteSavedAt: newBaseline.savedAt,
@@ -880,6 +1012,12 @@ export default class CoSceneLayoutManager implements ILayoutManager {
         }
       }),
     );
+    const cleanups = cleanupResults
+      .filter(
+        (result): result is PromiseFulfilledResult<CleanupFunction> =>
+          result.status === "fulfilled",
+      )
+      .map((result) => result.value);
 
     await this.#local.runExclusive(async (local) => {
       await Promise.all(
@@ -888,6 +1026,13 @@ export default class CoSceneLayoutManager implements ILayoutManager {
         }),
       );
     });
+
+    const failedResult = cleanupResults.find(
+      (result): result is PromiseRejectedResult => result.status === "rejected",
+    );
+    if (failedResult) {
+      throw failedResult.reason;
+    }
   }
 
   // sync remote layouts to local, then user can use layouts in offline status
@@ -906,7 +1051,13 @@ export default class CoSceneLayoutManager implements ILayoutManager {
 
         switch (operation.type) {
           case "mark-deleted": {
-            const { localLayout } = operation;
+            const localLayout = await local.get(operation.localLayout.id);
+            if (!localLayout) {
+              break;
+            }
+            if (!localLayoutSyncSnapshotMatches(localLayout, operation.localLayout)) {
+              break;
+            }
             log.debug(`Marking layout as remotely deleted: ${localLayout.id}`);
             await local.put({
               ...localLayout,
@@ -919,20 +1070,50 @@ export default class CoSceneLayoutManager implements ILayoutManager {
             break;
           }
 
-          case "delete-local":
+          case "delete-local": {
+            const localLayout = await local.get(operation.localLayout.id);
+            if (!localLayout) {
+              break;
+            }
+            if (
+              !localLayoutSyncSnapshotMatches(localLayout, operation.localLayout) ||
+              localLayout.syncInfo?.status === "updated"
+            ) {
+              break;
+            }
+            if (
+              localLayout.working != undefined &&
+              localLayout.syncInfo?.status !== "locally-deleted"
+            ) {
+              if (layoutIsProject(localLayout)) {
+                await local.put({
+                  ...localLayout,
+                  syncInfo: {
+                    status: "remotely-deleted",
+                    lastRemoteSavedAt: undefined,
+                    lastRemoteUpdatedAt: undefined,
+                  },
+                });
+              }
+              break;
+            }
             log.debug(
-              `Deleting local layout ${operation.localLayout.id}, whose sync status was ${operation.localLayout.syncInfo?.status}`,
+              `Deleting local layout ${localLayout.id}, whose sync status was ${localLayout.syncInfo?.status}`,
             );
-            await local.delete(operation.localLayout.id);
-            this.#notifyChangeListeners({ type: "delete", layoutId: operation.localLayout.id });
+            await local.delete(localLayout.id);
+            this.#notifyChangeListeners({ type: "delete", layoutId: localLayout.id });
             break;
+          }
 
           case "add-to-cache": {
             const { remoteLayout } = operation;
             log.debug(`Adding layout to cache: ${remoteLayout.id}`);
 
             // only backup layouts with personal layout
-            if (remoteLayout.permission === "PERSONAL_WRITE") {
+            if (
+              remoteLayout.permission === "PERSONAL_WRITE" &&
+              (await local.get(remoteLayout.id)) == undefined
+            ) {
               await local.put({
                 id: remoteLayout.id,
                 parent: remoteLayout.parent,
@@ -957,7 +1138,17 @@ export default class CoSceneLayoutManager implements ILayoutManager {
           }
 
           case "update-baseline": {
-            const { localLayout, remoteLayout } = operation;
+            const { remoteLayout } = operation;
+            const localLayout = await local.get(operation.localLayout.id);
+            if (!localLayout?.syncInfo) {
+              break;
+            }
+            if (
+              !localLayoutSyncSnapshotMatches(localLayout, operation.localLayout) ||
+              localLayout.syncInfo.status === "updated"
+            ) {
+              break;
+            }
             log.debug(`Updating baseline for ${localLayout.id}`);
 
             // only backup layouts with personal layout

--- a/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.ts
+++ b/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.ts
@@ -568,7 +568,7 @@ export default class CoSceneLayoutManager implements ILayoutManager {
           throw new Error("Cannot delete a shared layout while offline");
         }
         if (!(await remote.deleteLayout(id, expectedRemoteTimestamps(snapshot)))) {
-          throw remoteConflictError(id);
+          log.debug(`Deleting shared layout ${id} which was already absent in remote storage`);
         }
       }
 
@@ -928,7 +928,8 @@ export default class CoSceneLayoutManager implements ILayoutManager {
             ) {
               break;
             }
-            if ((await local.get(remoteLayout.id)) != undefined) {
+            const existingLayout = await local.get(remoteLayout.id);
+            if (existingLayout != undefined && options.backupPersonalOnly !== true) {
               break;
             }
             log.debug(`Adding layout to cache: ${remoteLayout.id}`);
@@ -1115,19 +1116,27 @@ export default class CoSceneLayoutManager implements ILayoutManager {
                 if (!localLayoutSyncSnapshotMatches(currentLayout, localLayout)) {
                   return false;
                 }
+                const hasDataConflict = !isLayoutEqual(
+                  remoteLayout.data,
+                  currentLayout.baseline.data,
+                );
+                const hasLocalMetadataChanges =
+                  !hasDataConflict &&
+                  (currentLayout.name !== remoteLayout.name ||
+                    currentLayout.folder !== remoteLayout.folder);
                 const working =
                   currentLayout.working ??
-                  (isLayoutEqual(remoteLayout.data, currentLayout.baseline.data)
-                    ? undefined
-                    : {
+                  (hasDataConflict
+                    ? {
                         data: currentLayout.baseline.data,
                         savedAt: currentLayout.baseline.savedAt,
-                      });
+                      }
+                    : undefined);
                 await local.put({
                   ...currentLayout,
                   parent: remoteLayout.parent,
-                  name: remoteLayout.name,
-                  folder: remoteLayout.folder,
+                  name: hasLocalMetadataChanges ? currentLayout.name : remoteLayout.name,
+                  folder: hasLocalMetadataChanges ? currentLayout.folder : remoteLayout.folder,
                   permission: remoteLayout.permission,
                   baseline: {
                     data: remoteLayout.data,
@@ -1137,7 +1146,7 @@ export default class CoSceneLayoutManager implements ILayoutManager {
                   },
                   working,
                   syncInfo: {
-                    status: "tracked",
+                    status: hasLocalMetadataChanges ? "updated" : "tracked",
                     lastRemoteSavedAt: remoteLayout.savedAt,
                     lastRemoteUpdatedAt: remoteLayout.updatedAt,
                   },
@@ -1151,21 +1160,33 @@ export default class CoSceneLayoutManager implements ILayoutManager {
               if (!currentLayout) {
                 return false;
               }
-              if (
-                currentLayout.syncInfo?.status !== localLayout.syncInfo?.status ||
-                currentLayout.name !== localLayout.name ||
-                currentLayout.folder !== localLayout.folder ||
-                !isLayoutEqual(currentLayout.baseline.data, localLayout.baseline.data)
-              ) {
+              if (currentLayout.syncInfo?.status !== localLayout.syncInfo?.status) {
+                if (currentLayout.syncInfo?.status === "locally-deleted") {
+                  await local.put({
+                    ...currentLayout,
+                    syncInfo: {
+                      status: "locally-deleted",
+                      lastRemoteSavedAt: newBaseline.savedAt,
+                      lastRemoteUpdatedAt: newBaseline.updatedAt,
+                    },
+                  });
+                  return true;
+                }
                 return false;
               }
+              const changedSinceUpload =
+                currentLayout.name !== localLayout.name ||
+                currentLayout.folder !== localLayout.folder ||
+                !isLayoutEqual(currentLayout.baseline.data, localLayout.baseline.data);
               await local.put({
                 ...currentLayout,
-                name: newBaseline.name,
-                folder: newBaseline.folder,
-                baseline: { ...currentLayout.baseline, savedAt: newBaseline.savedAt },
+                name: changedSinceUpload ? currentLayout.name : newBaseline.name,
+                folder: changedSinceUpload ? currentLayout.folder : newBaseline.folder,
+                baseline: changedSinceUpload
+                  ? currentLayout.baseline
+                  : { ...currentLayout.baseline, savedAt: newBaseline.savedAt },
                 syncInfo: {
-                  status: "tracked",
+                  status: changedSinceUpload ? "updated" : "tracked",
                   lastRemoteSavedAt: newBaseline.savedAt,
                   lastRemoteUpdatedAt: newBaseline.updatedAt,
                 },

--- a/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.ts
+++ b/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.ts
@@ -42,8 +42,18 @@ import { migratePanelsState } from "../migrateLayout";
 
 const log = Logger.getLogger(__filename);
 
-function remoteConflictError(id: LayoutID): Error {
-  return new Error(`Layout ${id} has changed on the server; local changes were not saved.`);
+class RemoteLayoutConflictError extends Error {
+  public readonly layoutId: LayoutID;
+
+  public constructor(layoutId: LayoutID) {
+    super(`Layout ${layoutId} has changed on the server; local changes were not saved.`);
+    this.name = "RemoteLayoutConflictError";
+    this.layoutId = layoutId;
+  }
+}
+
+function remoteConflictError(id: LayoutID): RemoteLayoutConflictError {
+  return new RemoteLayoutConflictError(id);
 }
 
 function expectedRemoteTimestamps(layout: Layout): {
@@ -847,7 +857,7 @@ export default class CoSceneLayoutManager implements ILayoutManager {
     storage: MutexLocked<NamespacedLayoutStorage>,
     operations: readonly (SyncOperation & { local: true })[],
     abortSignal: AbortSignal,
-    options: { backupPersonalOnly?: boolean } = {},
+    options: { backupPersonalOnly?: boolean; emitDeleteNotifications?: boolean } = {},
   ): Promise<void> {
     await storage.runExclusive(async (local) => {
       for (const operation of operations) {
@@ -904,7 +914,9 @@ export default class CoSceneLayoutManager implements ILayoutManager {
               `Deleting local layout ${localLayout.id}, whose sync status was ${localLayout.syncInfo?.status}`,
             );
             await local.delete(localLayout.id);
-            this.#notifyChangeListeners({ type: "delete", layoutId: localLayout.id });
+            if (options.emitDeleteNotifications !== false) {
+              this.#notifyChangeListeners({ type: "delete", layoutId: localLayout.id });
+            }
             break;
           }
 
@@ -998,7 +1010,7 @@ export default class CoSceneLayoutManager implements ILayoutManager {
 
     // Any necessary local cleanups are performed all at once after the server operations, so the
     // server ops can be done without blocking other local sync operations.
-    type CleanupFunction = (local: NamespacedLayoutStorage) => Promise<void>;
+    type CleanupFunction = (local: NamespacedLayoutStorage) => Promise<boolean>;
 
     const cleanupResults = await Promise.allSettled(
       operations.map(async (operation): Promise<CleanupFunction> => {
@@ -1013,12 +1025,14 @@ export default class CoSceneLayoutManager implements ILayoutManager {
             }
             return async (local) => {
               if (abortSignal.aborted) {
-                return;
+                return false;
               }
               const currentLayout = await local.get(localLayout.id);
               if (currentLayout?.syncInfo?.status === localLayout.syncInfo?.status) {
                 await local.delete(localLayout.id);
+                return true;
               }
+              return false;
             };
           }
 
@@ -1037,10 +1051,21 @@ export default class CoSceneLayoutManager implements ILayoutManager {
               // Don't check abortSignal; we need the cache to be updated to show the layout is tracked
               const currentLayout = await local.get(localLayout.id);
               if (!currentLayout) {
-                return;
+                return false;
               }
               if (currentLayout.syncInfo?.status !== localLayout.syncInfo?.status) {
-                return;
+                if (currentLayout.syncInfo?.status === "locally-deleted") {
+                  await local.put({
+                    ...currentLayout,
+                    syncInfo: {
+                      status: "locally-deleted",
+                      lastRemoteSavedAt: newBaseline.savedAt,
+                      lastRemoteUpdatedAt: newBaseline.updatedAt,
+                    },
+                  });
+                  return true;
+                }
+                return false;
               }
               const changedSinceUpload =
                 currentLayout.name !== localLayout.name ||
@@ -1055,27 +1080,76 @@ export default class CoSceneLayoutManager implements ILayoutManager {
                   lastRemoteUpdatedAt: newBaseline.updatedAt,
                 },
               });
+              return true;
             };
           }
 
           case "upload-updated": {
             const { localLayout } = operation;
             log.debug(`Uploading updated layout ${localLayout.id}`);
-            const newBaseline = await updateRemoteLayout(remote, {
-              id: localLayout.id,
-              parent: localLayout.parent,
-              name: localLayout.name,
-              folder: localLayout.folder,
-              data: localLayout.baseline.data,
-              ...expectedRemoteTimestamps(localLayout),
-              // savedAt:
-              //   localLayout.baseline.savedAt ?? (new Date().toISOString() as ISO8601Timestamp),
-            });
+            let newBaseline: RemoteLayout;
+            try {
+              newBaseline = await updateRemoteLayout(remote, {
+                id: localLayout.id,
+                parent: localLayout.parent,
+                name: localLayout.name,
+                folder: localLayout.folder,
+                data: localLayout.baseline.data,
+                ...expectedRemoteTimestamps(localLayout),
+                // savedAt:
+                //   localLayout.baseline.savedAt ?? (new Date().toISOString() as ISO8601Timestamp),
+              });
+            } catch (error) {
+              if (!(error instanceof RemoteLayoutConflictError)) {
+                throw error;
+              }
+              const remoteLayout = await remote.getLayout(localLayout.id);
+              if (!remoteLayout) {
+                throw error;
+              }
+              return async (local) => {
+                const currentLayout = await local.get(localLayout.id);
+                if (!currentLayout) {
+                  return false;
+                }
+                if (!localLayoutSyncSnapshotMatches(currentLayout, localLayout)) {
+                  return false;
+                }
+                const working =
+                  currentLayout.working ??
+                  (isLayoutEqual(remoteLayout.data, currentLayout.baseline.data)
+                    ? undefined
+                    : {
+                        data: currentLayout.baseline.data,
+                        savedAt: currentLayout.baseline.savedAt,
+                      });
+                await local.put({
+                  ...currentLayout,
+                  parent: remoteLayout.parent,
+                  name: remoteLayout.name,
+                  folder: remoteLayout.folder,
+                  permission: remoteLayout.permission,
+                  baseline: {
+                    data: remoteLayout.data,
+                    savedAt: remoteLayout.savedAt,
+                    modifier: remoteLayout.modifier,
+                    modifierNickname: remoteLayout.modifierNickname,
+                  },
+                  working,
+                  syncInfo: {
+                    status: "tracked",
+                    lastRemoteSavedAt: remoteLayout.savedAt,
+                    lastRemoteUpdatedAt: remoteLayout.updatedAt,
+                  },
+                });
+                return true;
+              };
+            }
             return async (local) => {
               // Don't check abortSignal; we need the cache to be updated to show the layout is tracked
               const currentLayout = await local.get(localLayout.id);
               if (!currentLayout) {
-                return;
+                return false;
               }
               if (
                 currentLayout.syncInfo?.status !== localLayout.syncInfo?.status ||
@@ -1083,7 +1157,7 @@ export default class CoSceneLayoutManager implements ILayoutManager {
                 currentLayout.folder !== localLayout.folder ||
                 !isLayoutEqual(currentLayout.baseline.data, localLayout.baseline.data)
               ) {
-                return;
+                return false;
               }
               await local.put({
                 ...currentLayout,
@@ -1096,6 +1170,7 @@ export default class CoSceneLayoutManager implements ILayoutManager {
                   lastRemoteUpdatedAt: newBaseline.updatedAt,
                 },
               });
+              return true;
             };
           }
         }
@@ -1108,18 +1183,22 @@ export default class CoSceneLayoutManager implements ILayoutManager {
       )
       .map((result) => result.value);
 
-    await this.#local.runExclusive(async (local) => {
-      await Promise.all(
+    const didApplyCleanup = await this.#local.runExclusive(async (local) => {
+      const cleanupApplied = await Promise.all(
         cleanups.map(async (cleanup) => {
-          await cleanup(local);
+          return await cleanup(local);
         }),
       );
+      return cleanupApplied.some(Boolean);
     });
 
     const failedResult = cleanupResults.find(
       (result): result is PromiseRejectedResult => result.status === "rejected",
     );
     if (failedResult) {
+      if (didApplyCleanup) {
+        this.#notifyChangeListeners({ type: "change", updatedLayout: undefined });
+      }
       throw failedResult.reason;
     }
   }
@@ -1134,6 +1213,7 @@ export default class CoSceneLayoutManager implements ILayoutManager {
     }
     await this.#performLocalSyncOperationsInStorage(this.#backupLocal, operations, abortSignal, {
       backupPersonalOnly: true,
+      emitDeleteNotifications: false,
     });
   }
 

--- a/packages/studio-base/src/services/LayoutManager/coSceneComputeLayoutSyncOperations.ts
+++ b/packages/studio-base/src/services/LayoutManager/coSceneComputeLayoutSyncOperations.ts
@@ -94,16 +94,16 @@ export default function coSceneComputeLayoutSyncOperations(
           break;
         case "updated":
           if (!layoutIsProject(localLayout)) {
-            ops.push({ local: true, type: "delete-local", localLayout });
+            ops.push({ local: false, type: "upload-new", localLayout });
           } else {
             ops.push({ local: true, type: "mark-deleted", localLayout });
           }
           break;
         case "tracked":
-          if (localLayout.working == undefined || !layoutIsProject(localLayout)) {
-            ops.push({ local: true, type: "delete-local", localLayout });
-          } else {
+          if (localLayout.working != undefined) {
             ops.push({ local: true, type: "mark-deleted", localLayout });
+          } else {
+            ops.push({ local: true, type: "delete-local", localLayout });
           }
           break;
         case "locally-deleted":

--- a/packages/studio-base/src/services/LayoutManager/coSceneComputeLayoutSyncOperations.ts
+++ b/packages/studio-base/src/services/LayoutManager/coSceneComputeLayoutSyncOperations.ts
@@ -58,7 +58,10 @@ export default function coSceneComputeLayoutSyncOperations(
             break;
           }
 
-          if (localLayout.syncInfo.lastRemoteSavedAt !== remoteLayout.savedAt) {
+          if (
+            localLayout.syncInfo.lastRemoteSavedAt !== remoteLayout.savedAt ||
+            localLayout.syncInfo.lastRemoteUpdatedAt !== remoteLayout.updatedAt
+          ) {
             ops.push({
               local: true,
               type: "update-baseline",


### PR DESCRIPTION
## Summary

Refactors the layout data/sync path while keeping the existing UI and interactions intact.

- Saves now use the current in-memory selected layout data instead of stale debounced working state.
- Autosave failures keep retryable pending layout snapshots and avoid reintroducing stale snapshots after explicit saves.
- Layout manager read-modify-write paths now re-read under the local mutex and guard sync cleanups with local snapshots.
- Remote sync treats list failures as hard failures, compares both `savedAt` and `updatedAt`, preserves local working drafts, and avoids silent project-layout overwrites with conservative timestamp checks.
- URL layout fallback now selects the first personal layout, then valid history, then opens the existing layout drawer.
- Project layouts deleted remotely now preserve local drafts while entering the existing `remotely-deleted` feedback state.

## Validation

- `yarn jest --runTestsByPath packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.test.ts packages/studio-base/src/services/CoSceneConsoleApiRemoteLayoutStorage.test.ts packages/studio-base/src/providers/CurrentLayoutProvider/index.test.tsx packages/studio-base/src/hooks/useSyncLayoutFromUrl.test.ts --runInBand`
- `yarn exec tsc -p packages/studio-base/tsconfig.json --noEmit`
- `git diff --check`

Subagent review loop completed: 8 rounds, with the final clean review reporting no new P0/P1/P2 issues.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785657684&installation_id=141984720&pr_number=1386&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1386&signature=0ae2b3310a9f812e272c3e3bb86f1a4c3806c571f74e829201d639934cf141fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->