### PR TITLE
feat: add ESA deploy workflow

### DIFF
--- a/.github/workflows/deploy-esa.yml
+++ b/.github/workflows/deploy-esa.yml
@@ -1,0 +1,74 @@
+name: deploy-esa
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Build and deploy web
+    runs-on: gcp
+    environment: saas
+    timeout-minutes: 30
+
+    env:
+      GH_PACKAGES_ORG_TOKEN: ${{ secrets.GH_PACKAGES_ORG_TOKEN }}
+      ALIBABA_CLOUD_ACCESS_KEY_ID: ${{ secrets.ALIBABA_CLOUD_ACCESS_KEY_ID }}
+      ALIBABA_CLOUD_ACCESS_KEY_SECRET: ${{ secrets.ALIBABA_CLOUD_ACCESS_KEY_SECRET }}
+      CONFIG_FILE_URL: ${{ vars.CONFIG_FILE_URL }}
+      ESA_SITE_ID: "152922880180456"
+      ESA_ROUTINE_NAME: honeybee-viz-staging
+      HONEYBEE_WEB_PUBLIC_PATH: /
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Validate deployment configuration
+        run: |
+          set -euo pipefail
+          : "${GH_PACKAGES_ORG_TOKEN:?GH_PACKAGES_ORG_TOKEN secret is required}"
+          : "${ALIBABA_CLOUD_ACCESS_KEY_ID:?ALIBABA_CLOUD_ACCESS_KEY_ID secret is required}"
+          : "${ALIBABA_CLOUD_ACCESS_KEY_SECRET:?ALIBABA_CLOUD_ACCESS_KEY_SECRET secret is required}"
+          : "${CONFIG_FILE_URL:?CONFIG_FILE_URL variable is required}"
+          : "${ESA_ROUTINE_NAME:?ESA_ROUTINE_NAME variable is required}"
+
+      - name: Enable corepack
+        run: corepack enable yarn
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Set cos config file
+        run: |
+          set -euo pipefail
+          curl -fsSL "${CONFIG_FILE_URL}" -o packages/studio-web/public/cos-config.js
+
+      - name: Build web production files
+        run: yarn run web:build:prod
+
+      - name: Validate web artifacts
+        run: |
+          set -euo pipefail
+          test -s web/.webpack/index.html
+          find web/.webpack -type f -name '*.js' -print -quit | grep -q .
+          if grep -q '/viz/cos-config.js' web/.webpack/index.html; then
+            echo "index.html still references /viz/cos-config.js"
+            exit 1
+          fi
+          grep -q '/cos-config.js' web/.webpack/index.html
+
+      - name: Deploy to ESA
+        run: node ci/deploy-esa.mjs


### PR DESCRIPTION
## Summary

Honeybee now has a manually triggered `deploy-esa` GitHub Actions workflow for building the web app at the domain root and deploying it to Alibaba Cloud ESA settings for `https://viz.coscene.cn/`.

This PR intentionally contains only the workflow file. The workflow expects the ESA deploy script at `ci/deploy-esa.mjs` to be present before it can run successfully.

## Validation

- Parsed `.github/workflows/deploy-esa.yml` with Ruby YAML
- `git diff --check`

## Post-Deploy Monitoring & Validation

After the matching deploy script is available, manually trigger `deploy-esa` and verify the run reaches dependency install, config download, root-path web build, artifact validation, and ESA deploy steps. Confirm `https://viz.coscene.cn/` loads the app and that the generated HTML references `/cos-config.js` instead of `/viz/cos-config.js`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785923547&installation_id=141984720&pr_number=1389&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1389&signature=24517680e49c86bae80a346ad56dbbcc0ba156a8ebf36cdcceb415e0e205a821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->