### PR TITLE
Fix IndexedDB cache review follow-ups

### DIFF
--- a/packages/studio-base/src/persistence/IndexedDbMessageStore.test.ts
+++ b/packages/studio-base/src/persistence/IndexedDbMessageStore.test.ts
@@ -1409,6 +1409,55 @@ describe("IndexedDbMessageStore", () => {
     }
   });
 
+  it("does not clean up a stale session while a replay reader holds a fresh lease", async () => {
+    const sessionId = "leased-replay-session";
+    const seed = new IndexedDbMessageStore({ sessionId, kind: "playback-spill" });
+    await seed.init();
+    await seed.append([messageEvent(1)]);
+    await seed.flush();
+    await seed.close();
+
+    const db = await IDB.openDB(PLAYBACK_MESSAGE_CACHE_DB_NAME);
+    const tx = db.transaction("sessions", "readwrite");
+    const metadata = (await tx.store.get(sessionId)) as CacheSessionMetadata;
+    await tx.store.put({ ...metadata, lastActiveAt: 1_000 });
+    await tx.done;
+    db.close();
+
+    const nowSpy = jest.spyOn(Date, "now").mockReturnValue(10_000);
+    const reader = new IndexedDbMessageStore({
+      sessionId,
+      kind: "playback-spill",
+      accessMode: "reader",
+    });
+    const cleaner = new IndexedDbMessageStore({
+      sessionId: "reader-lease-cleaner",
+      kind: "playback-spill",
+    });
+    try {
+      await reader.init();
+      await cleaner.init();
+      await cleaner.cleanupOldSessions("playback-spill", 5_000);
+
+      await expect(
+        reader.getMessages({
+          start: { sec: 0, nsec: 0 },
+          end: { sec: 20, nsec: 0 },
+        }),
+      ).resolves.toHaveLength(1);
+      expect(await getSessionMetadata(sessionId, "playback-spill")).toMatchObject({
+        status: "closed",
+        readers: [expect.any(String)],
+      });
+    } finally {
+      await reader.close();
+      await cleaner.close();
+      nowSpy.mockRestore();
+    }
+
+    expect(await getSessionMetadata(sessionId, "playback-spill")).toMatchObject({ readers: [] });
+  });
+
   it("continues cleanup after one reclaimable session fails", async () => {
     const first = new IndexedDbMessageStore({
       sessionId: "cleanup-first",
@@ -1808,6 +1857,40 @@ describe("IndexedDbMessageStore", () => {
       } else {
         Reflect.deleteProperty(globalThis, "window");
       }
+    }
+  });
+
+  it("does not disable a new writer for a sealed session awaiting reclamation", async () => {
+    const previousSessionId = "sealed-previous-playback";
+    const previous = new IndexedDbMessageStore({
+      sessionId: previousSessionId,
+      kind: "playback-spill",
+    });
+    await previous.init();
+    await previous.append([messageEvent(1)]);
+    await previous.flush();
+    await previous.close();
+
+    const db = await IDB.openDB(PLAYBACK_MESSAGE_CACHE_DB_NAME);
+    const tx = db.transaction("sessions", "readwrite");
+    const metadata = (await tx.store.get(previousSessionId)) as CacheSessionMetadata;
+    await tx.store.put({
+      ...metadata,
+      status: "pending-delete",
+      approximateSizeBytes: 3 * 1024 * 1024 * 1024,
+    });
+    await tx.done;
+    db.close();
+
+    const current = new IndexedDbMessageStore({
+      sessionId: "next-playback",
+      kind: "playback-spill",
+    });
+    try {
+      await current.init();
+      expect(current.isWritable()).toBe(true);
+    } finally {
+      await current.close();
     }
   });
 

--- a/packages/studio-base/src/persistence/IndexedDbMessageStore.test.ts
+++ b/packages/studio-base/src/persistence/IndexedDbMessageStore.test.ts
@@ -1922,7 +1922,7 @@ describe("IndexedDbMessageStore", () => {
       await janitor.init();
       const retryDelayMs = await janitor.runMaintenance();
       expect(console.warn).toHaveBeenCalledWith(
-        "Disabling IndexedDbMessageStore writes because active sessions exceed budget",
+        "Disabling IndexedDbMessageStore writes because non-reclaimable sessions exceed budget",
         expect.objectContaining({ dbName: PLAYBACK_MESSAGE_CACHE_DB_NAME }),
       );
       jest.mocked(console.warn).mockClear();
@@ -1931,6 +1931,49 @@ describe("IndexedDbMessageStore", () => {
       expect(await getSessionMetadata(sessionId, "playback-spill")).toMatchObject({
         status: "active",
       });
+    } finally {
+      await janitor.close();
+    }
+  });
+
+  it("requests a later maintenance pass for an over-budget session with a fresh reader lease", async () => {
+    const sessionId = "startup-fresh-reader";
+    const store = new IndexedDbMessageStore({ sessionId, kind: "playback-spill" });
+    await store.init();
+    await store.append([messageEvent(1)]);
+    await store.flush();
+    await store.close();
+
+    const db = await IDB.openDB(PLAYBACK_MESSAGE_CACHE_DB_NAME);
+    const tx = db.transaction("sessions", "readwrite");
+    const metadata = (await tx.store.get(sessionId)) as CacheSessionMetadata;
+    await tx.store.put({
+      ...metadata,
+      readers: ["replay-reader"],
+      lastActiveAt: Date.now(),
+      approximateSizeBytes: 3 * 1024 * 1024 * 1024,
+    });
+    await tx.done;
+    db.close();
+
+    const janitor = new IndexedDbMessageStore({
+      kind: "playback-spill",
+      accessMode: "maintenance",
+    });
+    try {
+      await janitor.init();
+      const retryDelayMs = await janitor.runMaintenance();
+      expect(retryDelayMs).toBeGreaterThan(4 * 60 * 1_000);
+      expect(retryDelayMs).toBeLessThanOrEqual(5 * 60 * 1_000 + 1_000);
+      expect(await getSessionMetadata(sessionId, "playback-spill")).toMatchObject({
+        status: "closed",
+        readers: ["replay-reader"],
+      });
+      expect(console.warn).toHaveBeenCalledWith(
+        "Disabling IndexedDbMessageStore writes because non-reclaimable sessions exceed budget",
+        expect.objectContaining({ dbName: PLAYBACK_MESSAGE_CACHE_DB_NAME }),
+      );
+      jest.mocked(console.warn).mockClear();
     } finally {
       await janitor.close();
     }

--- a/packages/studio-base/src/persistence/IndexedDbMessageStore.test.ts
+++ b/packages/studio-base/src/persistence/IndexedDbMessageStore.test.ts
@@ -1458,6 +1458,49 @@ describe("IndexedDbMessageStore", () => {
     expect(await getSessionMetadata(sessionId, "playback-spill")).toMatchObject({ readers: [] });
   });
 
+  it("cleans up a terminal session even while a replay reader lease is fresh", async () => {
+    const sessionId = "terminal-reader-session";
+    const seed = new IndexedDbMessageStore({ sessionId, kind: "playback-spill" });
+    await seed.init();
+    await seed.append([messageEvent(1)]);
+    await seed.flush();
+    await seed.close();
+
+    const reader = new IndexedDbMessageStore({
+      sessionId,
+      kind: "playback-spill",
+      accessMode: "reader",
+    });
+    const sealer = new IndexedDbMessageStore({ sessionId, kind: "playback-spill" });
+    const cleaner = new IndexedDbMessageStore({
+      sessionId: "terminal-reader-cleaner",
+      kind: "playback-spill",
+    });
+    try {
+      await reader.init();
+      await sealer.init();
+      await sealer.discardAndSeal("pending-delete");
+      expect(await getSessionMetadata(sessionId, "playback-spill")).toMatchObject({
+        status: "pending-delete",
+        readers: [expect.any(String)],
+      });
+
+      await cleaner.init();
+      await cleaner.cleanupOldSessions("playback-spill");
+
+      expect(await getSessionMetadata(sessionId, "playback-spill")).toBeUndefined();
+      await expect(
+        reader.getMessages({
+          start: { sec: 0, nsec: 0 },
+          end: { sec: 20, nsec: 0 },
+        }),
+      ).resolves.toHaveLength(0);
+    } finally {
+      await reader.close();
+      await cleaner.close();
+    }
+  });
+
   it("continues cleanup after one reclaimable session fails", async () => {
     const first = new IndexedDbMessageStore({
       sessionId: "cleanup-first",

--- a/packages/studio-base/src/persistence/IndexedDbMessageStore.ts
+++ b/packages/studio-base/src/persistence/IndexedDbMessageStore.ts
@@ -93,6 +93,8 @@ export type CacheSessionMetadata = {
   cleanupToken?: string;
   /** Live connection leases; stale entries are reclaimed with the session TTL after a crash. */
   owners?: readonly string[];
+  /** Active replay readers; stale entries are reclaimed with the session TTL after a crash. */
+  readers?: readonly string[];
   /** Persisted generation used to reject coverage written after another connection pruned data. */
   contentRevision?: number;
   nextSeq: number;
@@ -588,6 +590,7 @@ export class IndexedDbMessageStore implements PersistentMessageCache {
   #maintenanceTimeoutMs: number;
   #shutdownDeadlineAt: number | undefined;
   #sessionCreated = false;
+  #readerLeaseCreated = false;
 
   public constructor(options: IndexedDbMessageStoreOptions = {}) {
     const {
@@ -823,6 +826,10 @@ export class IndexedDbMessageStore implements PersistentMessageCache {
       }
 
       if (this.#accessMode === "reader") {
+        this.#readerLeaseCreated = await this.#awaitInitializationStage(
+          this.#registerReaderLease(),
+          "reader lease",
+        );
         await this.#awaitInitializationStage(
           this.#loadExistingMessageStats(),
           "message statistics",
@@ -878,6 +885,17 @@ export class IndexedDbMessageStore implements PersistentMessageCache {
           await this.#settleShutdownOperation(
             this.#updateSessionStatus(dbResult.value, "abandoned", { sealSession: true }),
             "session abandonment after initialization failure",
+          );
+        }
+      } else if (this.#readerLeaseCreated) {
+        const dbResult = await this.#settleShutdownOperation(
+          this.#dbPromise,
+          "database availability after reader initialization failure",
+        );
+        if (dbResult.status === "fulfilled") {
+          await this.#settleShutdownOperation(
+            this.#releaseReaderLease(dbResult.value),
+            "reader lease release after initialization failure",
           );
         }
       }
@@ -1153,9 +1171,13 @@ export class IndexedDbMessageStore implements PersistentMessageCache {
 
   #trackTransaction<T extends ActiveTransaction>(
     transaction: T,
-    options: { allowWhileClosing?: boolean } = {},
+    options: { allowWhileClosing?: boolean; allowReaderMetadataWrite?: boolean } = {},
   ): T {
-    if (this.#accessMode === "reader" && transaction.mode === "readwrite") {
+    if (
+      this.#accessMode === "reader" &&
+      transaction.mode === "readwrite" &&
+      options.allowReaderMetadataWrite !== true
+    ) {
       transaction.abort();
       throw new Error("Reader IndexedDbMessageStore cannot start a readwrite transaction");
     }
@@ -1372,10 +1394,15 @@ export class IndexedDbMessageStore implements PersistentMessageCache {
       if (this.#shouldStopInitialization()) {
         return;
       }
+      const readerLeaseCutoff =
+        Date.now() -
+        (this.#kind === "playback-spill" ? PLAYBACK_SPILL_PRESSURE_STALE_MS : THREE_DAYS_MS);
       for (const session of sessions) {
-        totalBytes += normalizedStoredSize(session.approximateSizeBytes);
+        if (session.status === "active" || this.#hasFreshReaderLease(session, readerLeaseCutoff)) {
+          totalBytes += normalizedStoredSize(session.approximateSizeBytes);
+          sessionCount++;
+        }
       }
-      sessionCount = sessions.length;
     } catch (error) {
       if (this.#shouldStopInitialization()) {
         return;
@@ -1428,6 +1455,7 @@ export class IndexedDbMessageStore implements PersistentMessageCache {
         maxBytes: this.#maxCacheSize,
         status: "active",
         owners: Array.from(new Set([...(existing?.owners ?? []), this.#ownerId])),
+        readers: existing?.readers,
         contentRevision: normalizedContentRevision(
           existing?.contentRevision ?? this.#contentRevision,
         ),
@@ -1447,6 +1475,34 @@ export class IndexedDbMessageStore implements PersistentMessageCache {
       log.error("Failed to record session metadata:", error);
       throw error;
     }
+  }
+
+  async #registerReaderLease(): Promise<boolean> {
+    const db = await this.#dbPromise;
+    const tx = this.#trackTransaction(db.transaction(SESSIONS_STORE, "readwrite"), {
+      allowReaderMetadataWrite: true,
+    });
+    const store = tx.objectStore(SESSIONS_STORE);
+    const existing = await store.get(this.#currentSessionId);
+    if (existing == undefined) {
+      await tx.done;
+      return false;
+    }
+    if (existing.status === "pending-delete" || existing.status === "abandoned") {
+      await tx.done;
+      throw new Error("IndexedDbMessageStore session is pending cleanup and cannot be replayed");
+    }
+    await store.put({
+      ...existing,
+      readers: Array.from(new Set([...(existing.readers ?? []), this.#ownerId])),
+      lastActiveAt: Date.now(),
+    });
+    await tx.done;
+    return true;
+  }
+
+  #hasFreshReaderLease(session: CacheSessionMetadata, cutoffTime: number): boolean {
+    return (session.readers?.length ?? 0) > 0 && session.lastActiveAt > cutoffTime;
   }
 
   public async cleanupOldSessions(
@@ -1469,7 +1525,9 @@ export class IndexedDbMessageStore implements PersistentMessageCache {
         if (
           session.status === "pending-delete" ||
           session.status === "abandoned" ||
-          (session.sessionId !== this.#currentSessionId && session.lastActiveAt <= cutoffTime)
+          (session.sessionId !== this.#currentSessionId &&
+            session.lastActiveAt <= cutoffTime &&
+            !this.#hasFreshReaderLease(session, cutoffTime))
         ) {
           candidates.push(session);
         }
@@ -1553,7 +1611,8 @@ export class IndexedDbMessageStore implements PersistentMessageCache {
         if (
           sessionMetadata.kind !== staleGuard.kind ||
           (sessionMetadata.status === "active" &&
-            sessionMetadata.lastActiveAt > staleGuard.cutoffTime)
+            sessionMetadata.lastActiveAt > staleGuard.cutoffTime) ||
+          this.#hasFreshReaderLease(sessionMetadata, staleGuard.cutoffTime)
         ) {
           await sealTx.done;
           return false;
@@ -1904,18 +1963,28 @@ export class IndexedDbMessageStore implements PersistentMessageCache {
   }
 
   public async touchSession(): Promise<boolean> {
-    if (!this.isWritable()) {
+    if (
+      this.#closed ||
+      this.#unavailable ||
+      (this.#accessMode === "reader" ? !this.#readerLeaseCreated : !this.isWritable())
+    ) {
       return false;
     }
     const db = await this.#dbPromise;
-    const tx = this.#trackTransaction(db.transaction(SESSIONS_STORE, "readwrite"));
+    const tx = this.#trackTransaction(db.transaction(SESSIONS_STORE, "readwrite"), {
+      allowReaderMetadataWrite: this.#accessMode === "reader",
+    });
     const store = tx.objectStore(SESSIONS_STORE);
     const existing = await store.get(this.#currentSessionId);
     if (existing == undefined) {
       await tx.done;
       return false;
     }
-    if (existing.status !== "active") {
+    if (
+      this.#accessMode === "reader"
+        ? !(existing.readers ?? []).includes(this.#ownerId)
+        : existing.status !== "active"
+    ) {
       await tx.done;
       return false;
     }
@@ -2335,6 +2404,7 @@ export class IndexedDbMessageStore implements PersistentMessageCache {
       .filter(
         (session) =>
           session.sessionId !== this.#currentSessionId &&
+          !this.#hasFreshReaderLease(session, staleCutoff) &&
           (session.status !== "active" || session.lastActiveAt <= staleCutoff),
       )
       .sort((left, right) => left.lastActiveAt - right.lastActiveAt);
@@ -3084,6 +3154,19 @@ export class IndexedDbMessageStore implements PersistentMessageCache {
             }
           }
         }
+      } else if (
+        dbResult.status === "fulfilled" &&
+        !this.#unavailable &&
+        this.#accessMode === "reader" &&
+        this.#readerLeaseCreated
+      ) {
+        const releaseResult = await this.#settleShutdownOperation(
+          this.#releaseReaderLease(dbResult.value),
+          "reader lease release",
+        );
+        if (releaseResult.status === "rejected") {
+          shutdownError ??= releaseResult.reason;
+        }
       } else if (dbResult.status === "rejected") {
         shutdownError ??= dbResult.reason;
       }
@@ -3137,6 +3220,24 @@ export class IndexedDbMessageStore implements PersistentMessageCache {
       }
     }
     await tx.done;
+  }
+
+  async #releaseReaderLease(db: IDB.IDBPDatabase<MessagesDB>): Promise<void> {
+    const tx = this.#trackTransaction(db.transaction(SESSIONS_STORE, "readwrite"), {
+      allowWhileClosing: true,
+      allowReaderMetadataWrite: true,
+    });
+    const store = tx.objectStore(SESSIONS_STORE);
+    const existing = await store.get(this.#currentSessionId);
+    if (existing != undefined) {
+      await store.put({
+        ...existing,
+        readers: (existing.readers ?? []).filter((reader) => reader !== this.#ownerId),
+        lastActiveAt: Date.now(),
+      });
+    }
+    await tx.done;
+    this.#readerLeaseCreated = false;
   }
 
   async #closeDatabaseConnection(): Promise<void> {

--- a/packages/studio-base/src/persistence/IndexedDbMessageStore.ts
+++ b/packages/studio-base/src/persistence/IndexedDbMessageStore.ts
@@ -1058,7 +1058,7 @@ export class IndexedDbMessageStore implements PersistentMessageCache {
   /**
    * Run the same TTL, pressure, and global-budget pass from an idle maintenance-only store.
    * Returns when another pass should run if pressure is currently protecting a fresh active
-   * session that may belong to another tab.
+   * writer or replay reader that may belong to another tab.
    */
   public async runMaintenance(): Promise<number | undefined> {
     if (this.#accessMode !== "maintenance") {
@@ -1096,7 +1096,9 @@ export class IndexedDbMessageStore implements PersistentMessageCache {
         const now = Date.now();
         const nextStaleAt = sessions
           .filter(
-            (session) => session.status === "active" && session.lastActiveAt + staleAfterMs > now,
+            (session) =>
+              (session.status === "active" || (session.readers?.length ?? 0) > 0) &&
+              session.lastActiveAt + staleAfterMs > now,
           )
           .reduce<number | undefined>((earliest, session) => {
             const staleAt = session.lastActiveAt + staleAfterMs;
@@ -2464,11 +2466,14 @@ export class IndexedDbMessageStore implements PersistentMessageCache {
     if (currentSession == undefined) {
       if (totalBytes > this.#globalBudgetBytes) {
         this.#writesDisabled = true;
-        log.warn("Disabling IndexedDbMessageStore writes because active sessions exceed budget", {
-          dbName: this.#dbName,
-          totalBytes,
-          maxCacheSize: this.#globalBudgetBytes,
-        });
+        log.warn(
+          "Disabling IndexedDbMessageStore writes because non-reclaimable sessions exceed budget",
+          {
+            dbName: this.#dbName,
+            totalBytes,
+            maxCacheSize: this.#globalBudgetBytes,
+          },
+        );
       }
       return;
     }
@@ -2495,11 +2500,14 @@ export class IndexedDbMessageStore implements PersistentMessageCache {
     await finalTx.done;
     if (finalTotalBytes > this.#globalBudgetBytes) {
       this.#writesDisabled = true;
-      log.warn("Disabling IndexedDbMessageStore writes because active sessions exceed budget", {
-        dbName: this.#dbName,
-        totalBytes: finalTotalBytes,
-        maxCacheSize: this.#globalBudgetBytes,
-      });
+      log.warn(
+        "Disabling IndexedDbMessageStore writes because non-reclaimable sessions exceed budget",
+        {
+          dbName: this.#dbName,
+          totalBytes: finalTotalBytes,
+          maxCacheSize: this.#globalBudgetBytes,
+        },
+      );
     }
   }
 
@@ -3054,6 +3062,30 @@ export class IndexedDbMessageStore implements PersistentMessageCache {
   // eslint-disable-next-line @typescript-eslint/promise-function-async
   public close(): Promise<void> {
     return this.#requestShutdown("closed", { discardQueued: false });
+  }
+
+  public async closeAfter(pendingOperations: readonly Promise<unknown>[]): Promise<void> {
+    this.#beginShutdown();
+    const pendingResult = await this.#settleShutdownOperation(
+      Promise.allSettled(pendingOperations),
+      "pending close operations",
+      { reserveRemainingMs: this.#shutdownStatusReserveMs() },
+    );
+    let shutdownError: unknown =
+      pendingResult.status === "rejected"
+        ? pendingResult.reason
+        : pendingResult.value.find((result) => result.status === "rejected")?.reason;
+
+    try {
+      await this.#requestShutdown(shutdownError == undefined ? "closed" : "abandoned", {
+        discardQueued: shutdownError != undefined,
+      });
+    } catch (error) {
+      shutdownError ??= error;
+    }
+    if (shutdownError != undefined) {
+      throw toError(shutdownError);
+    }
   }
 
   // Returning the stored promise directly preserves identity across concurrent callers.

--- a/packages/studio-base/src/persistence/IndexedDbMessageStore.ts
+++ b/packages/studio-base/src/persistence/IndexedDbMessageStore.ts
@@ -1610,11 +1610,14 @@ export class IndexedDbMessageStore implements PersistentMessageCache {
         return false;
       }
       if (staleGuard != undefined) {
+        const isTerminal =
+          sessionMetadata.status === "pending-delete" || sessionMetadata.status === "abandoned";
         if (
           sessionMetadata.kind !== staleGuard.kind ||
-          (sessionMetadata.status === "active" &&
-            sessionMetadata.lastActiveAt > staleGuard.cutoffTime) ||
-          this.#hasFreshReaderLease(sessionMetadata, staleGuard.cutoffTime)
+          (!isTerminal &&
+            ((sessionMetadata.status === "active" &&
+              sessionMetadata.lastActiveAt > staleGuard.cutoffTime) ||
+              this.#hasFreshReaderLease(sessionMetadata, staleGuard.cutoffTime)))
         ) {
           await sealTx.done;
           return false;

--- a/packages/studio-base/src/persistence/RealtimeVizHistoryCache.test.ts
+++ b/packages/studio-base/src/persistence/RealtimeVizHistoryCache.test.ts
@@ -63,8 +63,8 @@ describe("RealtimeVizHistoryCache", () => {
 
   it("abandons the cache when store shutdown fails", async () => {
     const closeError = new Error("store shutdown failed");
-    const closeSpy = jest
-      .spyOn(IndexedDbMessageStore.prototype, "close")
+    const closeAfterSpy = jest
+      .spyOn(IndexedDbMessageStore.prototype, "closeAfter")
       .mockRejectedValueOnce(closeError);
     const discardSpy = jest.spyOn(IndexedDbMessageStore.prototype, "discardAndSeal");
     const cache = new RealtimeVizHistoryCache({
@@ -80,7 +80,7 @@ describe("RealtimeVizHistoryCache", () => {
       await expect(closePromise).rejects.toBe(closeError);
       expect(discardSpy).toHaveBeenCalledWith("abandoned");
     } finally {
-      closeSpy.mockRestore();
+      closeAfterSpy.mockRestore();
       discardSpy.mockRestore();
     }
   });
@@ -115,6 +115,34 @@ describe("RealtimeVizHistoryCache", () => {
     } finally {
       resolveMetadata();
       storeTopicsSpy.mockRestore();
+    }
+  });
+
+  it("bounds close when a metadata write never settles", async () => {
+    jest.useFakeTimers();
+    const storeTopicsSpy = jest
+      .spyOn(IndexedDbMessageStore.prototype, "storeTopics")
+      .mockReturnValueOnce(new Promise<void>(() => undefined));
+    const cache = new RealtimeVizHistoryCache({
+      sessionId: "stalled-realtime-metadata",
+      retentionWindowMs: 30_000,
+    });
+
+    try {
+      await cache.init();
+      cache.storeTopics([{ name: "/topic", schemaName: "pkg/Msg" }], new Map());
+
+      const closeExpectation = expect(cache.close()).rejects.toThrow("pending close operations");
+      await jest.advanceTimersByTimeAsync(5_000);
+      await closeExpectation;
+      expect(console.warn).toHaveBeenCalledWith(
+        "IndexedDbMessageStore shutdown deadline exceeded",
+        expect.objectContaining({ operation: "pending close operations" }),
+      );
+      jest.mocked(console.warn).mockClear();
+    } finally {
+      storeTopicsSpy.mockRestore();
+      jest.useRealTimers();
     }
   });
 });

--- a/packages/studio-base/src/persistence/RealtimeVizHistoryCache.test.ts
+++ b/packages/studio-base/src/persistence/RealtimeVizHistoryCache.test.ts
@@ -84,4 +84,37 @@ describe("RealtimeVizHistoryCache", () => {
       discardSpy.mockRestore();
     }
   });
+
+  it("waits for queued metadata writes before close resolves", async () => {
+    let resolveMetadata = () => {};
+    const metadataWrite = new Promise<void>((resolve) => {
+      resolveMetadata = resolve;
+    });
+    const storeTopicsSpy = jest
+      .spyOn(IndexedDbMessageStore.prototype, "storeTopics")
+      .mockReturnValueOnce(metadataWrite);
+    const cache = new RealtimeVizHistoryCache({
+      sessionId: "pending-realtime-metadata",
+      retentionWindowMs: 30_000,
+    });
+
+    try {
+      await cache.init();
+      cache.storeTopics([{ name: "/topic", schemaName: "pkg/Msg" }], new Map());
+
+      let closeResolved = false;
+      const closePromise = cache.close().then(() => {
+        closeResolved = true;
+      });
+      await Promise.resolve();
+      expect(closeResolved).toBe(false);
+
+      resolveMetadata();
+      await closePromise;
+      expect(storeTopicsSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      resolveMetadata();
+      storeTopicsSpy.mockRestore();
+    }
+  });
 });

--- a/packages/studio-base/src/persistence/RealtimeVizHistoryCache.ts
+++ b/packages/studio-base/src/persistence/RealtimeVizHistoryCache.ts
@@ -163,8 +163,7 @@ export class RealtimeVizHistoryCache {
     }
     this.#disabled = true;
     try {
-      await Promise.all(this.#metadataWrites);
-      await this.#store.close();
+      await this.#store.closeAfter(Array.from(this.#metadataWrites));
     } catch (error) {
       try {
         await this.#store.discardAndSeal("abandoned");

--- a/packages/studio-base/src/persistence/RealtimeVizHistoryCache.ts
+++ b/packages/studio-base/src/persistence/RealtimeVizHistoryCache.ts
@@ -23,6 +23,7 @@ export class RealtimeVizHistoryCache {
   #latestTopics: readonly TopicWithDecodingInfo[] | undefined;
   #latestTopicStats: Map<string, TopicStats> | undefined;
   #latestDatatypes: RosDatatypes | undefined;
+  #metadataWrites = new Set<Promise<void>>();
   #closePromise: Promise<void> | undefined;
 
   public constructor({
@@ -102,9 +103,10 @@ export class RealtimeVizHistoryCache {
     if (!this.#initialized) {
       return;
     }
-    void this.#store.storeTopics(topics, topicStats).catch((error: unknown) => {
-      log.debug("Failed to store realtime topic metadata:", error);
-    });
+    this.#trackMetadataWrite(
+      this.#store.storeTopics(topics, topicStats),
+      "Failed to store realtime topic metadata:",
+    );
   }
 
   public storeDatatypes(datatypes: RosDatatypes): void {
@@ -115,24 +117,35 @@ export class RealtimeVizHistoryCache {
     if (!this.#initialized) {
       return;
     }
-    void this.#store.storeDatatypes(datatypes).catch((error: unknown) => {
-      log.debug("Failed to store realtime datatypes:", error);
-    });
+    this.#trackMetadataWrite(
+      this.#store.storeDatatypes(datatypes),
+      "Failed to store realtime datatypes:",
+    );
   }
 
   #persistLatestMetadata(): void {
     if (this.#latestTopics != undefined) {
-      void this.#store
-        .storeTopics(this.#latestTopics, this.#latestTopicStats)
-        .catch((error: unknown) => {
-          log.debug("Failed to store realtime topic metadata:", error);
-        });
+      this.#trackMetadataWrite(
+        this.#store.storeTopics(this.#latestTopics, this.#latestTopicStats),
+        "Failed to store realtime topic metadata:",
+      );
     }
     if (this.#latestDatatypes != undefined) {
-      void this.#store.storeDatatypes(this.#latestDatatypes).catch((error: unknown) => {
-        log.debug("Failed to store realtime datatypes:", error);
-      });
+      this.#trackMetadataWrite(
+        this.#store.storeDatatypes(this.#latestDatatypes),
+        "Failed to store realtime datatypes:",
+      );
     }
+  }
+
+  #trackMetadataWrite(write: Promise<void>, failureMessage: string): void {
+    const trackedWrite = write.catch((error: unknown) => {
+      log.debug(failureMessage, error);
+    });
+    this.#metadataWrites.add(trackedWrite);
+    void trackedWrite.finally(() => {
+      this.#metadataWrites.delete(trackedWrite);
+    });
   }
 
   // Returning the stored promise directly preserves identity across concurrent callers.
@@ -150,7 +163,7 @@ export class RealtimeVizHistoryCache {
     }
     this.#disabled = true;
     try {
-      // The store owns the single shutdown deadline and waits for tracked metadata transactions.
+      await Promise.all(this.#metadataWrites);
       await this.#store.close();
     } catch (error) {
       try {

--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.ts
@@ -1061,9 +1061,10 @@ class CachingIterableSource<MessageType = unknown>
     let pendingTimeGroup: MessageEvent[] = [];
     let pendingTimeGroupBytes = 0;
     let yieldedCompleteTimeGroup = false;
+    let nextUnyieldedTime = args.start;
     const incompleteResult = (): SpillRangeReadResult => ({
       complete: false,
-      resumeFrom: pendingTimeGroup[0]?.receiveTime ?? args.start,
+      resumeFrom: pendingTimeGroup[0]?.receiveTime ?? nextUnyieldedTime,
       directSource: yieldedCompleteTimeGroup || pendingTimeGroup.length > 0,
     });
     if (!this.#isCurrentTopicGeneration(args.topicGeneration)) {
@@ -1130,6 +1131,7 @@ class CachingIterableSource<MessageType = unknown>
               throw new Error("Playback spill pages were not ordered by receive time");
             }
             if (timeComparison < 0) {
+              const yieldedTime = pendingTimeGroup[0]!.receiveTime;
               for (const pendingMessage of pendingTimeGroup) {
                 yield {
                   type: "message-event",
@@ -1137,6 +1139,7 @@ class CachingIterableSource<MessageType = unknown>
                 };
               }
               yieldedCompleteTimeGroup = true;
+              nextUnyieldedTime = add(yieldedTime, { sec: 0, nsec: 1 });
               pendingTimeGroup = [];
               pendingTimeGroupBytes = 0;
             }

--- a/packages/studio-base/src/players/IterablePlayer/PersistentCache/PersistentCacheIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/PersistentCache/PersistentCacheIterableSource.test.ts
@@ -130,8 +130,8 @@ describe("PersistentCacheIterableSource", () => {
     await reader.close();
   });
 
-  it("opens an existing cache without reviving or rewriting its session metadata", async () => {
-    const sessionId = "reader-does-not-mutate";
+  it("leases an existing cache for replay without reviving the writer session", async () => {
+    const sessionId = "reader-lease";
     const store = new IndexedDbMessageStore({
       sessionId,
       retentionWindowMs: 120_000,
@@ -158,10 +158,22 @@ describe("PersistentCacheIterableSource", () => {
       maxCacheSize: 1,
     });
     await source.initialize();
-    expect(await readSessionMetadata(sessionId)).toEqual(metadataBeforeReplay);
+    expect(await readSessionMetadata(sessionId)).toEqual({
+      ...metadataBeforeReplay,
+      lastActiveAt: expect.any(Number),
+      status: "closed",
+      owners: [],
+      readers: [expect.any(String)],
+    });
 
     await source.terminate();
-    expect(await readSessionMetadata(sessionId)).toEqual(metadataBeforeReplay);
+    expect(await readSessionMetadata(sessionId)).toEqual({
+      ...metadataBeforeReplay,
+      lastActiveAt: expect.any(Number),
+      status: "closed",
+      owners: [],
+      readers: [],
+    });
   });
 
   it("does not create metadata when a replay session does not exist", async () => {

--- a/packages/studio-base/src/players/IterablePlayer/PersistentCache/PersistentCacheIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/PersistentCache/PersistentCacheIterableSource.ts
@@ -23,11 +23,13 @@ import {
 } from "../IIterableSource";
 
 const log = Logger.getLogger(__filename);
+const READER_LEASE_HEARTBEAT_MS = 30_000;
 
 export class PersistentCacheIterableSource implements IIterableSource {
   #retentionWindowMs?: number;
   #maxCacheSize?: number;
   #cache?: IndexedDbMessageStore;
+  #readerLeaseHeartbeat?: ReturnType<typeof setInterval>;
   #sessionId: string;
 
   public constructor({
@@ -59,6 +61,11 @@ export class PersistentCacheIterableSource implements IIterableSource {
       const stats = await cache.stats();
       const storedTopics = await cache.getTopics();
       const datatypes = (await cache.getDatatypes()) ?? new Map();
+      this.#readerLeaseHeartbeat = setInterval(() => {
+        void cache.touchSession().catch((error: unknown) => {
+          log.debug("Failed to refresh persistent cache replay lease", error);
+        });
+      }, READER_LEASE_HEARTBEAT_MS);
 
       // If no data is available, return minimal initialization
       if (stats.count === 0 || !stats.earliest || !stats.latest) {
@@ -113,6 +120,10 @@ export class PersistentCacheIterableSource implements IIterableSource {
         problems: [],
       };
     } catch (error) {
+      if (this.#readerLeaseHeartbeat != undefined) {
+        clearInterval(this.#readerLeaseHeartbeat);
+        this.#readerLeaseHeartbeat = undefined;
+      }
       if (this.#cache === cache) {
         this.#cache = undefined;
       }
@@ -230,6 +241,10 @@ export class PersistentCacheIterableSource implements IIterableSource {
   }
 
   public async terminate(): Promise<void> {
+    if (this.#readerLeaseHeartbeat != undefined) {
+      clearInterval(this.#readerLeaseHeartbeat);
+      this.#readerLeaseHeartbeat = undefined;
+    }
     const cache = this.#cache;
     this.#cache = undefined;
     await cache?.close();

--- a/packages/studio-base/src/providers/ExtensionCatalogProvider.test.tsx
+++ b/packages/studio-base/src/providers/ExtensionCatalogProvider.test.tsx
@@ -768,6 +768,46 @@ describe("ExtensionCatalogProvider", () => {
     jest.mocked(console.error).mockClear();
   });
 
+  it("does not restore an uninstalled extension when the follow-up list fails", async () => {
+    const extension = fakeExtension({ id: "removed", qualifiedName: "removed" });
+    const uninstallExtension = jest.fn().mockResolvedValue(undefined);
+    const loader: ExtensionLoader = {
+      namespace: "local",
+      getExtensions: jest
+        .fn()
+        .mockResolvedValueOnce([extension])
+        .mockRejectedValueOnce(new Error("temporary list failure")),
+      loadExtension: jest.fn().mockResolvedValue(`
+        module.exports = {
+          activate: function(ctx) {
+            ctx.registerPanel({ name: "panel", initPanel: function() {} });
+          }
+        }
+      `),
+      installExtension: jest.fn(),
+      uninstallExtension,
+    };
+
+    const { result } = renderHook(() => useExtensionCatalog((state) => state), {
+      wrapper: ({ children }) => (
+        <ExtensionCatalogProvider loaders={[loader]}>{children}</ExtensionCatalogProvider>
+      ),
+    });
+    await waitFor(() => {
+      expect(result.current.installedPanels?.["removed.panel"]).toBeDefined();
+    });
+
+    await act(async () => {
+      await result.current.uninstallExtension("local", extension.id);
+    });
+
+    expect(result.current.loadState).toBe("degraded");
+    expect(result.current.installedExtensions).toEqual([]);
+    expect(result.current.installedPanels).toEqual({});
+    expect(uninstallExtension).toHaveBeenCalledWith(extension.id);
+    jest.mocked(console.error).mockClear();
+  });
+
   it("coalesces overlapping refreshes and resolves callers after the pending rerun publishes", async () => {
     const firstList = deferred<ExtensionInfo[]>();
     const latestList = deferred<ExtensionInfo[]>();

--- a/packages/studio-base/src/providers/ExtensionCatalogProvider.tsx
+++ b/packages/studio-base/src/providers/ExtensionCatalogProvider.tsx
@@ -294,6 +294,17 @@ function createExtensionRegistryStore(
   let refreshInFlight: Promise<void> | undefined;
 
   return createStore((set, get) => {
+    const invalidateExtension = (loader: ExtensionLoader, id: string): void => {
+      activationSnapshots.delete(extensionIdentity(loader.namespace, id));
+      const extensions = lastSuccessfulExtensionLists.get(loader);
+      if (extensions != undefined) {
+        lastSuccessfulExtensionLists.set(
+          loader,
+          extensions.filter((extension) => extension.id !== id),
+        );
+      }
+    };
+
     const buildRefreshResult = async (): Promise<RefreshResult> => {
       const nextActivationSnapshots = new Map(activationSnapshots);
       const nextLastSuccessfulExtensionLists = new Map(lastSuccessfulExtensionLists);
@@ -549,6 +560,7 @@ function createExtensionRegistryStore(
           throw new Error("No extension loader found for namespace " + namespace);
         }
         await namespacedLoader.uninstallExtension(id);
+        invalidateExtension(namespacedLoader, id);
         await get().refreshExtensions();
       },
     };


### PR DESCRIPTION
**User-Facing Changes**

Improve IndexedDB cache reliability when replaying saved realtime history, switching data sources, unloading extensions, and falling back from playback spill reads.

**Description**

Follow-up to #1400 addressing the remaining review findings:

- lease replay readers so maintenance cannot delete an actively read session
- exclude sealed/reclaimable sessions from the startup logical budget
- invalidate extension fallback snapshots after a confirmed uninstall
- resume source fallback after the last fully yielded spill timestamp
- wait for realtime topic/datatype metadata writes before closing

Validation:

- 138 targeted Jest tests
- ESLint on all changed files
- `yarn tsc --noEmit --pretty false`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1410"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787126018&installation_id=141984720&pr_number=1410&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1410&signature=79cd300b8f0230c8c949f8cd9d199caec14ae60863d1e9374c452e1cfac7a37d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->