### PR TITLE
Fix compressed video playback review feedback

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.test.ts
@@ -633,6 +633,74 @@ describe("CompressedVideoController", () => {
     ]);
   });
 
+  it("keeps playback paused when a failed reset replay starts another cached replay", async () => {
+    const keyframe = makeVideoMessage(0n, "key");
+    const firstDelta = makeVideoMessage(10_000_000n, "delta");
+    const resetDelta = makeVideoMessage(20_000_000n, "delta");
+    const laterDelta = makeVideoMessage(30_000_000n, "delta");
+    let resolveFirstReplay!: (result: ImageSetImageResult) => void;
+    let resolveSecondReplay!: (result: ImageSetImageResult) => void;
+    const firstReplay = new Promise<ImageSetImageResult>((resolve) => {
+      resolveFirstReplay = resolve;
+    });
+    const secondReplay = new Promise<ImageSetImageResult>((resolve) => {
+      resolveSecondReplay = resolve;
+    });
+    const releases: jest.Mock[] = [];
+    const acquireSeekKeyframeSearchPlaybackPause = jest.fn(() => {
+      const release = jest.fn();
+      releases.push(release);
+      return release;
+    });
+    const displayFrames = jest.fn<
+      Promise<ImageSetImageResult>,
+      Parameters<CompressedVideoDisplayFrames>
+    >(async (frames) => {
+      const times = frameReceiveTimes(frames).join(",");
+      if (times === "0,10000000,20000000") {
+        return await firstReplay;
+      }
+      if (times === "0,10000000,20000000,30000000") {
+        return await secondReplay;
+      }
+      return { ok: true };
+    });
+    const controller = makeController({
+      renderer: makeRenderer({ acquireSeekKeyframeSearchPlaybackPause }),
+      displayFrames,
+    });
+
+    controller.processMessage(keyframe);
+    controller.processMessage(firstDelta);
+    await flushAsyncWork();
+
+    controller.resetPlaybackState();
+    displayFrames.mockClear();
+
+    controller.processMessage(resetDelta);
+    await flushAsyncWork();
+    controller.processMessage(laterDelta);
+    await flushAsyncWork();
+
+    expect(acquireSeekKeyframeSearchPlaybackPause).toHaveBeenCalledTimes(1);
+
+    resolveFirstReplay({ ok: false, reason: "failed" });
+    await flushAsyncWork();
+
+    expect(nonResetCalls(displayFrames).map(([frames]) => frameReceiveTimes(frames))).toEqual([
+      [0n, 10_000_000n, 20_000_000n],
+      [0n, 10_000_000n, 20_000_000n, 30_000_000n],
+    ]);
+    expect(acquireSeekKeyframeSearchPlaybackPause).toHaveBeenCalledTimes(2);
+    expect(releases[0]).toHaveBeenCalledTimes(1);
+    expect(releases[1]).not.toHaveBeenCalled();
+
+    resolveSecondReplay({ ok: true });
+    await flushAsyncWork();
+
+    expect(releases[1]).toHaveBeenCalledTimes(1);
+  });
+
   it("uses progressive lookback when seek receives a delta frame outside the cache", async () => {
     const keyframe = makeVideoMessage(0n, "key");
     const delta = makeVideoMessage(10_000_000n, "delta");

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.test.ts
@@ -546,6 +546,93 @@ describe("CompressedVideoController", () => {
     expect(nonResetCalls(displayFrames).map((call) => call[2]?.decodeMode)).toEqual(["exact"]);
   });
 
+  it("resumes buffered playback keyframes after cached playback replay fails", async () => {
+    const keyframe = makeVideoMessage(0n, "key");
+    const firstDelta = makeVideoMessage(10_000_000n, "delta");
+    const resetDelta = makeVideoMessage(20_000_000n, "delta");
+    const nextKeyframe = makeVideoMessage(30_000_000n, "key");
+    const nextDelta = makeVideoMessage(40_000_000n, "delta");
+    let resolveReplay!: (result: ImageSetImageResult) => void;
+    const failedReplay = new Promise<ImageSetImageResult>((resolve) => {
+      resolveReplay = resolve;
+    });
+    const displayFrames = jest.fn<
+      Promise<ImageSetImageResult>,
+      Parameters<CompressedVideoDisplayFrames>
+    >(async (frames) => {
+      return frameReceiveTimes(frames).join(",") === "0,10000000,20000000"
+        ? await failedReplay
+        : { ok: true };
+    });
+    const controller = makeController({ displayFrames });
+
+    controller.processMessage(keyframe);
+    controller.processMessage(firstDelta);
+    await flushAsyncWork();
+
+    controller.resetPlaybackState();
+    displayFrames.mockClear();
+
+    controller.processMessage(resetDelta);
+    await flushAsyncWork();
+    controller.processMessage(nextKeyframe);
+    controller.processMessage(nextDelta);
+    await flushAsyncWork();
+
+    expect(nonResetCalls(displayFrames).map(([frames]) => frameReceiveTimes(frames))).toEqual([
+      [0n, 10_000_000n, 20_000_000n],
+    ]);
+
+    resolveReplay({ ok: false, reason: "failed" });
+    await flushAsyncWork();
+
+    expect(nonResetCalls(displayFrames).map(([frames]) => frameReceiveTimes(frames))).toEqual([
+      [0n, 10_000_000n, 20_000_000n],
+      [30_000_000n],
+      [40_000_000n],
+    ]);
+  });
+
+  it("retries cached playback replay for later deltas after a failed reset replay", async () => {
+    const keyframe = makeVideoMessage(0n, "key");
+    const firstDelta = makeVideoMessage(10_000_000n, "delta");
+    const resetDelta = makeVideoMessage(20_000_000n, "delta");
+    const laterDelta = makeVideoMessage(30_000_000n, "delta");
+    let failedResetReplay = false;
+    const displayFrames = jest.fn<
+      Promise<ImageSetImageResult>,
+      Parameters<CompressedVideoDisplayFrames>
+    >(async (frames) => {
+      if (!failedResetReplay && frameReceiveTimes(frames).join(",") === "0,10000000,20000000") {
+        failedResetReplay = true;
+        return { ok: false, reason: "failed" };
+      }
+      return { ok: true };
+    });
+    const controller = makeController({ displayFrames });
+
+    controller.processMessage(keyframe);
+    controller.processMessage(firstDelta);
+    await flushAsyncWork();
+
+    controller.resetPlaybackState();
+    displayFrames.mockClear();
+
+    controller.processMessage(resetDelta);
+    await flushAsyncWork();
+    controller.processMessage(laterDelta);
+    await flushAsyncWork();
+
+    expect(nonResetCalls(displayFrames).map(([frames]) => frameReceiveTimes(frames))).toEqual([
+      [0n, 10_000_000n, 20_000_000n],
+      [0n, 10_000_000n, 20_000_000n, 30_000_000n],
+    ]);
+    expect(nonResetCalls(displayFrames).map((call) => call[2]?.decodeMode)).toEqual([
+      "exact",
+      "exact",
+    ]);
+  });
+
   it("uses progressive lookback when seek receives a delta frame outside the cache", async () => {
     const keyframe = makeVideoMessage(0n, "key");
     const delta = makeVideoMessage(10_000_000n, "delta");

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.test.ts
@@ -519,6 +519,33 @@ describe("CompressedVideoController", () => {
     expect(events).toEqual(["reset", "display:0,10000000"]);
   });
 
+  it("replays cached GOP frames for the first delta after playback reset", async () => {
+    const keyframe = makeVideoMessage(0n, "key");
+    const firstDelta = makeVideoMessage(10_000_000n, "delta");
+    const nextDelta = makeVideoMessage(20_000_000n, "delta");
+    const displayFrames = makeSuccessfulDisplayFrames();
+    const controller = makeController({ displayFrames });
+
+    controller.processMessage(keyframe);
+    controller.processMessage(firstDelta);
+    await flushAsyncWork();
+
+    controller.resetPlaybackState();
+    displayFrames.mockClear();
+
+    controller.processMessage(nextDelta);
+    await flushAsyncWork();
+
+    expect(nonResetCalls(displayFrames).map(([frames]) => frameReceiveTimes(frames))).toEqual([
+      [0n, 10_000_000n, 20_000_000n],
+    ]);
+    expect(nonResetCalls(displayFrames).map((call) => call[1])).toEqual(["playback"]);
+    expect(
+      nonResetCalls(displayFrames).map((call) => call[2]?.allowIntermediateVideoFrame),
+    ).toEqual([false]);
+    expect(nonResetCalls(displayFrames).map((call) => call[2]?.decodeMode)).toEqual(["exact"]);
+  });
+
   it("uses progressive lookback when seek receives a delta frame outside the cache", async () => {
     const keyframe = makeVideoMessage(0n, "key");
     const delta = makeVideoMessage(10_000_000n, "delta");

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts
@@ -66,6 +66,7 @@ type ControllerState = {
   successfulWindowSeconds?: number;
   completedSeekGeneration?: number;
   decoderResetGeneration?: number;
+  playbackDecoderResetGeneration?: number;
   lastDisplayedPublishTimeNs?: bigint;
 };
 
@@ -197,6 +198,9 @@ export class CompressedVideoController {
     if (this.#suppressPlaybackDuringPendingSeekReplay(normalizedEvent, options)) {
       return;
     }
+    if (this.#replayCachedPlaybackAfterDecoderReset(normalizedEvent, frameInfo, options)) {
+      return;
+    }
     if (this.#getSeekReplayTarget?.(normalizedEvent) != undefined) {
       void this.#displayReplayFrames([normalizedEvent], this.#generation, "playback", {
         ...options,
@@ -290,6 +294,7 @@ export class CompressedVideoController {
   public handleSeek(options?: SetCompressedVideoFramesOptions): void {
     this.#generation++;
     this.#state.pendingPlaybackAfterReplay = undefined;
+    this.#state.playbackDecoderResetGeneration = undefined;
     this.#seekTargetNs = this.#renderer.currentTime;
     this.#cache.handleSeek(fromNanoSec(this.#renderer.currentTime));
 
@@ -309,7 +314,7 @@ export class CompressedVideoController {
     this.#state.pendingPlaybackAfterReplay = undefined;
     this.#state.replayGeneration = undefined;
     this.#state.completedSeekGeneration = undefined;
-    this.#state.decoderResetGeneration = this.#generation;
+    this.#state.playbackDecoderResetGeneration = this.#generation;
     this.#state.lastDisplayedPublishTimeNs = undefined;
     this.#resetDecoderForReplay();
   }
@@ -319,6 +324,7 @@ export class CompressedVideoController {
     this.#cancelLookback();
     this.#endSeekReplayPlaybackPause();
     this.#state.pendingPlaybackAfterReplay = undefined;
+    this.#state.playbackDecoderResetGeneration = undefined;
     this.#cache.clearTopic(this.#topic);
     this.#endSeekKeyframeSearch();
   }
@@ -357,6 +363,7 @@ export class CompressedVideoController {
     this.#cache.handleSeek(fromNanoSec(this.#seekTargetNs));
     this.#cancelLookback();
     this.#state.pendingPlaybackAfterReplay = undefined;
+    this.#state.playbackDecoderResetGeneration = undefined;
     this.#state.lastDisplayedPublishTimeNs = undefined;
   }
 
@@ -364,6 +371,7 @@ export class CompressedVideoController {
     const generation = ++this.#generation;
     this.#cancelLookback();
     this.#state.pendingPlaybackAfterReplay = undefined;
+    this.#state.playbackDecoderResetGeneration = undefined;
     this.#state.replayGeneration = undefined;
     this.#state.completedSeekGeneration = undefined;
     return generation;
@@ -398,6 +406,75 @@ export class CompressedVideoController {
           this.#isCurrentGeneration(generation) && (upstreamGuard?.() ?? true),
       }),
     ).catch(() => {});
+  }
+
+  #replayCachedPlaybackAfterDecoderReset(
+    messageEvent: MessageEvent<CompressedVideo>,
+    frameInfo: NonNullable<ReturnType<typeof parseVideoFrameInfo>>,
+    options?: SetCompressedVideoFramesOptions,
+  ): boolean {
+    if (this.#state.playbackDecoderResetGeneration !== this.#generation) {
+      return false;
+    }
+    if (frameInfo.isKeyframe) {
+      this.#state.playbackDecoderResetGeneration = undefined;
+      return false;
+    }
+
+    const frames = this.#cachedFramesForReplayTarget({
+      type: "receive",
+      time: messageEvent.receiveTime,
+    });
+    if (frames == undefined || frames.length <= 1) {
+      return false;
+    }
+
+    this.#startPlaybackReplayAfterDecoderReset(this.#generation, frames, options);
+    return true;
+  }
+
+  #startPlaybackReplayAfterDecoderReset(
+    generation: number,
+    frames: readonly MessageEvent[],
+    options?: SetCompressedVideoFramesOptions,
+  ): void {
+    if (this.#state.replayGeneration === generation) {
+      return;
+    }
+
+    this.#cancelLookback();
+    this.#state.replayGeneration = generation;
+    void this.#runPlaybackReplayAfterDecoderReset(generation, frames, options);
+  }
+
+  async #runPlaybackReplayAfterDecoderReset(
+    generation: number,
+    frames: readonly MessageEvent[],
+    options?: SetCompressedVideoFramesOptions,
+  ): Promise<void> {
+    this.#beginSeekReplayPlaybackPause(generation);
+    try {
+      const result = await this.#displayReplayFramesResult(frames, generation, "playback", {
+        ...options,
+        decodeMode: "exact",
+        allowIntermediateVideoFrame: false,
+      });
+      if (!this.#isCurrentGeneration(generation)) {
+        return;
+      }
+
+      this.#state.replayGeneration = undefined;
+      this.#state.playbackDecoderResetGeneration = undefined;
+      if (result.ok) {
+        this.#recordLastDisplayedPublishTime(frames);
+        this.#flushPendingPlaybackAfterReplay(generation);
+        return;
+      }
+
+      this.#resetDecoderForReplay();
+    } finally {
+      this.#endSeekReplayPlaybackPause(generation);
+    }
   }
 
   #resetDecoderForReplayableFrames(): void {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts
@@ -452,6 +452,7 @@ export class CompressedVideoController {
     frames: readonly MessageEvent[],
     options?: SetCompressedVideoFramesOptions,
   ): Promise<void> {
+    let resumePendingAfterFailedReplay = false;
     this.#beginSeekReplayPlaybackPause(generation);
     try {
       const result = await this.#displayReplayFramesResult(frames, generation, "playback", {
@@ -472,9 +473,12 @@ export class CompressedVideoController {
       }
 
       this.#resetDecoderForReplay();
-      this.#resumePendingPlaybackAfterFailedResetReplay(generation);
+      resumePendingAfterFailedReplay = true;
     } finally {
       this.#endSeekReplayPlaybackPause(generation);
+      if (resumePendingAfterFailedReplay) {
+        this.#resumePendingPlaybackAfterFailedResetReplay(generation);
+      }
     }
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts
@@ -464,16 +464,44 @@ export class CompressedVideoController {
       }
 
       this.#state.replayGeneration = undefined;
-      this.#state.playbackDecoderResetGeneration = undefined;
       if (result.ok) {
+        this.#state.playbackDecoderResetGeneration = undefined;
         this.#recordLastDisplayedPublishTime(frames);
         this.#flushPendingPlaybackAfterReplay(generation);
         return;
       }
 
       this.#resetDecoderForReplay();
+      this.#resumePendingPlaybackAfterFailedResetReplay(generation);
     } finally {
       this.#endSeekReplayPlaybackPause(generation);
+    }
+  }
+
+  #resumePendingPlaybackAfterFailedResetReplay(generation: number): void {
+    const pendingPlayback = this.#state.pendingPlaybackAfterReplay;
+    if (
+      pendingPlayback == undefined ||
+      pendingPlayback.generation !== generation ||
+      !this.#isCurrentGeneration(generation)
+    ) {
+      return;
+    }
+
+    const entries = pendingPlayback.entries;
+    this.#state.pendingPlaybackAfterReplay = undefined;
+    for (let i = 0; i < entries.length; i++) {
+      const entry = entries[i]!;
+      this.processMessage(entry.messageEvent, entry.options);
+      if (!this.#isCurrentGeneration(generation)) {
+        return;
+      }
+      if (this.#state.replayGeneration === generation) {
+        const remainingEntries = entries.slice(i + 1);
+        this.#state.pendingPlaybackAfterReplay =
+          remainingEntries.length > 0 ? { generation, entries: remainingEntries } : undefined;
+        return;
+      }
     }
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts
@@ -981,6 +981,56 @@ describe("ImageRenderable", () => {
     }
   });
 
+  it("bounds playback metadata retained for undecoded compressed video frames", async () => {
+    const time = mockDateNow();
+    try {
+      const decodedFrame = new MockVideoFrame() as unknown as VideoFrame;
+      const events = Array.from({ length: 520 }, (_value, index) =>
+        videoFrameEvent(BigInt(index + 1) * 10n, index + 1, index === 0 ? "key" : "delta"),
+      );
+      const firstEvent = events[0];
+      const lastEvent = events[events.length - 1];
+      if (firstEvent == undefined || lastEvent == undefined) {
+        throw new Error("Expected playback events");
+      }
+      let decodeCount = 0;
+      const decodeVideoFrame = jest.fn<
+        Promise<DecodedVideoFrame | undefined>,
+        [CompressedVideo, bigint]
+      >(async (): Promise<DecodedVideoFrame | undefined> => {
+        decodeCount++;
+        if (decodeCount !== events.length) {
+          return undefined;
+        }
+        return { frame: decodedFrame, originalTimestamp: 1n, receiveTime: 10n };
+      });
+      const decoder = {
+        decodeVideoFrame,
+        decodeVideoFrames: jest.fn(),
+        awaitTargetFrame: abortAwaitTargetFrame(),
+        resetVideoDecoder: jest.fn(),
+        terminate: jest.fn(),
+      } as unknown as WorkerImageDecoder;
+      const renderable = new TestVideoBatchRenderable(decoder);
+      const updateImageState = jest.fn();
+
+      for (const event of events.slice(0, -1)) {
+        await renderable.setCompressedVideoFrames([event], { updateImageState });
+        time.advance(20);
+      }
+
+      await expect(
+        renderable.setCompressedVideoFrames([lastEvent], { updateImageState }),
+      ).resolves.toEqual<ImageSetImageResult>({ ok: true });
+
+      expect(renderable.getDecodedImage()).toBe(decodedFrame);
+      expect(updateImageState).not.toHaveBeenCalled();
+      expect(renderable.userData.displayedFrameState).toBeUndefined();
+    } finally {
+      time.restore();
+    }
+  });
+
   it("closes decoded playback frames when the renderable is hidden", async () => {
     const time = mockDateNow();
     try {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -70,6 +70,7 @@ export const IMAGE_RENDERABLE_DEFAULT_SETTINGS: ImageRenderableSettings = {
 const VIDEO_FORMATS = new Set(["h264", "h265"]);
 const MIN_IMAGE_RENDER_INTERVAL_MS = 16;
 const DEFAULT_TARGET_FRAME_TIMEOUT_MS = 1000;
+const MAX_COMPRESSED_VIDEO_FRAME_EVENT_CACHE_SIZE = 512;
 
 type DecodedImageResource = ImageBitmap | ImageData | VideoFrame;
 type DecodedImageResult =
@@ -618,6 +619,25 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     this.userData.latestMessageState = { image: frameEvent.message, receiveTime };
     if (VIDEO_FORMATS.has(frameEvent.message.format)) {
       this.#compressedVideoFrameEventsByReceiveTime.set(receiveTime, frameEvent);
+      this.#pruneCompressedVideoFrameEventCache();
+    }
+  }
+
+  #pruneCompressedVideoFrameEventCache(): void {
+    while (
+      this.#compressedVideoFrameEventsByReceiveTime.size >
+      MAX_COMPRESSED_VIDEO_FRAME_EVENT_CACHE_SIZE
+    ) {
+      let oldestReceiveTime: bigint | undefined;
+      for (const receiveTime of this.#compressedVideoFrameEventsByReceiveTime.keys()) {
+        if (oldestReceiveTime == undefined || receiveTime < oldestReceiveTime) {
+          oldestReceiveTime = receiveTime;
+        }
+      }
+      if (oldestReceiveTime == undefined) {
+        return;
+      }
+      this.#compressedVideoFrameEventsByReceiveTime.delete(oldestReceiveTime);
     }
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/WorkerImageDecoder.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/WorkerImageDecoder.ts
@@ -101,8 +101,7 @@ export class WorkerImageDecoder {
     frame: CompressedVideo,
     receiveTime: bigint,
   ): Promise<DecodedVideoFrame | undefined> {
-    await this.#remote.decodeVideoFrame({ frame, receiveTime });
-    return await this.#remote.getLatestVideoFrame();
+    return await this.#remote.decodeVideoFrame({ frame, receiveTime });
   }
 
   public async decodeVideoFrames(args: DecodeVideoFramesArgs): Promise<DecodeVideoFramesResult> {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/WorkerImageDecoder.worker.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/WorkerImageDecoder.worker.test.ts
@@ -21,6 +21,15 @@ let mockQueueFramesImpl:
       onFrame: (frame: { frame: VideoFrame; metadata: unknown }) => void,
     ) => void)
   | undefined;
+let mockDecodeAndWaitForFrameImpl:
+  | ((
+      this: MockVideoPlayer,
+      data: Uint8Array,
+      timestampMicros: number,
+      type: "key" | "delta",
+      timeoutMs?: number,
+    ) => Promise<VideoFrame | undefined>)
+  | undefined;
 
 jest.mock("@coscene-io/comlink", () => ({
   expose: jest.fn(),
@@ -46,12 +55,28 @@ jest.mock("@foxglove/den/video", () => {
       },
     );
     public readonly decodeAndWaitForFrame = jest.fn(
-      async (data: Uint8Array, timestampMicros: number, type: "key" | "delta") =>
-        await new Promise<VideoFrame | undefined>((resolve) => {
-          this.queueFrames([{ data, timestampMicros, type, metadata: undefined }], ({ frame }) => {
-            resolve(frame);
-          });
-        }),
+      async (
+        data: Uint8Array,
+        timestampMicros: number,
+        type: "key" | "delta",
+        timeoutMs?: number,
+      ) =>
+        mockDecodeAndWaitForFrameImpl != undefined
+          ? await mockDecodeAndWaitForFrameImpl.call(
+              this as unknown as MockVideoPlayer,
+              data,
+              timestampMicros,
+              type,
+              timeoutMs,
+            )
+          : await new Promise<VideoFrame | undefined>((resolve) => {
+              this.queueFrames(
+                [{ data, timestampMicros, type, metadata: undefined }],
+                ({ frame }) => {
+                  resolve(frame);
+                },
+              );
+            }),
     );
 
     public constructor() {
@@ -147,10 +172,12 @@ describe("WorkerImageDecoder worker video batches", () => {
     mockVideoPlayers.length = 0;
     jest.clearAllMocks();
     mockQueueFramesImpl = undefined;
+    mockDecodeAndWaitForFrameImpl = undefined;
     service = (await import("./WorkerImageDecoder.worker")).service;
   });
 
   afterEach(() => {
+    jest.useRealTimers();
     service.resetVideoDecoder();
   });
 
@@ -326,6 +353,47 @@ describe("WorkerImageDecoder worker video batches", () => {
 
     const player = mockVideoPlayers[0]!;
     expect(player.queueFrames).toHaveBeenCalledTimes(1);
+    expect(settled).toBe(false);
+
+    const decodedFrame = emitLastQueuedFrame(player);
+    await expect(resultPromise).resolves.toMatchObject({
+      frame: decodedFrame,
+      originalTimestamp: 1_000_000_000n,
+      receiveTime: 10n,
+    });
+  });
+
+  it("keeps waiting for late reordered single-frame playback output", async () => {
+    jest.useFakeTimers();
+    mockDecodeAndWaitForFrameImpl = async function (data, timestampMicros, type, timeoutMs = 1000) {
+      return await new Promise<VideoFrame | undefined>((resolve) => {
+        const timer = setTimeout(() => {
+          resolve(undefined);
+        }, timeoutMs);
+        this.queueFrames(
+          [{ data, timestampMicros, type, metadata: undefined }],
+          (decoded: { frame: VideoFrame }) => {
+            clearTimeout(timer);
+            resolve(decoded.frame);
+          },
+        );
+      });
+    };
+
+    let settled = false;
+    const resultPromise = service
+      .decodeVideoFrame({ frame: h264Frame(1, "key"), receiveTime: 10n })
+      .then((result) => {
+        settled = true;
+        return result;
+      });
+    await flushPromises();
+
+    const player = mockVideoPlayers[0]!;
+    expect(player.queueFrames).toHaveBeenCalledTimes(1);
+
+    await jest.advanceTimersByTimeAsync(1000);
+    await flushPromises();
     expect(settled).toBe(false);
 
     const decodedFrame = emitLastQueuedFrame(player);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/WorkerImageDecoder.worker.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/WorkerImageDecoder.worker.test.ts
@@ -45,6 +45,14 @@ jest.mock("@foxglove/den/video", () => {
         mockQueueFramesImpl?.(frames, onFrame);
       },
     );
+    public readonly decodeAndWaitForFrame = jest.fn(
+      async (data: Uint8Array, timestampMicros: number, type: "key" | "delta") =>
+        await new Promise<VideoFrame | undefined>((resolve) => {
+          this.queueFrames([{ data, timestampMicros, type, metadata: undefined }], ({ frame }) => {
+            resolve(frame);
+          });
+        }),
+    );
 
     public constructor() {
       mockVideoPlayers.push(this as unknown as MockVideoPlayer);
@@ -73,6 +81,10 @@ type MockVideoPlayer = {
   isInitialized: jest.Mock<boolean, []>;
   resetForSeek: jest.Mock<void, []>;
   queueFrames: jest.Mock;
+  decodeAndWaitForFrame: jest.Mock<
+    Promise<VideoFrame | undefined>,
+    [Uint8Array, number, "key" | "delta", number?]
+  >;
 };
 
 let service: typeof import("./WorkerImageDecoder.worker").service;
@@ -283,15 +295,18 @@ describe("WorkerImageDecoder worker video batches", () => {
     await expect(resultPromise).resolves.toMatchObject({ type: "TargetFrame" });
   });
 
-  it("queues playback frames through the single-frame API and exposes the latest decoded frame", async () => {
-    await service.decodeVideoFrame({ frame: h264Frame(1, "key"), receiveTime: 10n });
+  it("queues playback frames through the single-frame API and returns the decoded frame", async () => {
+    const resultPromise = service.decodeVideoFrame({
+      frame: h264Frame(1, "key"),
+      receiveTime: 10n,
+    });
     await flushPromises();
 
     const player = mockVideoPlayers[0]!;
     expect(player.queueFrames).toHaveBeenCalledTimes(1);
     const decodedFrame = emitLastQueuedFrame(player);
 
-    expect(service.getLatestVideoFrame()).toMatchObject({
+    await expect(resultPromise).resolves.toMatchObject({
       frame: decodedFrame,
       originalTimestamp: 1_000_000_000n,
       receiveTime: 10n,
@@ -299,21 +314,71 @@ describe("WorkerImageDecoder worker video batches", () => {
     expect(service.getLatestVideoFrame()).toBeUndefined();
   });
 
-  it("keeps only the newest decoded playback frame and closes older pending output", async () => {
-    await service.decodeVideoFrame({ frame: h264Frame(1, "key"), receiveTime: 10n });
-    await service.decodeVideoFrame({ frame: h264Frame(2, "delta"), receiveTime: 20n });
+  it("waits for single-frame playback output before resolving", async () => {
+    let settled = false;
+    const resultPromise = service
+      .decodeVideoFrame({ frame: h264Frame(1, "key"), receiveTime: 10n })
+      .then((result) => {
+        settled = true;
+        return result;
+      });
+    await flushPromises();
+
+    const player = mockVideoPlayers[0]!;
+    expect(player.queueFrames).toHaveBeenCalledTimes(1);
+    expect(settled).toBe(false);
+
+    const decodedFrame = emitLastQueuedFrame(player);
+    await expect(resultPromise).resolves.toMatchObject({
+      frame: decodedFrame,
+      originalTimestamp: 1_000_000_000n,
+      receiveTime: 10n,
+    });
+  });
+
+  it("does not expose stale single-frame output after an out-of-order reset", async () => {
+    const resultPromise = service.decodeVideoFrame({
+      frame: h264Frame(2, "key"),
+      receiveTime: 20n,
+    });
+    await flushPromises();
+    const player = mockVideoPlayers[0]!;
+    const decodedFrame = emitLastQueuedFrame(player);
+    await expect(resultPromise).resolves.toMatchObject({ frame: decodedFrame });
+
+    const resetResult = service.decodeVideoFrame({ frame: h264Frame(1, "key"), receiveTime: 10n });
+    await flushPromises();
+
+    expect(player.resetForSeek).toHaveBeenCalled();
+    expect(service.getLatestVideoFrame()).toBeUndefined();
+    emitLastQueuedFrame(player);
+    await expect(resetResult).resolves.toMatchObject({ receiveTime: 10n });
+  });
+
+  it("resolves single-frame playback requests with their matching output", async () => {
+    const firstResult = service.decodeVideoFrame({ frame: h264Frame(1, "key"), receiveTime: 10n });
     await flushPromises();
 
     const player = mockVideoPlayers[0]!;
     const firstFrame = emitQueuedFrameFromCall(player, 0, 0);
-    const secondFrame = emitQueuedFrameFromCall(player, 1, 0);
+    await expect(firstResult).resolves.toMatchObject({
+      frame: firstFrame,
+      originalTimestamp: 1_000_000_000n,
+      receiveTime: 10n,
+    });
 
-    expect((firstFrame as unknown as { close: jest.Mock }).close).toHaveBeenCalledTimes(1);
-    expect(service.getLatestVideoFrame()).toMatchObject({
+    const secondResult = service.decodeVideoFrame({
+      frame: h264Frame(2, "delta"),
+      receiveTime: 20n,
+    });
+    await flushPromises();
+    const secondFrame = emitQueuedFrameFromCall(player, 1, 0);
+    await expect(secondResult).resolves.toMatchObject({
       frame: secondFrame,
       originalTimestamp: 2_000_000_000n,
       receiveTime: 20n,
     });
+    expect((firstFrame as unknown as { close: jest.Mock }).close).not.toHaveBeenCalled();
     expect((secondFrame as unknown as { close: jest.Mock }).close).not.toHaveBeenCalled();
   });
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/WorkerImageDecoder.worker.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/WorkerImageDecoder.worker.ts
@@ -16,6 +16,7 @@ import type { CompressedVideo } from "./ImageTypes";
 const log = Logger.getLogger(__filename);
 const TARGET_FRAME_TIMEOUT_MS = 1000;
 const ANY_FRAME_TIMEOUT_MS = 2000;
+const PLAYBACK_FRAME_TIMEOUT_MS = 1000;
 
 let videoPlayer: VideoPlayer | undefined;
 let initPromise: Promise<void> | undefined;
@@ -25,7 +26,6 @@ let activeBatchAbort: (() => void) | undefined;
 let streamBaseTimestampMicros: number | undefined;
 let lastQueuedTimestampMicros: number | undefined;
 let pendingTargetFrame: PendingTargetFrame | undefined;
-let latestPlaybackFrame: DecodedVideoFrameResult | undefined;
 
 export type DecodeVideoFrameInput = {
   frame: CompressedVideo;
@@ -174,7 +174,9 @@ async function ensureInitialized(
   return player.isInitialized();
 }
 
-async function decodeVideoFrame(entry: DecodeVideoFrameInput): Promise<void> {
+async function decodeVideoFrame(
+  entry: DecodeVideoFrameInput,
+): Promise<DecodedVideoFrameResult | undefined> {
   abortPendingTargetFrame();
 
   const frame = entry.frame;
@@ -186,18 +188,18 @@ async function decodeVideoFrame(entry: DecodeVideoFrameInput): Promise<void> {
   const player = getVideoPlayer();
   const frameInfo = getVideoFrameInfo(frame);
   if (frameInfo == undefined) {
-    return;
+    return undefined;
   }
 
   if (!(await ensureInitialized(player, frame, frameInfo.type))) {
-    return;
+    return undefined;
   }
 
   streamBaseTimestampMicros ??= toMicroSec(frame.timestamp);
   let timestampMicros = toMicroSec(frame.timestamp) - streamBaseTimestampMicros;
   if (timestampMicros < 0) {
     resetVideoPlayerForDisorder();
-    return;
+    return undefined;
   }
 
   if (lastQueuedTimestampMicros != undefined && timestampMicros <= lastQueuedTimestampMicros) {
@@ -210,32 +212,26 @@ async function decodeVideoFrame(entry: DecodeVideoFrameInput): Promise<void> {
       ? (H264.RewriteForLowLatencyDecoding(frame.data) ?? frame.data)
       : frame.data;
 
-  player.queueFrames(
-    [
-      {
-        data: frameData,
-        timestampMicros,
-        type: frameInfo.type,
-        metadata: {
-          originalTimestamp: toNanoSec(frame.timestamp),
-          receiveTime: entry.receiveTime,
-        },
-      },
-    ],
-    (decodedFrame) => {
-      closeDecodedVideoFrameResult(latestPlaybackFrame);
-      latestPlaybackFrame = { frame: decodedFrame.frame, ...decodedFrame.metadata };
-    },
+  const decodedFrame = await player.decodeAndWaitForFrame(
+    frameData,
+    timestampMicros,
+    frameInfo.type,
+    PLAYBACK_FRAME_TIMEOUT_MS,
   );
+  if (decodedFrame == undefined) {
+    return undefined;
+  }
+
+  const result = {
+    frame: decodedFrame,
+    originalTimestamp: toNanoSec(frame.timestamp),
+    receiveTime: entry.receiveTime,
+  };
+  return Comlink.transfer(result, [decodedFrame]);
 }
 
 function getLatestVideoFrame(): DecodedVideoFrameResult | undefined {
-  const frame = latestPlaybackFrame;
-  latestPlaybackFrame = undefined;
-  if (frame == undefined) {
-    return undefined;
-  }
-  return Comlink.transfer(frame, [frame.frame]);
+  return undefined;
 }
 
 async function decodeVideoFrames(args: DecodeVideoFramesArgs): Promise<DecodeVideoFramesResult> {
@@ -527,8 +523,6 @@ function resetVideoDecoder(): void {
   activeBatchAbort?.();
   activeBatchAbort = undefined;
   abortPendingTargetFrame();
-  closeDecodedVideoFrameResult(latestPlaybackFrame);
-  latestPlaybackFrame = undefined;
   videoPlayer?.resetForSeek();
   initPromise = undefined;
   lastDecodeTime = { sec: 0, nsec: 0 };

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/WorkerImageDecoder.worker.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/WorkerImageDecoder.worker.ts
@@ -16,7 +16,8 @@ import type { CompressedVideo } from "./ImageTypes";
 const log = Logger.getLogger(__filename);
 const TARGET_FRAME_TIMEOUT_MS = 1000;
 const ANY_FRAME_TIMEOUT_MS = 2000;
-const PLAYBACK_FRAME_TIMEOUT_MS = 1000;
+// Playback decoders can output reordered frames only after later packets arrive.
+const PLAYBACK_FRAME_TIMEOUT_MS = 5000;
 
 let videoPlayer: VideoPlayer | undefined;
 let initPromise: Promise<void> | undefined;


### PR DESCRIPTION
## Summary
- Await single-frame playback decode output instead of polling the worker immediately.
- Bound retained compressed-video metadata while preserving delayed decode metadata inside the cache limit.
- Replay cached GOP frames after playback decoder resets so deltas can decode before the next keyframe.
- Separate playback reset replay state from seek replay state to avoid replaying GOPs after normal seek recovery.

## Validation
- `yarn test --runTestsByPath packages/den/video/VideoPlayer.test.ts packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.test.ts packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.test.ts packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.test.ts packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/WorkerImageDecoder.worker.test.ts packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoGopCache.test.ts`
- `yarn build:packages`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786093146&installation_id=141984720&pr_number=1394&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1394&signature=f865237c7e9c9d7ebd8e61df7862ec8c8b19f118acd8b0cb2d791751bc9555e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->