### PR TITLE
Batch spill writes and add cursor prefetching

### DIFF
--- a/packages/studio-base/src/persistence/IndexedDbMessageStore.ts
+++ b/packages/studio-base/src/persistence/IndexedDbMessageStore.ts
@@ -730,6 +730,7 @@ export class IndexedDbMessageStore implements PersistentMessageCache {
     let latestTime: Time | undefined;
     let approximateSizeBytesAdded = 0;
     let seq = this.#nextSeq;
+    const putPromises: Promise<unknown>[] = [];
 
     for (const ev of batch) {
       latestTime =
@@ -737,21 +738,24 @@ export class IndexedDbMessageStore implements PersistentMessageCache {
           ? ev.receiveTime
           : latestTime;
       approximateSizeBytesAdded += eventSize(ev);
-      await store.put(sanitizeEvent(sessionId, seq++, ev));
+      putPromises.push(store.put(sanitizeEvent(sessionId, seq++, ev)));
     }
 
     const now = Date.now();
-    await sessionsStore.put({
-      ...sessionData,
-      lastActiveAt: now,
-      nextSeq: seq,
-      messageCount: Math.max(0, (sessionData.messageCount ?? 0) + batch.length),
-      approximateSizeBytes: Math.max(
-        0,
-        sessionData.approximateSizeBytes + approximateSizeBytesAdded,
-      ),
-    });
+    putPromises.push(
+      sessionsStore.put({
+        ...sessionData,
+        lastActiveAt: now,
+        nextSeq: seq,
+        messageCount: Math.max(0, (sessionData.messageCount ?? 0) + batch.length),
+        approximateSizeBytes: Math.max(
+          0,
+          sessionData.approximateSizeBytes + approximateSizeBytesAdded,
+        ),
+      }),
+    );
 
+    await Promise.all(putPromises);
     await tx.done;
 
     this.#nextSeq = seq;

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.test.ts
@@ -1842,6 +1842,7 @@ describe("CachingIterableSource", () => {
     let releaseSource: (() => void) | undefined;
 
     await bufferedSource.initialize();
+    const appendSpy = jest.spyOn(IndexedDbMessageStore.prototype, "append");
 
     source.messageIterator = async function* messageIterator(
       _args: MessageIteratorArgs,
@@ -1890,6 +1891,8 @@ describe("CachingIterableSource", () => {
       done: false,
       value: { type: "stamp", stamp: { sec: 2, nsec: 0 } },
     });
+    expect(appendSpy).toHaveBeenCalledTimes(1);
+    expect(appendSpy.mock.calls[0]?.[0]).toHaveLength(2);
 
     const sessions = await getPlaybackSpillSessions();
     expect(sessions).toHaveLength(1);
@@ -1915,6 +1918,7 @@ describe("CachingIterableSource", () => {
     releaseSource?.();
     await iterator.return?.();
     await bufferedSource.terminate();
+    appendSpy.mockRestore();
     await expect(getPlaybackSpillSessions()).resolves.toEqual([]);
   });
 

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
@@ -34,7 +34,8 @@ import {
 
 const log = Log.getLogger(__filename);
 const MAX_SPILL_MESSAGES_BEFORE_APPEND = 1000;
-const MAX_SPILL_MESSAGES_BEFORE_FLUSH = 10000;
+const MAX_SPILL_MESSAGES_PER_IDB_TRANSACTION = 1000;
+const MAX_SPILL_MESSAGES_BEFORE_FLUSH = 5000;
 const PLAYBACK_SPILL_HEARTBEAT_MS = 30 * 1000;
 const PLAYBACK_SPILL_STALE_MS = 5 * 60 * 1000;
 
@@ -242,7 +243,7 @@ class CachingIterableSource<MessageType = unknown>
       maxCacheSize: this.#spillCacheOptions.maxCacheSize,
       sourceId: this.#spillCacheOptions.sourceId,
       sourceKey,
-      appendBatchMaxSize: MAX_SPILL_MESSAGES_BEFORE_FLUSH,
+      appendBatchMaxSize: MAX_SPILL_MESSAGES_PER_IDB_TRANSACTION,
     });
 
     try {

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
@@ -33,7 +33,8 @@ import {
 // CoScene
 
 const log = Log.getLogger(__filename);
-const MAX_SPILL_APPENDS_BEFORE_FLUSH = 1000;
+const MAX_SPILL_MESSAGES_BEFORE_APPEND = 1000;
+const MAX_SPILL_MESSAGES_BEFORE_FLUSH = 10000;
 const PLAYBACK_SPILL_HEARTBEAT_MS = 30 * 1000;
 const PLAYBACK_SPILL_STALE_MS = 5 * 60 * 1000;
 
@@ -173,7 +174,7 @@ class CachingIterableSource<MessageType = unknown>
   #spillCacheOptions?: NonNullable<Options["spillCache"]>;
   #spillTopicFingerprint?: string;
   #spillLoadedRanges: readonly LoadedRange[] = [];
-  #spillAppendCountSinceFlush = 0;
+  #spillMessageCountSinceFlush = 0;
   #spillLastSessionCheckAt: number | undefined;
   #spillHeartbeatTimer: ReturnType<typeof setInterval> | undefined;
   #spillPageHideHandler: ((event: PageTransitionEvent) => void) | undefined;
@@ -241,6 +242,7 @@ class CachingIterableSource<MessageType = unknown>
       maxCacheSize: this.#spillCacheOptions.maxCacheSize,
       sourceId: this.#spillCacheOptions.sourceId,
       sourceKey,
+      appendBatchMaxSize: MAX_SPILL_MESSAGES_BEFORE_FLUSH,
     });
 
     try {
@@ -262,7 +264,7 @@ class CachingIterableSource<MessageType = unknown>
     this.#spillStore = undefined;
     this.#spillTopicFingerprint = undefined;
     this.#spillLoadedRanges = [];
-    this.#spillAppendCountSinceFlush = 0;
+    this.#spillMessageCountSinceFlush = 0;
     this.#spillLastSessionCheckAt = undefined;
 
     if (store == undefined) {
@@ -415,7 +417,7 @@ class CachingIterableSource<MessageType = unknown>
         this.#spillTopicFingerprint = savedFingerprint;
       }
       this.#spillLoadedRanges = [];
-      this.#spillAppendCountSinceFlush = 0;
+      this.#spillMessageCountSinceFlush = 0;
       this.#spillLastSessionCheckAt = Date.now();
       this.#recomputeLoadedRangeCache();
     } catch (error) {
@@ -444,7 +446,7 @@ class CachingIterableSource<MessageType = unknown>
       await this.#spillStore.clear();
       this.#spillTopicFingerprint = nextFingerprint;
       this.#spillLoadedRanges = [];
-      this.#spillAppendCountSinceFlush = 0;
+      this.#spillMessageCountSinceFlush = 0;
       this.#recomputeLoadedRangeCache();
     } catch (error) {
       log.warn("Disabling playback spill cache after topic reset failed:", error);
@@ -453,21 +455,17 @@ class CachingIterableSource<MessageType = unknown>
     }
   }
 
-  async #appendSpill(iterResult: IteratorResult<MessageType>): Promise<void> {
-    if (
-      !this.#spillEnabled ||
-      this.#spillStore == undefined ||
-      iterResult.type !== "message-event"
-    ) {
+  async #appendSpillMessages(messages: readonly MessageEvent[]): Promise<void> {
+    if (!this.#spillEnabled || this.#spillStore == undefined || messages.length === 0) {
       return;
     }
 
     try {
-      await this.#spillStore.append([iterResult.msgEvent as MessageEvent]);
-      this.#spillAppendCountSinceFlush++;
-      if (this.#spillAppendCountSinceFlush >= MAX_SPILL_APPENDS_BEFORE_FLUSH) {
+      await this.#spillStore.append(messages);
+      this.#spillMessageCountSinceFlush += messages.length;
+      if (this.#spillMessageCountSinceFlush >= MAX_SPILL_MESSAGES_BEFORE_FLUSH) {
         await this.#spillStore.flush();
-        this.#spillAppendCountSinceFlush = 0;
+        this.#spillMessageCountSinceFlush = 0;
       }
     } catch (error) {
       log.warn("Disabling playback spill cache after append failed:", error);
@@ -488,7 +486,7 @@ class CachingIterableSource<MessageType = unknown>
 
     try {
       await this.#spillStore.flush();
-      this.#spillAppendCountSinceFlush = 0;
+      this.#spillMessageCountSinceFlush = 0;
       await this.#spillStore.putLoadedRange({
         sessionId: this.#spillStore.getSessionId(),
         topicFingerprint: this.#spillTopicFingerprint,
@@ -680,6 +678,7 @@ class CachingIterableSource<MessageType = unknown>
     let block: CacheBlock<MessageType> | undefined;
 
     const pendingIterResults: [bigint, IteratorResult<MessageType>][] = [];
+    let pendingSpillMessages: MessageEvent[] = [];
     const discardPendingIterResults = () => {
       for (const pendingIterResult of pendingIterResults) {
         const item = pendingIterResult[1];
@@ -688,11 +687,23 @@ class CachingIterableSource<MessageType = unknown>
       }
       pendingIterResults.length = 0;
     };
+    const discardPendingSpillMessages = () => {
+      pendingSpillMessages = [];
+    };
+    const flushPendingSpillMessages = async () => {
+      if (pendingSpillMessages.length === 0) {
+        return;
+      }
+      const messages = pendingSpillMessages;
+      pendingSpillMessages = [];
+      await this.#appendSpillMessages(messages);
+    };
 
     try {
       for await (const iterResult of sourceMessageIterator) {
         if (isAborted(args.abortSignal)) {
           discardPendingIterResults();
+          discardPendingSpillMessages();
           return false;
         }
 
@@ -780,14 +791,18 @@ class CachingIterableSource<MessageType = unknown>
 
         // Store the latest message in pending results and flush to the block when time moves forward
         pendingIterResults.push([lastTime, iterResult]);
-        if (args.writeSpill) {
-          await this.#appendSpill(iterResult);
+        if (args.writeSpill && iterResult.type === "message-event") {
+          pendingSpillMessages.push(iterResult.msgEvent as MessageEvent);
+          if (pendingSpillMessages.length >= MAX_SPILL_MESSAGES_BEFORE_APPEND) {
+            await flushPendingSpillMessages();
+          }
         }
 
         if (args.writeSpill && iterResult.type === "stamp") {
           const spillRangeEnd =
             compare(iterResult.stamp, args.end) > 0 ? args.end : iterResult.stamp;
           if (!sourceHadProblemInRange && compare(spillRangeStart, spillRangeEnd) <= 0) {
+            await flushPendingSpillMessages();
             await this.#recordSpillLoadedRange(spillRangeStart, spillRangeEnd);
           }
           sourceHadProblemInRange = false;
@@ -799,6 +814,7 @@ class CachingIterableSource<MessageType = unknown>
     } catch (error) {
       if (isAborted(args.abortSignal) && isAbortError(error)) {
         discardPendingIterResults();
+        discardPendingSpillMessages();
         return false;
       }
       throw error;
@@ -806,6 +822,7 @@ class CachingIterableSource<MessageType = unknown>
 
     if (isAborted(args.abortSignal)) {
       discardPendingIterResults();
+      discardPendingSpillMessages();
       return false;
     }
 
@@ -855,8 +872,11 @@ class CachingIterableSource<MessageType = unknown>
       this.#recomputeLoadedRangeCache();
     }
 
-    if (args.writeSpill && !sourceHadProblemInRange && compare(spillRangeStart, args.end) <= 0) {
-      await this.#recordSpillLoadedRange(spillRangeStart, args.end);
+    if (args.writeSpill) {
+      await flushPendingSpillMessages();
+      if (!sourceHadProblemInRange && compare(spillRangeStart, args.end) <= 0) {
+        await this.#recordSpillLoadedRange(spillRangeStart, args.end);
+      }
     }
     return true;
   }

--- a/packages/studio-base/src/players/IterablePlayer/PrefetchingMessageCursor.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/PrefetchingMessageCursor.test.ts
@@ -82,7 +82,9 @@ describe("PrefetchingMessageCursor", () => {
   });
 
   it("does not prefetch after an empty batch", async () => {
-    const nextBatch = jest.fn<Promise<IteratorResult[] | undefined>, [number]>().mockResolvedValue([]);
+    const nextBatch = jest
+      .fn<Promise<IteratorResult[] | undefined>, [number]>()
+      .mockResolvedValue([]);
     const cursor = new PrefetchingMessageCursor(makeCursor(nextBatch));
 
     await expect(cursor.nextBatch(100)).resolves.toEqual([]);
@@ -163,7 +165,9 @@ describe("PrefetchingMessageCursor", () => {
   });
 
   it("delegates direct reads before batch prefetching starts", async () => {
-    const nextBatch = jest.fn<Promise<IteratorResult[] | undefined>, [number]>().mockResolvedValue([]);
+    const nextBatch = jest
+      .fn<Promise<IteratorResult[] | undefined>, [number]>()
+      .mockResolvedValue([]);
     const readUntil = jest.fn(async () => []);
     const underlying = { ...makeCursor(nextBatch), readUntil };
     const cursor = new PrefetchingMessageCursor(underlying);

--- a/packages/studio-base/src/players/IterablePlayer/PrefetchingMessageCursor.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/PrefetchingMessageCursor.test.ts
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Time } from "@foxglove/studio";
+
+import { IMessageCursor, IteratorResult } from "./IIterableSource";
+import { PrefetchingMessageCursor } from "./PrefetchingMessageCursor";
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  reject: (err: unknown) => void;
+  resolve: (value: T) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, reject, resolve };
+}
+
+function stamp(sec: number): IteratorResult {
+  return { type: "stamp", stamp: { sec, nsec: 0 } };
+}
+
+function makeCursor(
+  nextBatch: jest.Mock<Promise<IteratorResult[] | undefined>, [number]>,
+): IMessageCursor {
+  return {
+    next: jest.fn(async () => undefined),
+    nextBatch,
+    readUntil: jest.fn(async () => []),
+    end: jest.fn(async () => {}),
+  };
+}
+
+describe("PrefetchingMessageCursor", () => {
+  it("starts the next batch as soon as the current batch resolves", async () => {
+    const first = deferred<IteratorResult[] | undefined>();
+    const second = deferred<IteratorResult[] | undefined>();
+    const nextBatch = jest
+      .fn<Promise<IteratorResult[] | undefined>, [number]>()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise)
+      .mockResolvedValueOnce(undefined);
+    const cursor = new PrefetchingMessageCursor(makeCursor(nextBatch));
+
+    const firstRead = cursor.nextBatch(100);
+    expect(nextBatch).toHaveBeenCalledTimes(1);
+
+    first.resolve([stamp(1)]);
+    await expect(firstRead).resolves.toEqual([stamp(1)]);
+    expect(nextBatch).toHaveBeenCalledTimes(2);
+
+    const secondRead = cursor.nextBatch(100);
+    expect(nextBatch).toHaveBeenCalledTimes(2);
+
+    second.resolve([stamp(2)]);
+    await expect(secondRead).resolves.toEqual([stamp(2)]);
+    expect(nextBatch).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not prefetch after the cursor is exhausted", async () => {
+    const nextBatch = jest
+      .fn<Promise<IteratorResult[] | undefined>, [number]>()
+      .mockResolvedValueOnce([stamp(1)])
+      .mockResolvedValueOnce(undefined);
+    const cursor = new PrefetchingMessageCursor(makeCursor(nextBatch));
+
+    await expect(cursor.nextBatch(100)).resolves.toEqual([stamp(1)]);
+    expect(nextBatch).toHaveBeenCalledTimes(2);
+
+    await expect(cursor.nextBatch(100)).resolves.toBeUndefined();
+    expect(nextBatch).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not prefetch after an empty batch", async () => {
+    const nextBatch = jest.fn<Promise<IteratorResult[] | undefined>, [number]>().mockResolvedValue([]);
+    const cursor = new PrefetchingMessageCursor(makeCursor(nextBatch));
+
+    await expect(cursor.nextBatch(100)).resolves.toEqual([]);
+    expect(nextBatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates errors from a prefetched batch", async () => {
+    const err = new Error("prefetch failed");
+    const nextBatch = jest
+      .fn<Promise<IteratorResult[] | undefined>, [number]>()
+      .mockResolvedValueOnce([stamp(1)])
+      .mockRejectedValueOnce(err);
+    const cursor = new PrefetchingMessageCursor(makeCursor(nextBatch));
+
+    await cursor.nextBatch(100);
+    await expect(cursor.nextBatch(100)).rejects.toThrow("prefetch failed");
+  });
+
+  it("waits for an in-flight prefetch before ending the underlying cursor", async () => {
+    const second = deferred<IteratorResult[] | undefined>();
+    const end = jest.fn(async () => {});
+    const underlying = {
+      ...makeCursor(
+        jest
+          .fn<Promise<IteratorResult[] | undefined>, [number]>()
+          .mockResolvedValueOnce([stamp(1)])
+          .mockReturnValueOnce(second.promise),
+      ),
+      end,
+    };
+    const cursor = new PrefetchingMessageCursor(underlying);
+
+    await cursor.nextBatch(100);
+    const endPromise = cursor.end();
+    await Promise.resolve();
+    expect(end).not.toHaveBeenCalled();
+
+    second.resolve([stamp(2)]);
+    await endPromise;
+    expect(end).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects batch duration changes on the same cursor", async () => {
+    const cursor = new PrefetchingMessageCursor(
+      makeCursor(jest.fn<Promise<IteratorResult[] | undefined>, [number]>().mockResolvedValue([])),
+    );
+
+    await cursor.nextBatch(100);
+    await expect(cursor.nextBatch(17)).rejects.toThrow("Batch duration changed mid-stream");
+  });
+
+  it("rejects direct reads after batch prefetching starts", async () => {
+    const cursor = new PrefetchingMessageCursor(
+      makeCursor(jest.fn<Promise<IteratorResult[] | undefined>, [number]>().mockResolvedValue([])),
+    );
+
+    await cursor.nextBatch(100);
+    await expect(cursor.readUntil({ sec: 1, nsec: 0 } as Time)).rejects.toThrow(
+      "Cannot mix nextBatch with direct cursor reads",
+    );
+  });
+
+  it("delegates direct reads before batch prefetching starts", async () => {
+    const nextBatch = jest.fn<Promise<IteratorResult[] | undefined>, [number]>().mockResolvedValue([]);
+    const readUntil = jest.fn(async () => []);
+    const underlying = { ...makeCursor(nextBatch), readUntil };
+    const cursor = new PrefetchingMessageCursor(underlying);
+    const end = { sec: 1, nsec: 0 } as Time;
+
+    await cursor.readUntil(end);
+
+    expect(readUntil).toHaveBeenCalledWith(end);
+    expect(nextBatch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/studio-base/src/players/IterablePlayer/PrefetchingMessageCursor.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/PrefetchingMessageCursor.test.ts
@@ -101,7 +101,7 @@ describe("PrefetchingMessageCursor", () => {
     await expect(cursor.nextBatch(100)).rejects.toThrow("prefetch failed");
   });
 
-  it("waits for an in-flight prefetch before ending the underlying cursor", async () => {
+  it("ends the underlying cursor before an in-flight prefetch completes", async () => {
     const second = deferred<IteratorResult[] | undefined>();
     const end = jest.fn(async () => {});
     const underlying = {
@@ -118,31 +118,48 @@ describe("PrefetchingMessageCursor", () => {
     await cursor.nextBatch(100);
     const endPromise = cursor.end();
     await Promise.resolve();
-    expect(end).not.toHaveBeenCalled();
+    expect(end).toHaveBeenCalledTimes(1);
 
     second.resolve([stamp(2)]);
     await endPromise;
-    expect(end).toHaveBeenCalledTimes(1);
   });
 
-  it("rejects batch duration changes on the same cursor", async () => {
-    const cursor = new PrefetchingMessageCursor(
-      makeCursor(jest.fn<Promise<IteratorResult[] | undefined>, [number]>().mockResolvedValue([])),
-    );
+  it("supports batch duration changes on the same cursor", async () => {
+    const nextBatch = jest
+      .fn<Promise<IteratorResult[] | undefined>, [number]>()
+      .mockResolvedValueOnce([stamp(1)])
+      .mockResolvedValueOnce([stamp(2)]);
+    const cursor = new PrefetchingMessageCursor(makeCursor(nextBatch));
 
-    await cursor.nextBatch(100);
-    await expect(cursor.nextBatch(17)).rejects.toThrow("Batch duration changed mid-stream");
+    await expect(cursor.nextBatch(100)).resolves.toEqual([stamp(1)]);
+    await expect(cursor.nextBatch(17)).resolves.toEqual([stamp(2)]);
   });
 
-  it("rejects direct reads after batch prefetching starts", async () => {
-    const cursor = new PrefetchingMessageCursor(
-      makeCursor(jest.fn<Promise<IteratorResult[] | undefined>, [number]>().mockResolvedValue([])),
-    );
+  it("does not merge old buffered results with a same-duration prefetched batch", async () => {
+    const nextBatch = jest
+      .fn<Promise<IteratorResult[] | undefined>, [number]>()
+      .mockResolvedValueOnce([stamp(0)])
+      .mockResolvedValueOnce([stamp(200), stamp(230), stamp(260)])
+      .mockResolvedValueOnce([stamp(300), stamp(330), stamp(360)])
+      .mockResolvedValue(undefined);
+    const cursor = new PrefetchingMessageCursor(makeCursor(nextBatch));
+
+    await expect(cursor.nextBatch(100)).resolves.toEqual([stamp(0)]);
+    await expect(cursor.nextBatch(17)).resolves.toEqual([stamp(200), stamp(230)]);
+
+    await expect(cursor.nextBatch(17)).resolves.toEqual([stamp(260), stamp(300)]);
+  });
+
+  it("serves direct reads from an already-prefetched batch", async () => {
+    const nextBatch = jest
+      .fn<Promise<IteratorResult[] | undefined>, [number]>()
+      .mockResolvedValueOnce([stamp(1)])
+      .mockResolvedValueOnce([stamp(2), stamp(3)]);
+    const cursor = new PrefetchingMessageCursor(makeCursor(nextBatch));
 
     await cursor.nextBatch(100);
-    await expect(cursor.readUntil({ sec: 1, nsec: 0 } as Time)).rejects.toThrow(
-      "Cannot mix nextBatch with direct cursor reads",
-    );
+    await expect(cursor.readUntil({ sec: 3, nsec: 0 } as Time)).resolves.toEqual([stamp(2)]);
+    await expect(cursor.next()).resolves.toEqual(stamp(3));
   });
 
   it("delegates direct reads before batch prefetching starts", async () => {

--- a/packages/studio-base/src/players/IterablePlayer/PrefetchingMessageCursor.ts
+++ b/packages/studio-base/src/players/IterablePlayer/PrefetchingMessageCursor.ts
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Time } from "@foxglove/studio";
+
+import type { IMessageCursor, IteratorResult } from "./IIterableSource";
+
+type CursorMode = "batch" | "direct";
+
+/**
+ * Wraps a message cursor and keeps one nextBatch call in flight.
+ *
+ * Worker-backed cursors otherwise only start loading the next batch after the main thread asks for it.
+ * Prefetching overlaps worker/network reads with main-thread processing of the current batch.
+ */
+export class PrefetchingMessageCursor<MessageType = unknown>
+  implements IMessageCursor<MessageType>
+{
+  #cursor: IMessageCursor<MessageType>;
+  #pendingBatch?: Promise<IteratorResult<MessageType>[] | undefined>;
+  #batchDurationMs?: number;
+  #mode?: CursorMode;
+
+  public constructor(cursor: IMessageCursor<MessageType>) {
+    this.#cursor = cursor;
+  }
+
+  public async next(): ReturnType<IMessageCursor<MessageType>["next"]> {
+    this.#enterDirectMode();
+    return await this.#cursor.next();
+  }
+
+  public async nextBatch(durationMs: number): ReturnType<IMessageCursor<MessageType>["nextBatch"]> {
+    this.#enterBatchMode(durationMs);
+
+    const pendingBatch = this.#pendingBatch;
+    this.#pendingBatch = undefined;
+
+    const batch = pendingBatch ? await pendingBatch : await this.#cursor.nextBatch(durationMs);
+    if (batch != undefined && batch.length > 0) {
+      this.#pendingBatch = this.#cursor.nextBatch(durationMs);
+      void this.#pendingBatch.catch(() => {
+        // The next nextBatch call will observe this error. This catch only prevents an unhandled
+        // rejection if the caller ends the cursor before consuming the prefetched batch.
+      });
+    }
+
+    return batch;
+  }
+
+  public async readUntil(end: Time): ReturnType<IMessageCursor<MessageType>["readUntil"]> {
+    this.#enterDirectMode();
+    return await this.#cursor.readUntil(end);
+  }
+
+  public async end(): ReturnType<IMessageCursor<MessageType>["end"]> {
+    const pendingBatch = this.#pendingBatch;
+    this.#pendingBatch = undefined;
+    try {
+      await pendingBatch?.catch(() => undefined);
+    } finally {
+      await this.#cursor.end();
+    }
+  }
+
+  #enterBatchMode(durationMs: number): void {
+    if (this.#mode === "direct") {
+      throw new Error("Cannot mix direct cursor reads with nextBatch on the same cursor");
+    }
+    if (this.#batchDurationMs != undefined && this.#batchDurationMs !== durationMs) {
+      throw new Error(`Batch duration changed mid-stream: ${this.#batchDurationMs} -> ${durationMs}`);
+    }
+
+    this.#mode = "batch";
+    this.#batchDurationMs = durationMs;
+  }
+
+  #enterDirectMode(): void {
+    if (this.#mode === "batch") {
+      throw new Error("Cannot mix nextBatch with direct cursor reads on the same cursor");
+    }
+
+    this.#mode = "direct";
+  }
+}

--- a/packages/studio-base/src/players/IterablePlayer/PrefetchingMessageCursor.ts
+++ b/packages/studio-base/src/players/IterablePlayer/PrefetchingMessageCursor.ts
@@ -21,9 +21,9 @@ type PendingBatchResult<MessageType> =
  * Worker-backed cursors otherwise only start loading the next batch after the main thread asks for it.
  * Prefetching overlaps worker/network reads with main-thread processing of the current batch.
  */
-export class PrefetchingMessageCursor<MessageType = unknown>
-  implements IMessageCursor<MessageType>
-{
+export class PrefetchingMessageCursor<
+  MessageType = unknown,
+> implements IMessageCursor<MessageType> {
   #cursor: IMessageCursor<MessageType>;
   #pendingBatch?: {
     durationMs: number;

--- a/packages/studio-base/src/players/IterablePlayer/PrefetchingMessageCursor.ts
+++ b/packages/studio-base/src/players/IterablePlayer/PrefetchingMessageCursor.ts
@@ -5,11 +5,15 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import { add as addTime, compare } from "@foxglove/rostime";
 import { Time } from "@foxglove/studio";
 
 import type { IMessageCursor, IteratorResult } from "./IIterableSource";
 
-type CursorMode = "batch" | "direct";
+type PendingBatchResult<MessageType> =
+  | { status: "none" }
+  | { durationMs: number; status: "done" | "empty" }
+  | { batch: IteratorResult<MessageType>[]; durationMs: number; status: "data" };
 
 /**
  * Wraps a message cursor and keeps one nextBatch call in flight.
@@ -21,69 +25,196 @@ export class PrefetchingMessageCursor<MessageType = unknown>
   implements IMessageCursor<MessageType>
 {
   #cursor: IMessageCursor<MessageType>;
-  #pendingBatch?: Promise<IteratorResult<MessageType>[] | undefined>;
-  #batchDurationMs?: number;
-  #mode?: CursorMode;
+  #pendingBatch?: {
+    durationMs: number;
+    promise: Promise<IteratorResult<MessageType>[] | undefined>;
+  };
+  #bufferedResults: IteratorResult<MessageType>[] = [];
 
   public constructor(cursor: IMessageCursor<MessageType>) {
     this.#cursor = cursor;
   }
 
   public async next(): ReturnType<IMessageCursor<MessageType>["next"]> {
-    this.#enterDirectMode();
+    const buffered = await this.#shiftBufferedResult();
+    if (buffered.hasBufferedResult) {
+      return buffered.result;
+    }
+
     return await this.#cursor.next();
   }
 
   public async nextBatch(durationMs: number): ReturnType<IMessageCursor<MessageType>["nextBatch"]> {
-    this.#enterBatchMode(durationMs);
+    const hadBufferedResults = this.#bufferedResults.length > 0;
+    const pendingBatch =
+      this.#pendingBatch == undefined
+        ? { status: "none" as const }
+        : await this.#consumePendingBatch();
 
-    const pendingBatch = this.#pendingBatch;
-    this.#pendingBatch = undefined;
+    let batch: IteratorResult<MessageType>[] | undefined;
+    let exhausted = pendingBatch.status === "done";
+    if (
+      pendingBatch.status === "data" &&
+      pendingBatch.durationMs === durationMs &&
+      !hadBufferedResults
+    ) {
+      batch = pendingBatch.batch;
+    } else {
+      this.#bufferPendingBatch(pendingBatch);
+    }
 
-    const batch = pendingBatch ? await pendingBatch : await this.#cursor.nextBatch(durationMs);
-    if (batch != undefined && batch.length > 0) {
-      this.#pendingBatch = this.#cursor.nextBatch(durationMs);
-      void this.#pendingBatch.catch(() => {
-        // The next nextBatch call will observe this error. This catch only prevents an unhandled
-        // rejection if the caller ends the cursor before consuming the prefetched batch.
-      });
+    if (batch == undefined) {
+      if (this.#bufferedResults.length > 0) {
+        ({ batch, exhausted } = await this.#readBatchFromBufferedResults(durationMs));
+      } else if (pendingBatch.status === "done") {
+        batch = undefined;
+      } else if (pendingBatch.status === "empty") {
+        batch = [];
+      } else {
+        batch = await this.#cursor.nextBatch(durationMs);
+        exhausted = batch == undefined;
+      }
+    }
+
+    if (!exhausted && batch != undefined && batch.length > 0) {
+      this.#prefetch(durationMs);
     }
 
     return batch;
   }
 
   public async readUntil(end: Time): ReturnType<IMessageCursor<MessageType>["readUntil"]> {
-    this.#enterDirectMode();
-    return await this.#cursor.readUntil(end);
+    this.#bufferPendingBatch(await this.#consumePendingBatch());
+
+    const results: IteratorResult<MessageType>[] = [];
+    while (this.#bufferedResults.length > 0) {
+      const result = this.#bufferedResults[0]!;
+      if (this.#isReadUntilBoundary(result, end)) {
+        return results;
+      }
+      results.push(this.#bufferedResults.shift()!);
+    }
+
+    const remainingResults = await this.#cursor.readUntil(end);
+    if (remainingResults == undefined) {
+      return results.length === 0 ? undefined : results;
+    }
+
+    return results.concat(remainingResults);
   }
 
   public async end(): ReturnType<IMessageCursor<MessageType>["end"]> {
     const pendingBatch = this.#pendingBatch;
     this.#pendingBatch = undefined;
-    try {
-      await pendingBatch?.catch(() => undefined);
-    } finally {
-      await this.#cursor.end();
+    this.#bufferedResults = [];
+    void pendingBatch?.promise.catch(() => {
+      // Prevent an unhandled rejection if the prefetch completes after the cursor has been ended.
+    });
+    await this.#cursor.end();
+  }
+
+  async #consumePendingBatch(): Promise<PendingBatchResult<MessageType>> {
+    const pendingBatch = this.#pendingBatch;
+    if (pendingBatch == undefined) {
+      return { status: "none" };
+    }
+
+    this.#pendingBatch = undefined;
+    const batch = await pendingBatch.promise;
+    if (batch == undefined) {
+      return { durationMs: pendingBatch.durationMs, status: "done" };
+    }
+    if (batch.length === 0) {
+      return { durationMs: pendingBatch.durationMs, status: "empty" };
+    }
+
+    return { batch, durationMs: pendingBatch.durationMs, status: "data" };
+  }
+
+  #bufferPendingBatch(pendingBatch: PendingBatchResult<MessageType>): void {
+    if (pendingBatch.status === "data") {
+      this.#bufferedResults.push(...pendingBatch.batch);
     }
   }
 
-  #enterBatchMode(durationMs: number): void {
-    if (this.#mode === "direct") {
-      throw new Error("Cannot mix direct cursor reads with nextBatch on the same cursor");
-    }
-    if (this.#batchDurationMs != undefined && this.#batchDurationMs !== durationMs) {
-      throw new Error(`Batch duration changed mid-stream: ${this.#batchDurationMs} -> ${durationMs}`);
+  async #shiftBufferedResult(): Promise<{
+    hasBufferedResult: boolean;
+    result: IteratorResult<MessageType> | undefined;
+  }> {
+    if (this.#bufferedResults.length > 0) {
+      return { hasBufferedResult: true, result: this.#bufferedResults.shift() };
     }
 
-    this.#mode = "batch";
-    this.#batchDurationMs = durationMs;
+    const pendingBatch = await this.#consumePendingBatch();
+    this.#bufferPendingBatch(pendingBatch);
+    if (this.#bufferedResults.length > 0) {
+      return { hasBufferedResult: true, result: this.#bufferedResults.shift() };
+    }
+    if (pendingBatch.status === "done") {
+      return { hasBufferedResult: true, result: undefined };
+    }
+
+    return { hasBufferedResult: false, result: undefined };
   }
 
-  #enterDirectMode(): void {
-    if (this.#mode === "batch") {
-      throw new Error("Cannot mix nextBatch with direct cursor reads on the same cursor");
+  async #readBatchFromBufferedResults(durationMs: number): Promise<{
+    batch: IteratorResult<MessageType>[] | undefined;
+    exhausted: boolean;
+  }> {
+    const firstResult = this.#bufferedResults.shift() ?? (await this.#cursor.next());
+    if (firstResult == undefined) {
+      return { batch: undefined, exhausted: true };
     }
 
-    this.#mode = "direct";
+    const batch: IteratorResult<MessageType>[] = [firstResult];
+    if (firstResult.type === "problem") {
+      return { batch, exhausted: false };
+    }
+
+    const cutoffTime =
+      firstResult.type === "stamp"
+        ? addTime(firstResult.stamp, { sec: 0, nsec: durationMs * 1e6 })
+        : addTime(firstResult.msgEvent.receiveTime, { sec: 0, nsec: durationMs * 1e6 });
+
+    for (;;) {
+      const result = this.#bufferedResults.shift() ?? (await this.#cursor.next());
+      if (result == undefined) {
+        return { batch, exhausted: true };
+      }
+
+      batch.push(result);
+      if (this.#isBatchBoundary(result, cutoffTime)) {
+        return { batch, exhausted: false };
+      }
+    }
+  }
+
+  #prefetch(durationMs: number): void {
+    const promise = this.#cursor.nextBatch(durationMs);
+    this.#pendingBatch = { durationMs, promise };
+    void promise.catch(() => {
+      // The next read will observe this error. This catch only prevents an unhandled rejection if
+      // the caller ends the cursor before consuming the prefetched batch.
+    });
+  }
+
+  #isBatchBoundary(result: IteratorResult<MessageType>, cutoffTime: Time): boolean {
+    if (result.type === "problem") {
+      return true;
+    }
+    if (result.type === "stamp") {
+      return compare(result.stamp, cutoffTime) > 0;
+    }
+    return compare(result.msgEvent.receiveTime, cutoffTime) > 0;
+  }
+
+  #isReadUntilBoundary(result: IteratorResult<MessageType>, end: Time): boolean {
+    if (result.type === "stamp") {
+      return compare(result.stamp, end) >= 0;
+    }
+    if (result.type === "message-event") {
+      return compare(result.msgEvent.receiveTime, end) > 0;
+    }
+    return false;
   }
 }

--- a/packages/studio-base/src/players/IterablePlayer/WorkerIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/WorkerIterableSource.test.ts
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import * as Comlink from "@coscene-io/comlink";
+
+import { ComlinkWrap } from "@foxglove/den/worker";
+import { mockTopicSelection } from "@foxglove/studio-base/test/mocks/mockTopicSelection";
+
+import { Initalization, IteratorResult, MessageIteratorArgs } from "./IIterableSource";
+import { WorkerIterableSource } from "./WorkerIterableSource";
+import { WorkerSerializedIterableSource } from "./WorkerSerializedIterableSource";
+
+jest.mock("@foxglove/den/worker", () => ({
+  ComlinkWrap: jest.fn(),
+}));
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  reject: (err: unknown) => void;
+  resolve: (value: T) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, reject, resolve };
+}
+
+function stamp(sec: number): IteratorResult {
+  return { type: "stamp", stamp: { sec, nsec: 0 } };
+}
+
+const initResult: Initalization = {
+  start: { sec: 0, nsec: 0 },
+  end: { sec: 1, nsec: 0 },
+  topics: [],
+  topicStats: new Map(),
+  profile: undefined,
+  problems: [],
+  datatypes: new Map(),
+  publishersByTopic: new Map(),
+};
+
+const iteratorArgs: MessageIteratorArgs = {
+  topics: mockTopicSelection("a"),
+  start: { sec: 0, nsec: 0 },
+};
+
+function setupWorkerRemote() {
+  const first = deferred<IteratorResult[] | undefined>();
+  const second = deferred<IteratorResult[] | undefined>();
+  const releaseProxy = jest.fn();
+  const remoteCursor = {
+    next: jest.fn(async () => undefined),
+    nextBatch: jest
+      .fn<Promise<IteratorResult[] | undefined>, [number]>()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise)
+      .mockResolvedValueOnce(undefined),
+    readUntil: jest.fn(async () => []),
+    end: jest.fn(async () => {}),
+    [Comlink.releaseProxy]: releaseProxy,
+  };
+  const sourceWorkerRemote = {
+    initialize: jest.fn(async () => initResult),
+    getBackfillMessages: jest.fn(async () => []),
+    getMessageCursor: jest.fn(async () => remoteCursor),
+    terminate: jest.fn(async () => {}),
+  };
+  const initializeWorker = jest.fn(async () => sourceWorkerRemote);
+  const dispose = jest.fn();
+  (ComlinkWrap as jest.Mock).mockReturnValue({ remote: initializeWorker, dispose });
+
+  return { first, second, remoteCursor, releaseProxy };
+}
+
+describe("WorkerIterableSource", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("prefetches the next worker cursor batch", async () => {
+    const { first, second, remoteCursor, releaseProxy } = setupWorkerRemote();
+    const source = new WorkerIterableSource({
+      initWorker: () => ({}) as Worker,
+      initArgs: {},
+    });
+    await source.initialize();
+
+    const cursor = source.getMessageCursor(iteratorArgs);
+    const firstRead = cursor.nextBatch(100);
+    await Promise.resolve();
+    expect(remoteCursor.nextBatch).toHaveBeenCalledTimes(1);
+
+    first.resolve([stamp(1)]);
+    await expect(firstRead).resolves.toEqual([stamp(1)]);
+    expect(remoteCursor.nextBatch).toHaveBeenCalledTimes(2);
+
+    const secondRead = cursor.nextBatch(100);
+    expect(remoteCursor.nextBatch).toHaveBeenCalledTimes(2);
+
+    second.resolve([stamp(2)]);
+    await expect(secondRead).resolves.toEqual([stamp(2)]);
+
+    await cursor.end();
+    expect(releaseProxy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("WorkerSerializedIterableSource", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("prefetches the next serialized worker cursor batch", async () => {
+    const { first, second, remoteCursor, releaseProxy } = setupWorkerRemote();
+    const source = new WorkerSerializedIterableSource({
+      initWorker: () => ({}) as Worker,
+      initArgs: {},
+    });
+    await source.initialize();
+
+    const cursor = source.getMessageCursor(iteratorArgs);
+    const firstRead = cursor.nextBatch(100);
+    await Promise.resolve();
+    expect(remoteCursor.nextBatch).toHaveBeenCalledTimes(1);
+
+    first.resolve([stamp(1)]);
+    await expect(firstRead).resolves.toEqual([stamp(1)]);
+    expect(remoteCursor.nextBatch).toHaveBeenCalledTimes(2);
+
+    const secondRead = cursor.nextBatch(100);
+    expect(remoteCursor.nextBatch).toHaveBeenCalledTimes(2);
+
+    second.resolve([stamp(2)]);
+    await expect(secondRead).resolves.toEqual([stamp(2)]);
+
+    await cursor.end();
+    expect(releaseProxy).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses 100ms batches for serialized worker message iteration", async () => {
+    const { remoteCursor } = setupWorkerRemote();
+    remoteCursor.nextBatch.mockReset().mockResolvedValueOnce(undefined);
+    const source = new WorkerSerializedIterableSource({
+      initWorker: () => ({}) as Worker,
+      initArgs: {},
+    });
+    await source.initialize();
+
+    const iterator = source.messageIterator(iteratorArgs);
+    await iterator.next();
+
+    expect(remoteCursor.nextBatch).toHaveBeenCalledWith(100);
+  });
+});

--- a/packages/studio-base/src/players/IterablePlayer/WorkerIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/WorkerIterableSource.test.ts
@@ -38,6 +38,11 @@ function stamp(sec: number): IteratorResult {
   return { type: "stamp", stamp: { sec, nsec: 0 } };
 }
 
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
 const initResult: Initalization = {
   start: { sec: 0, nsec: 0 },
   end: { sec: 1, nsec: 0 },
@@ -87,8 +92,35 @@ describe("WorkerIterableSource", () => {
     jest.clearAllMocks();
   });
 
-  it("prefetches the next worker cursor batch", async () => {
+  it("prefetches the next worker cursor batch during message iteration", async () => {
     const { first, second, remoteCursor, releaseProxy } = setupWorkerRemote();
+    const source = new WorkerIterableSource({
+      initWorker: () => ({}) as Worker,
+      initArgs: {},
+    });
+    await source.initialize();
+
+    const iterator = source.messageIterator(iteratorArgs);
+    const firstRead = iterator.next();
+    await flushPromises();
+    expect(remoteCursor.nextBatch).toHaveBeenCalledTimes(1);
+
+    first.resolve([stamp(1)]);
+    await expect(firstRead).resolves.toEqual({ done: false, value: stamp(1) });
+    expect(remoteCursor.nextBatch).toHaveBeenCalledTimes(2);
+
+    const secondRead = iterator.next();
+    expect(remoteCursor.nextBatch).toHaveBeenCalledTimes(2);
+
+    second.resolve([stamp(2)]);
+    await expect(secondRead).resolves.toEqual({ done: false, value: stamp(2) });
+
+    await iterator.return?.();
+    expect(releaseProxy).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns an unwrapped worker cursor from getMessageCursor", async () => {
+    const { first, remoteCursor, releaseProxy } = setupWorkerRemote();
     const source = new WorkerIterableSource({
       initWorker: () => ({}) as Worker,
       initArgs: {},
@@ -97,18 +129,12 @@ describe("WorkerIterableSource", () => {
 
     const cursor = source.getMessageCursor(iteratorArgs);
     const firstRead = cursor.nextBatch(100);
-    await Promise.resolve();
+    await flushPromises();
     expect(remoteCursor.nextBatch).toHaveBeenCalledTimes(1);
 
     first.resolve([stamp(1)]);
     await expect(firstRead).resolves.toEqual([stamp(1)]);
-    expect(remoteCursor.nextBatch).toHaveBeenCalledTimes(2);
-
-    const secondRead = cursor.nextBatch(100);
-    expect(remoteCursor.nextBatch).toHaveBeenCalledTimes(2);
-
-    second.resolve([stamp(2)]);
-    await expect(secondRead).resolves.toEqual([stamp(2)]);
+    expect(remoteCursor.nextBatch).toHaveBeenCalledTimes(1);
 
     await cursor.end();
     expect(releaseProxy).toHaveBeenCalledTimes(1);
@@ -120,7 +146,7 @@ describe("WorkerSerializedIterableSource", () => {
     jest.clearAllMocks();
   });
 
-  it("prefetches the next serialized worker cursor batch", async () => {
+  it("prefetches the next serialized worker cursor batch during message iteration", async () => {
     const { first, second, remoteCursor, releaseProxy } = setupWorkerRemote();
     const source = new WorkerSerializedIterableSource({
       initWorker: () => ({}) as Worker,
@@ -128,22 +154,22 @@ describe("WorkerSerializedIterableSource", () => {
     });
     await source.initialize();
 
-    const cursor = source.getMessageCursor(iteratorArgs);
-    const firstRead = cursor.nextBatch(100);
-    await Promise.resolve();
+    const iterator = source.messageIterator(iteratorArgs);
+    const firstRead = iterator.next();
+    await flushPromises();
     expect(remoteCursor.nextBatch).toHaveBeenCalledTimes(1);
 
     first.resolve([stamp(1)]);
-    await expect(firstRead).resolves.toEqual([stamp(1)]);
+    await expect(firstRead).resolves.toEqual({ done: false, value: stamp(1) });
     expect(remoteCursor.nextBatch).toHaveBeenCalledTimes(2);
 
-    const secondRead = cursor.nextBatch(100);
+    const secondRead = iterator.next();
     expect(remoteCursor.nextBatch).toHaveBeenCalledTimes(2);
 
     second.resolve([stamp(2)]);
-    await expect(secondRead).resolves.toEqual([stamp(2)]);
+    await expect(secondRead).resolves.toEqual({ done: false, value: stamp(2) });
 
-    await cursor.end();
+    await iterator.return?.();
     expect(releaseProxy).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/studio-base/src/players/IterablePlayer/WorkerIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/WorkerIterableSource.ts
@@ -66,7 +66,7 @@ export class WorkerIterableSource implements IDeserializedIterableSource {
       throw new Error(`WorkerIterableSource is not initialized`);
     }
 
-    const cursor = this.getMessageCursor(args);
+    const cursor = new PrefetchingMessageCursor(this.getMessageCursor(args));
     try {
       for (;;) {
         // We previously used 17ms batches (roughly one 60fps frame) so each fetch could feed a frame,
@@ -114,7 +114,7 @@ export class WorkerIterableSource implements IDeserializedIterableSource {
       abort ?? abortSignal,
     );
 
-    const cursor: IMessageCursor = new PrefetchingMessageCursor({
+    const cursor: IMessageCursor = {
       async next() {
         const messageCursor = await messageCursorPromise;
         return await messageCursor.next();
@@ -138,7 +138,7 @@ export class WorkerIterableSource implements IDeserializedIterableSource {
           messageCursor[Comlink.releaseProxy]();
         }
       },
-    });
+    };
 
     return cursor;
   }

--- a/packages/studio-base/src/players/IterablePlayer/WorkerIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/WorkerIterableSource.ts
@@ -20,7 +20,9 @@ import type {
   IterableSourceInitializeArgs,
   IDeserializedIterableSource,
 } from "./IIterableSource";
+import { PrefetchingMessageCursor } from "./PrefetchingMessageCursor";
 import type { WorkerIterableSourceWorker } from "./WorkerIterableSourceWorker";
+import { WORKER_CURSOR_BATCH_DURATION_MS } from "./workerCursorBatchDuration";
 
 Comlink.transferHandlers.set("abortsignal", abortSignalTransferHandler);
 
@@ -73,7 +75,7 @@ export class WorkerIterableSource implements IDeserializedIterableSource {
         // significantly reducing time lost to cross-thread overhead while still returning data fast enough
         // for playback and preloading consumers. With the same 6-15ms per-call cost but 5-6x more payload per call,
         // our downstream consumers see roughly 2x higher effective throughput even though the per-batch latency grew modestly.
-        const results = await cursor.nextBatch(100 /* milliseconds */);
+        const results = await cursor.nextBatch(WORKER_CURSOR_BATCH_DURATION_MS);
         if (!results || results.length === 0) {
           break;
         }
@@ -112,7 +114,7 @@ export class WorkerIterableSource implements IDeserializedIterableSource {
       abort ?? abortSignal,
     );
 
-    const cursor: IMessageCursor = {
+    const cursor: IMessageCursor = new PrefetchingMessageCursor({
       async next() {
         const messageCursor = await messageCursorPromise;
         return await messageCursor.next();
@@ -136,7 +138,7 @@ export class WorkerIterableSource implements IDeserializedIterableSource {
           messageCursor[Comlink.releaseProxy]();
         }
       },
-    };
+    });
 
     return cursor;
   }

--- a/packages/studio-base/src/players/IterablePlayer/WorkerSerializedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/WorkerSerializedIterableSource.ts
@@ -65,7 +65,7 @@ export class WorkerSerializedIterableSource implements ISerializedIterableSource
       throw new Error(`WorkerIterableSource is not initialized`);
     }
 
-    const cursor = this.getMessageCursor(args);
+    const cursor = new PrefetchingMessageCursor(this.getMessageCursor(args));
     try {
       for (;;) {
         const results = await cursor.nextBatch(WORKER_CURSOR_BATCH_DURATION_MS);
@@ -109,7 +109,7 @@ export class WorkerSerializedIterableSource implements ISerializedIterableSource
       abort ?? abortSignal,
     );
 
-    const cursor: IMessageCursor<Uint8Array> = new PrefetchingMessageCursor({
+    const cursor: IMessageCursor<Uint8Array> = {
       async next() {
         const messageCursor = await messageCursorPromise;
         return await messageCursor.next();
@@ -133,7 +133,7 @@ export class WorkerSerializedIterableSource implements ISerializedIterableSource
           messageCursor[Comlink.releaseProxy]();
         }
       },
-    });
+    };
 
     return cursor;
   }

--- a/packages/studio-base/src/players/IterablePlayer/WorkerSerializedIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/WorkerSerializedIterableSource.ts
@@ -20,7 +20,9 @@ import type {
   ISerializedIterableSource,
   Initalization,
 } from "./IIterableSource";
+import { PrefetchingMessageCursor } from "./PrefetchingMessageCursor";
 import type { WorkerSerializedIterableSourceWorker } from "./WorkerSerializedIterableSourceWorker";
+import { WORKER_CURSOR_BATCH_DURATION_MS } from "./workerCursorBatchDuration";
 
 Comlink.transferHandlers.set("abortsignal", abortSignalTransferHandler);
 
@@ -66,11 +68,7 @@ export class WorkerSerializedIterableSource implements ISerializedIterableSource
     const cursor = this.getMessageCursor(args);
     try {
       for (;;) {
-        // The fastest framerate that studio renders at is 60fps. So to render a frame studio needs
-        // at minimum ~16 milliseconds of messages before it will render a frame. Here we fetch
-        // batches of 17 milliseconds so that one batch fetch could result in one frame render.
-        // Fetching too much in a batch means we cannot render until the batch is returned.
-        const results = await cursor.nextBatch(17 /* milliseconds */);
+        const results = await cursor.nextBatch(WORKER_CURSOR_BATCH_DURATION_MS);
         if (!results || results.length === 0) {
           break;
         }
@@ -111,7 +109,7 @@ export class WorkerSerializedIterableSource implements ISerializedIterableSource
       abort ?? abortSignal,
     );
 
-    const cursor: IMessageCursor<Uint8Array> = {
+    const cursor: IMessageCursor<Uint8Array> = new PrefetchingMessageCursor({
       async next() {
         const messageCursor = await messageCursorPromise;
         return await messageCursor.next();
@@ -135,7 +133,7 @@ export class WorkerSerializedIterableSource implements ISerializedIterableSource
           messageCursor[Comlink.releaseProxy]();
         }
       },
-    };
+    });
 
     return cursor;
   }

--- a/packages/studio-base/src/players/IterablePlayer/workerCursorBatchDuration.ts
+++ b/packages/studio-base/src/players/IterablePlayer/workerCursorBatchDuration.ts
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export const WORKER_CURSOR_BATCH_DURATION_MS = 100;


### PR DESCRIPTION
## Summary
- Batch IndexedDB message writes inside a single transaction to reduce per-event overhead
- Buffer spill-cache message appends and flush them in larger chunks, with updated tests for append batching
- Introduce `PrefetchingMessageCursor` to keep one worker batch in flight and reuse a shared batch duration constant across worker sources

## Testing
- Added unit tests for `PrefetchingMessageCursor`
- Added worker source tests covering batch prefetch behavior
- Updated spill-cache tests to verify batched append calls

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786166476&installation_id=141984720&pr_number=1395&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1395&signature=a39ba6a550dc6dd7c88d34a896660263a52db903239d0aed942055eed342c7cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->