### PR TITLE
Fix record device detail link

### DIFF
--- a/packages/studio-base/src/components/RecordInfo/index.test.tsx
+++ b/packages/studio-base/src/components/RecordInfo/index.test.tsx
@@ -1,0 +1,102 @@
+/** @jest-environment jsdom */
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { create } from "@bufbuild/protobuf";
+import type { Organization } from "@coscene-io/cosceneapis-es-v2/coscene/dataplatform/v1alpha1/resources/organization_pb";
+import { ProjectSchema } from "@coscene-io/cosceneapis-es-v2/coscene/dataplatform/v1alpha1/resources/project_pb";
+import { DeviceSchema } from "@coscene-io/cosceneapis-es-v2/coscene/dataplatform/v1alpha2/resources/device_pb";
+import { RecordSchema } from "@coscene-io/cosceneapis-es-v2/coscene/dataplatform/v1alpha2/resources/record_pb";
+import { render } from "@testing-library/react";
+import { useLayoutEffect } from "react";
+import { createStore } from "zustand";
+
+import RecordInfo from "@foxglove/studio-base/components/RecordInfo";
+import CoSceneConsoleApiContext from "@foxglove/studio-base/context/CoSceneConsoleApiContext";
+import { useCoreData } from "@foxglove/studio-base/context/CoreDataContext";
+import {
+  SubscriptionEntitlementContext,
+  SubscriptionEntitlementStore,
+} from "@foxglove/studio-base/context/SubscriptionEntitlementContext";
+import CoreDataProvider from "@foxglove/studio-base/providers/CoreDataProvider";
+import type ConsoleApi from "@foxglove/studio-base/services/api/CoSceneConsoleApi";
+import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
+
+jest.mock("@foxglove/studio-base/components/RecordInfo/ProjectDeviceSelector", () => {
+  const React = jest.requireActual<typeof import("react")>("react");
+  return {
+    __esModule: true,
+    default: () => React.createElement(React.Fragment),
+  };
+});
+
+const deviceId = "e7bf6e9d-e95e-42f4-9ce3-fcb86674d785";
+const device = create(DeviceSchema, {
+  name: `devices/${deviceId}`,
+  serialNumber: "bag-noetic_043",
+});
+
+const subscriptionStore = createStore<SubscriptionEntitlementStore>(() => ({
+  paid: true,
+  subscription: undefined,
+  setSubscription: jest.fn(),
+  getEntitlement: jest.fn(),
+}));
+
+function CoreDataSeeder(): ReactNull {
+  const setOrganization = useCoreData((state) => state.setOrganization);
+  const setProject = useCoreData((state) => state.setProject);
+  const setRecord = useCoreData((state) => state.setRecord);
+
+  useLayoutEffect(() => {
+    setOrganization({
+      loading: false,
+      value: { slug: "coscene-lark" } as Organization,
+    });
+    setProject({
+      loading: false,
+      value: create(ProjectSchema, { slug: "bubbl" }),
+    });
+    setRecord({
+      loading: false,
+      value: create(RecordSchema, {
+        name: "warehouses/warehouse/projects/project/records/record",
+        device,
+      }),
+    });
+  }, [setOrganization, setProject, setRecord]);
+
+  return ReactNull;
+}
+
+describe("<RecordInfo />", () => {
+  it("links a record device to its project-device details page", async () => {
+    const consoleApi = {
+      getDevice: jest.fn(async () => device),
+      updateRecord: Object.assign(jest.fn(), { permission: () => true }),
+    } as unknown as ConsoleApi;
+
+    const root = render(
+      <CoSceneConsoleApiContext.Provider value={consoleApi}>
+        <SubscriptionEntitlementContext.Provider value={subscriptionStore}>
+          <CoreDataProvider>
+            <CoreDataSeeder />
+            <ThemeProvider isDark>
+              <RecordInfo />
+            </ThemeProvider>
+          </CoreDataProvider>
+        </SubscriptionEntitlementContext.Provider>
+      </CoSceneConsoleApiContext.Provider>,
+    );
+
+    const deviceLink = await root.findByRole("link", { name: device.serialNumber });
+
+    expect(deviceLink.getAttribute("href")).toBe(
+      `/coscene-lark/bubbl/devices/project-devices/${deviceId}`,
+    );
+  });
+});

--- a/packages/studio-base/src/components/RecordInfo/index.tsx
+++ b/packages/studio-base/src/components/RecordInfo/index.tsx
@@ -87,6 +87,11 @@ function DeviceInfoSection({ updateRecord }: { updateRecord: UpdateRecordFn }): 
     deviceInfo.value?.name != undefined && deviceInfo.value.name === deviceName
       ? deviceInfo.value
       : undefined;
+  const deviceId = currentDeviceInfo?.name.split("/").pop();
+  const deviceHref =
+    organizationSlug && projectSlug && deviceId
+      ? `/${organizationSlug}/${projectSlug}/devices/project-devices/${deviceId}`
+      : undefined;
 
   useEffect(() => {
     if (!deviceName) {
@@ -112,7 +117,7 @@ function DeviceInfoSection({ updateRecord }: { updateRecord: UpdateRecordFn }): 
           variant="body2"
           underline="hover"
           data-testid={currentDeviceInfo?.serialNumber}
-          href={`/${organizationSlug}/${projectSlug}/${currentDeviceInfo?.name}`}
+          href={deviceHref}
           target="_blank"
         >
           {currentDeviceInfo?.serialNumber}


### PR DESCRIPTION
## What changed

- Build the RecordInfo device link with the project-device route.
- Avoid emitting an invalid link while organization, project, or device data is unavailable.
- Add a regression test for the complete device details URL.

## Root cause

The API resource name (`devices/{id}`) was appended directly to the project URL, but the console page route requires `devices/project-devices/{id}`.

## Impact

Clicking the device ID in RecordInfo now opens the expected project device details page.

## Validation

- `yarn test packages/studio-base/src/components/RecordInfo/index.test.tsx --runInBand`
- `yarn eslint packages/studio-base/src/components/RecordInfo/index.tsx packages/studio-base/src/components/RecordInfo/index.test.tsx --max-warnings=0`
- `yarn prettier --check packages/studio-base/src/components/RecordInfo/index.tsx packages/studio-base/src/components/RecordInfo/index.test.tsx`
- `git diff --check`

A full `yarn tsc --noEmit -p packages/studio-base/tsconfig.json` remains blocked by existing unrelated type errors in FrameNavigationStatus.test.tsx, useFrameNavigation.test.tsx, and useSyncLayoutFromUrl.test.ts.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787126150&installation_id=141984720&pr_number=1411&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1411&signature=ca238c7bcfbc1b907d8a8d1ee703061039a8ae7faf5d0f8712b7a143e140a753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->