### PR TITLE
Fix frame navigation edge cases

### DIFF
--- a/packages/studio-base/src/components/MessagePathSyntax/useMessageDataItem.test.tsx
+++ b/packages/studio-base/src/components/MessagePathSyntax/useMessageDataItem.test.tsx
@@ -190,6 +190,38 @@ describe("useMessageDataItem", () => {
     ]);
   });
 
+  it("uses the latest restore callback", () => {
+    let rosTopics: Topic[] = [];
+    const firstRestore = jest.fn();
+    const secondRestore = jest.fn();
+    const { rerender } = renderHook(
+      ({ onRestore }) => useMessageDataItem("/topic.value", { historySize: 1, onRestore }),
+      {
+        initialProps: { onRestore: firstRestore },
+        wrapper({ children }) {
+          return (
+            <MockCurrentLayoutProvider>
+              <MockMessagePipelineProvider
+                messages={fixtureMessages}
+                topics={rosTopics}
+                datatypes={datatypes}
+              >
+                {children}
+              </MockMessagePipelineProvider>
+            </MockCurrentLayoutProvider>
+          );
+        },
+      },
+    );
+    firstRestore.mockClear();
+
+    rosTopics = topics;
+    rerender({ onRestore: secondRestore });
+
+    expect(firstRestore).not.toHaveBeenCalled();
+    expect(secondRestore).toHaveBeenCalled();
+  });
+
   it("clears previous messages on topic change", async () => {
     const { result, rerender } = renderHook(
       ({ path }) => useMessageDataItem(path, { historySize: 2 }),

--- a/packages/studio-base/src/components/MessagePathSyntax/useMessageDataItem.ts
+++ b/packages/studio-base/src/components/MessagePathSyntax/useMessageDataItem.ts
@@ -15,6 +15,7 @@
 //   You may not use this file except in compliance with the License.
 
 import { useCallback, useMemo } from "react";
+import { useLatest } from "react-use";
 
 import { useMessageReducer } from "@foxglove/studio-base/PanelAPI";
 import { subscribePayloadFromMessagePath } from "@foxglove/studio-base/players/subscribePayloadFromMessagePath";
@@ -71,6 +72,7 @@ type ReducedValue = {
  */
 export function useMessageDataItem(path: string, options?: Options): ReducedValue["matches"] {
   const { historySize = 1, onRestore } = options ?? {};
+  const onRestoreRef = useLatest(onRestore);
   const topics: SubscribePayload[] = useMemo(() => {
     const payload = subscribePayloadFromMessagePath(path, "partial");
     if (payload) {
@@ -124,7 +126,7 @@ export function useMessageDataItem(path: string, options?: Options): ReducedValu
 
   const restore = useCallback(
     (prevValue?: ReducedValue): ReducedValue => {
-      onRestore?.();
+      onRestoreRef.current?.();
 
       if (!prevValue) {
         return {
@@ -156,7 +158,7 @@ export function useMessageDataItem(path: string, options?: Options): ReducedValu
 
       return prevValue;
     },
-    [cachedGetMessagePathDataItems, historySize, path],
+    [cachedGetMessagePathDataItems, historySize, onRestoreRef, path],
   );
 
   const reducedValue = useMessageReducer<ReducedValue>({

--- a/packages/studio-base/src/hooks/FrameNavigationNotifier.test.ts
+++ b/packages/studio-base/src/hooks/FrameNavigationNotifier.test.ts
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import { FrameNavigationNotifier } from "./FrameNavigationNotifier";
+
+describe("FrameNavigationNotifier", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("does not clear a restarted navigation with a deferred end", () => {
+    jest.useFakeTimers();
+    const notifier = new FrameNavigationNotifier();
+
+    notifier.startNavigation("panel");
+    notifier.endNavigation("panel");
+    notifier.startNavigation("panel");
+    jest.runOnlyPendingTimers();
+
+    expect(notifier.isNavigationActive("panel")).toBe(true);
+  });
+
+  it("notifies the previous navigation when another one starts", () => {
+    const notifier = new FrameNavigationNotifier();
+    const onSuperseded = jest.fn();
+
+    notifier.startNavigation("first", onSuperseded);
+    notifier.startNavigation("second");
+
+    expect(onSuperseded).toHaveBeenCalledTimes(1);
+    expect(notifier.isNavigationActive("second")).toBe(true);
+  });
+});

--- a/packages/studio-base/src/hooks/FrameNavigationNotifier.ts
+++ b/packages/studio-base/src/hooks/FrameNavigationNotifier.ts
@@ -6,28 +6,32 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 export class FrameNavigationNotifier {
-  #activeNavigationId: string | undefined = undefined;
+  #activeNavigation: { readonly id: string; readonly onSuperseded?: () => void } | undefined =
+    undefined;
 
-  public startNavigation(navigationId: string): void {
-    this.#activeNavigationId = navigationId;
+  public startNavigation(navigationId: string, onSuperseded?: () => void): void {
+    const previousNavigation = this.#activeNavigation;
+    this.#activeNavigation = { id: navigationId, onSuperseded };
+    previousNavigation?.onSuperseded?.();
   }
 
   public endNavigation(navigationId: string): void {
-    if (this.#activeNavigationId === navigationId) {
+    const navigation = this.#activeNavigation;
+    if (navigation?.id === navigationId) {
       setTimeout(() => {
-        if (this.#activeNavigationId === navigationId) {
-          this.#activeNavigationId = undefined;
+        if (this.#activeNavigation === navigation) {
+          this.#activeNavigation = undefined;
         }
       }, 0);
     }
   }
 
   public isOtherNavigationActive(navigationId: string): boolean {
-    return this.#activeNavigationId != undefined && this.#activeNavigationId !== navigationId;
+    return this.#activeNavigation != undefined && this.#activeNavigation.id !== navigationId;
   }
 
   public isNavigationActive(navigationId: string): boolean {
-    return this.#activeNavigationId === navigationId;
+    return this.#activeNavigation?.id === navigationId;
   }
 }
 

--- a/packages/studio-base/src/hooks/FrameNavigationNotifier.ts
+++ b/packages/studio-base/src/hooks/FrameNavigationNotifier.ts
@@ -26,6 +26,12 @@ export class FrameNavigationNotifier {
     }
   }
 
+  public cancelNavigation(navigationId: string): void {
+    if (this.#activeNavigation?.id === navigationId) {
+      this.#activeNavigation = undefined;
+    }
+  }
+
   public isOtherNavigationActive(navigationId: string): boolean {
     return this.#activeNavigation != undefined && this.#activeNavigation.id !== navigationId;
   }

--- a/packages/studio-base/src/hooks/useFallbackFrameNavigation.ts
+++ b/packages/studio-base/src/hooks/useFallbackFrameNavigation.ts
@@ -31,6 +31,7 @@ type UseFallbackFrameNavigationArgs = {
   readonly startPlayback: (() => void) | undefined;
   readonly pausePlayback: (() => void) | undefined;
   readonly activeTimes: ActiveTimes | undefined;
+  readonly playbackTime: Time | undefined;
 };
 
 function hasTimeSuffix(times: readonly Time[], suffix: readonly Time[]): boolean {
@@ -69,6 +70,7 @@ export function useFallbackFrameNavigation(args: UseFallbackFrameNavigationArgs)
     navigationId,
     notifier,
     pausePlayback,
+    playbackTime,
     seekPlayback,
     startPlayback,
   } = args;
@@ -83,6 +85,8 @@ export function useFallbackFrameNavigation(args: UseFallbackFrameNavigationArgs)
   const fallbackNextStartTime = useRef<Time | undefined>();
   const activeTimesRef = useRef(activeTimes);
   activeTimesRef.current = activeTimes;
+  const playbackTimeRef = useRef(playbackTime);
+  playbackTimeRef.current = playbackTime;
 
   const freezeCurrentMessages = useCallback(() => {
     if (currentMessagesRef.current.length > 0) {
@@ -247,14 +251,18 @@ export function useFallbackFrameNavigation(args: UseFallbackFrameNavigationArgs)
   const updateRenderedTime = useCallback(
     (messages: MessageAndData[]) => {
       currentMessagesRef.current = messages;
+      const heldTime = heldNavigationTime.current;
+      const reachedHeldTime =
+        heldTime != undefined &&
+        messages.some((message) => compare(message.messageEvent.receiveTime, heldTime) === 0);
+      const playbackPassedHeldTime =
+        heldTime != undefined &&
+        playbackTimeRef.current != undefined &&
+        compare(playbackTimeRef.current, heldTime) > 0;
       if (
         frameState.current === "current" &&
-        messages.length > 0 &&
         keepFrozenMessagesAfterRestore.current &&
-        messages.some((message) => {
-          const heldTime = heldNavigationTime.current;
-          return heldTime != undefined && compare(message.messageEvent.receiveTime, heldTime) === 0;
-        })
+        (reachedHeldTime || playbackPassedHeldTime)
       ) {
         clearFrozenMessages();
       }

--- a/packages/studio-base/src/hooks/useFallbackFrameNavigation.ts
+++ b/packages/studio-base/src/hooks/useFallbackFrameNavigation.ts
@@ -230,12 +230,17 @@ export function useFallbackFrameNavigation(args: UseFallbackFrameNavigationArgs)
 
   const getEffectiveMessages = useCallback(
     <T extends MessageAndData[]>(messages: T): T => {
+      const heldTime = heldNavigationTime.current;
+      const playbackPassedHeldTime =
+        heldTime != undefined &&
+        playbackTimeRef.current != undefined &&
+        compare(playbackTimeRef.current, heldTime) > 0;
       if (
         frozenMessagesRef.current != undefined &&
         (frameState.current !== "current" ||
           (keepFrozenMessagesAfterRestore.current &&
+            !playbackPassedHeldTime &&
             !messages.some((message) => {
-              const heldTime = heldNavigationTime.current;
               return (
                 heldTime != undefined && compare(message.messageEvent.receiveTime, heldTime) === 0
               );

--- a/packages/studio-base/src/hooks/useFallbackFrameNavigation.ts
+++ b/packages/studio-base/src/hooks/useFallbackFrameNavigation.ts
@@ -229,7 +229,13 @@ export function useFallbackFrameNavigation(args: UseFallbackFrameNavigationArgs)
       if (
         frozenMessagesRef.current != undefined &&
         (frameState.current !== "current" ||
-          (keepFrozenMessagesAfterRestore.current && messages.length === 0))
+          (keepFrozenMessagesAfterRestore.current &&
+            !messages.some((message) => {
+              const heldTime = heldNavigationTime.current;
+              return (
+                heldTime != undefined && compare(message.messageEvent.receiveTime, heldTime) === 0
+              );
+            })))
       ) {
         return frozenMessagesRef.current as T;
       }

--- a/packages/studio-base/src/hooks/useFallbackFrameNavigation.ts
+++ b/packages/studio-base/src/hooks/useFallbackFrameNavigation.ts
@@ -53,6 +53,7 @@ export function useFallbackFrameNavigation(args: UseFallbackFrameNavigationArgs)
   readonly freezeCurrentMessages: () => void;
   readonly clearFrozenMessages: () => void;
   readonly holdNavigationMessages: (messages: MessageAndData[]) => void;
+  readonly markPreviousFrameUnavailable: () => void;
   readonly resetRenderedHistory: () => void;
   readonly restoreFallbackState: () => RestoreFallbackStateResult;
   readonly runPreviousFrameToMessage: (message: MessageAndData) => boolean;
@@ -93,6 +94,10 @@ export function useFallbackFrameNavigation(args: UseFallbackFrameNavigationArgs)
     frozenMessagesRef.current = undefined;
     keepFrozenMessagesAfterRestore.current = false;
     heldNavigationTime.current = undefined;
+  }, []);
+
+  const markPreviousFrameUnavailable = useCallback(() => {
+    setHasPreFrame(false);
   }, []);
 
   const resetRenderedHistory = useCallback(() => {
@@ -339,6 +344,7 @@ export function useFallbackFrameNavigation(args: UseFallbackFrameNavigationArgs)
     freezeCurrentMessages,
     clearFrozenMessages,
     holdNavigationMessages,
+    markPreviousFrameUnavailable,
     resetRenderedHistory,
     restoreFallbackState,
     runPreviousFrameToMessage,

--- a/packages/studio-base/src/hooks/useFallbackFrameNavigation.ts
+++ b/packages/studio-base/src/hooks/useFallbackFrameNavigation.ts
@@ -133,6 +133,7 @@ export function useFallbackFrameNavigation(args: UseFallbackFrameNavigationArgs)
       frameState.current === "current" &&
       notifier.isOtherNavigationActive(navigationId.current)
     ) {
+      clearFrozenMessages();
       return "other-navigation";
     }
 

--- a/packages/studio-base/src/hooks/useFallbackFrameNavigation.ts
+++ b/packages/studio-base/src/hooks/useFallbackFrameNavigation.ts
@@ -100,6 +100,15 @@ export function useFallbackFrameNavigation(args: UseFallbackFrameNavigationArgs)
     heldNavigationTime.current = undefined;
   }, []);
 
+  const finishSupersededNavigation = useCallback(() => {
+    if (frameState.current !== "current") {
+      frameState.current = "current";
+      fallbackNextFrameActive.current = false;
+      fallbackNextStartTime.current = undefined;
+      clearFrozenMessages();
+    }
+  }, [clearFrozenMessages, frameState]);
+
   const markPreviousFrameUnavailable = useCallback(() => {
     setHasPreFrame(false);
   }, []);
@@ -149,7 +158,7 @@ export function useFallbackFrameNavigation(args: UseFallbackFrameNavigationArgs)
       }
 
       pausePlayback?.();
-      notifier.startNavigation(navigationId.current);
+      notifier.startNavigation(navigationId.current, finishSupersededNavigation);
       fallbackNextFrameActive.current = false;
       fallbackNextStartTime.current = undefined;
       frameState.current = "previous";
@@ -162,7 +171,15 @@ export function useFallbackFrameNavigation(args: UseFallbackFrameNavigationArgs)
       }
       return true;
     },
-    [frameState, holdNavigationMessages, navigationId, notifier, pausePlayback, seekPlayback],
+    [
+      finishSupersededNavigation,
+      frameState,
+      holdNavigationMessages,
+      navigationId,
+      notifier,
+      pausePlayback,
+      seekPlayback,
+    ],
   );
 
   const runPreviousFrameFromRenderedHistory = useCallback(
@@ -216,7 +233,7 @@ export function useFallbackFrameNavigation(args: UseFallbackFrameNavigationArgs)
       }
 
       freezeCurrentMessages();
-      notifier.startNavigation(navigationId.current);
+      notifier.startNavigation(navigationId.current, finishSupersededNavigation);
       fallbackNextFrameActive.current = true;
       fallbackNextStartTime.current =
         currentMessagesRef.current.at(-1)?.messageEvent.receiveTime ??
@@ -225,7 +242,14 @@ export function useFallbackFrameNavigation(args: UseFallbackFrameNavigationArgs)
       startPlayback?.();
       return true;
     },
-    [frameState, freezeCurrentMessages, navigationId, notifier, startPlayback],
+    [
+      finishSupersededNavigation,
+      frameState,
+      freezeCurrentMessages,
+      navigationId,
+      notifier,
+      startPlayback,
+    ],
   );
 
   const getEffectiveMessages = useCallback(

--- a/packages/studio-base/src/hooks/useFrameNavigation.test.tsx
+++ b/packages/studio-base/src/hooks/useFrameNavigation.test.tsx
@@ -128,6 +128,7 @@ function wrapper(options: {
   readonly pausePlayback?: () => void;
   readonly startPlayback?: () => void;
   readonly currentTime?: Time;
+  readonly isPlaying?: boolean;
   readonly requestWindow?: number;
   readonly playerId?: () => string;
   readonly globalVariables?: Record<string, string | number>;
@@ -155,6 +156,7 @@ function wrapper(options: {
             startPlayback={options.startPlayback}
             startTime={time(0)}
             currentTime={options.currentTime ?? time(1)}
+            isPlaying={options.isPlaying}
             endTime={time(5)}
             playerId={options.playerId?.()}
           >
@@ -284,6 +286,30 @@ describe("useFrameNavigation", () => {
       expect(result.current.frameNavigationStatusMessage).toBe("No previous");
     });
     expect(result.current.isFrameNavigationPending).toBe(false);
+    expect(result.current.hasPreFrame).toBe(false);
+    expect(seekPlayback).not.toHaveBeenCalled();
+  });
+
+  it("finishes next navigation when the matching frame is already current", async () => {
+    const currentTime = time(2);
+    const displayedMessage = message(1, 1);
+    const currentMessage = messageAt(currentTime, 1);
+    const subscribeMessageRange = makeSubscribeMessageRange([currentMessage]);
+    const seekPlayback = jest.fn<void, [Time]>();
+
+    const { result } = renderHook(() => useFrameNavigation({ path }), {
+      wrapper: wrapper({ subscribeMessageRange, seekPlayback, currentTime }),
+    });
+
+    act(() => {
+      result.current.updateRenderedTime([messageAndData(displayedMessage)]);
+      result.current.handleNextFrame([messageAndData(displayedMessage)]);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isFrameNavigationPending).toBe(false);
+    });
+    expect(result.current.getEffectiveMessages([])).toEqual([messageAndData(currentMessage)]);
     expect(seekPlayback).not.toHaveBeenCalled();
   });
 
@@ -802,6 +828,8 @@ describe("useFrameNavigation", () => {
       Parameters<SubscribeMessageRange>
     >(() => undefined);
     const seekPlayback = jest.fn<void, [Time]>();
+    const pausePlayback = jest.fn<void, []>();
+    const startPlayback = jest.fn<void, []>();
 
     const { result } = renderHook(
       () =>
@@ -811,7 +839,14 @@ describe("useFrameNavigation", () => {
           noNextFrameMessage: "No next",
         }),
       {
-        wrapper: wrapper({ subscribeMessageRange, seekPlayback, currentTime: time(2) }),
+        wrapper: wrapper({
+          subscribeMessageRange,
+          seekPlayback,
+          pausePlayback,
+          startPlayback,
+          currentTime: time(2),
+          isPlaying: true,
+        }),
       },
     );
 
@@ -829,6 +864,8 @@ describe("useFrameNavigation", () => {
       expect(result.current.hasPreFrame).toBe(false);
     });
     expect(seekPlayback).not.toHaveBeenCalled();
+    expect(pausePlayback).toHaveBeenCalledTimes(1);
+    expect(startPlayback).toHaveBeenCalledTimes(1);
     expect(subscribeMessageRange).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/studio-base/src/hooks/useFrameNavigation.test.tsx
+++ b/packages/studio-base/src/hooks/useFrameNavigation.test.tsx
@@ -348,6 +348,14 @@ describe("useFrameNavigation", () => {
       expect(result.current.frameNavigationStatusMessage).toBe("No next");
     });
     expect(seekPlayback).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.handleNextFrame([messageAndData(staleMessage)]);
+    });
+    await waitFor(() => {
+      expect(result.current.frameNavigationStatusMessage).toBe("No next");
+    });
+    expect(seekPlayback).not.toHaveBeenCalled();
   });
 
   it("uses rendered history before requesting a previous range", () => {
@@ -512,6 +520,52 @@ describe("useFrameNavigation", () => {
       expect(seekPlayback).toHaveBeenCalledTimes(1);
     });
     expect(seekPlayback).toHaveBeenCalledWith(time(3));
+  });
+
+  it("clears a completed seek when another panel supersedes it before restore", async () => {
+    const secondRelease = deferred();
+    let requestIndex = 0;
+    const subscribeMessageRange = jest.fn<
+      ReturnType<SubscribeMessageRange>,
+      Parameters<SubscribeMessageRange>
+    >(({ onNewRangeIterator }) => {
+      const index = requestIndex++;
+      void onNewRangeIterator(
+        (async function* () {
+          if (index === 1) {
+            await secondRelease.promise;
+          }
+          yield [message(index === 0 ? 2 : 3, 1)];
+        })(),
+      );
+      return jest.fn();
+    });
+    const seekPlayback = jest.fn<void, [Time]>();
+    const { result } = renderHook(
+      () => ({ first: useFrameNavigation({ path }), second: useFrameNavigation({ path }) }),
+      { wrapper: wrapper({ subscribeMessageRange, seekPlayback }) },
+    );
+    const currentMessage = messageAndData(message(1, 1));
+
+    act(() => {
+      result.current.first.updateRenderedTime([currentMessage]);
+      result.current.second.updateRenderedTime([currentMessage]);
+      result.current.first.handleNextFrame([currentMessage]);
+    });
+    await waitFor(() => {
+      expect(seekPlayback).toHaveBeenCalledWith(time(2));
+    });
+
+    act(() => {
+      result.current.second.handleNextFrame([currentMessage]);
+    });
+
+    expect(result.current.first.isFrameNavigationPending).toBe(false);
+    expect(result.current.first.getEffectiveMessages([currentMessage])).toEqual([currentMessage]);
+    await act(async () => {
+      secondRelease.resolve();
+      await Promise.resolve();
+    });
   });
 
   it("keeps the found range frame visible when the seek snapshot has no matching messages", async () => {

--- a/packages/studio-base/src/hooks/useFrameNavigation.test.tsx
+++ b/packages/studio-base/src/hooks/useFrameNavigation.test.tsx
@@ -128,6 +128,7 @@ function wrapper(options: {
   readonly pausePlayback?: () => void;
   readonly startPlayback?: () => void;
   readonly currentTime?: Time | (() => Time);
+  readonly endTime?: Time | (() => Time);
   readonly isPlaying?: boolean;
   readonly requestWindow?: number;
   readonly playerId?: () => string;
@@ -161,7 +162,11 @@ function wrapper(options: {
                 : (options.currentTime ?? time(1))
             }
             isPlaying={options.isPlaying}
-            endTime={time(5)}
+            endTime={
+              typeof options.endTime === "function"
+                ? options.endTime()
+                : (options.endTime ?? time(5))
+            }
             playerId={options.playerId?.()}
           >
             {children}
@@ -697,6 +702,42 @@ describe("useFrameNavigation", () => {
       result.current.onRestore();
     });
     expect(result.current.frameNavigationStatusMessage).toBeUndefined();
+  });
+
+  it("retries next navigation when the available range grows", async () => {
+    const rangeMessages: MessageEvent[] = [];
+    const subscribeMessageRange = makeSubscribeMessageRange(rangeMessages);
+    const seekPlayback = jest.fn<void, [Time]>();
+    let endTime = time(2);
+    const { result, rerender } = renderHook(() => useFrameNavigation({ path }), {
+      wrapper: wrapper({
+        subscribeMessageRange,
+        seekPlayback,
+        currentTime: time(1),
+        endTime: () => endTime,
+      }),
+    });
+    const currentMessage = message(1, 1);
+
+    act(() => {
+      result.current.updateRenderedTime([messageAndData(currentMessage)]);
+      result.current.handleNextFrame([messageAndData(currentMessage)]);
+    });
+    await waitFor(() => {
+      expect(result.current.isFrameNavigationPending).toBe(false);
+    });
+
+    const newMessage = message(3, 1);
+    rangeMessages.push(newMessage);
+    endTime = time(3);
+    rerender();
+    act(() => {
+      result.current.handleNextFrame([messageAndData(currentMessage)]);
+    });
+
+    await waitFor(() => {
+      expect(seekPlayback).toHaveBeenCalledWith(newMessage.receiveTime);
+    });
   });
 
   it("exposes cancellable inline feedback for a slow range navigation", async () => {

--- a/packages/studio-base/src/hooks/useFrameNavigation.test.tsx
+++ b/packages/studio-base/src/hooks/useFrameNavigation.test.tsx
@@ -337,6 +337,47 @@ describe("useFrameNavigation", () => {
     });
   });
 
+  it("seeks when playback moves after a range search starts", async () => {
+    const release = deferred();
+    const subscribeMessageRange = jest.fn<
+      ReturnType<SubscribeMessageRange>,
+      Parameters<SubscribeMessageRange>
+    >(({ onNewRangeIterator }) => {
+      void onNewRangeIterator(
+        (async function* () {
+          await release.promise;
+          yield [message(2, 1)];
+        })(),
+      );
+      return jest.fn();
+    });
+    const seekPlayback = jest.fn<void, [Time]>();
+    let currentTime = time(2);
+    const { result, rerender } = renderHook(() => useFrameNavigation({ path }), {
+      wrapper: wrapper({
+        subscribeMessageRange,
+        seekPlayback,
+        currentTime: () => currentTime,
+      }),
+    });
+    const displayedMessage = message(1, 1);
+
+    act(() => {
+      result.current.updateRenderedTime([messageAndData(displayedMessage)]);
+      result.current.handleNextFrame([messageAndData(displayedMessage)]);
+    });
+    currentTime = time(3);
+    rerender();
+    await act(async () => {
+      release.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(seekPlayback).toHaveBeenCalledWith(time(2));
+    });
+  });
+
   it("searches from the playback cursor after a manual seek leaves stale messages", async () => {
     const staleMessage = message(1, 1);
     const rangeMessages = [message(2, 1)];

--- a/packages/studio-base/src/hooks/useFrameNavigation.test.tsx
+++ b/packages/studio-base/src/hooks/useFrameNavigation.test.tsx
@@ -129,6 +129,7 @@ function wrapper(options: {
   readonly startPlayback?: () => void;
   readonly currentTime?: Time | (() => Time);
   readonly endTime?: Time | (() => Time);
+  readonly lastSeekTime?: number | (() => number);
   readonly isPlaying?: boolean;
   readonly requestWindow?: number;
   readonly playerId?: () => string;
@@ -166,6 +167,16 @@ function wrapper(options: {
               typeof options.endTime === "function"
                 ? options.endTime()
                 : (options.endTime ?? time(5))
+            }
+            activeData={
+              options.lastSeekTime != undefined
+                ? {
+                    lastSeekTime:
+                      typeof options.lastSeekTime === "function"
+                        ? options.lastSeekTime()
+                        : options.lastSeekTime,
+                  }
+                : undefined
             }
             playerId={options.playerId?.()}
           >
@@ -384,23 +395,31 @@ describe("useFrameNavigation", () => {
     const subscribeMessageRange = makeSubscribeMessageRange(rangeMessages);
     const seekPlayback = jest.fn<void, [Time]>();
     let currentTime = time(1);
+    let lastSeekTime = 0;
 
     const { result, rerender } = renderHook(
       () => useFrameNavigation({ path, noNextFrameMessage: "No next" }),
-      { wrapper: wrapper({ subscribeMessageRange, seekPlayback, currentTime: () => currentTime }) },
+      {
+        wrapper: wrapper({
+          subscribeMessageRange,
+          seekPlayback,
+          currentTime: () => currentTime,
+          lastSeekTime: () => lastSeekTime,
+        }),
+      },
     );
 
-    const restoreFromPreviousRender = result.current.onRestore;
     act(() => {
       result.current.updateRenderedTime([messageAndData(staleMessage)]);
     });
     currentTime = time(3);
+    lastSeekTime++;
     rerender();
     await act(async () => {
       await Promise.resolve();
     });
     act(() => {
-      restoreFromPreviousRender();
+      result.current.onRestore();
       result.current.handleNextFrame([messageAndData(staleMessage)]);
     });
 
@@ -869,6 +888,62 @@ describe("useFrameNavigation", () => {
     });
     await waitFor(() => {
       expect(seekPlayback).toHaveBeenCalledWith(newMessage.receiveTime);
+    });
+  });
+
+  it("does not cache a no-previous result from an older playback cursor", async () => {
+    const release = deferred();
+    const previousMessage = message(3, 1);
+    let requestCount = 0;
+    const subscribeMessageRange = jest.fn<
+      ReturnType<SubscribeMessageRange>,
+      Parameters<SubscribeMessageRange>
+    >(({ onNewRangeIterator }) => {
+      const requestIndex = requestCount++;
+      void onNewRangeIterator(
+        (async function* () {
+          if (requestIndex === 0) {
+            await release.promise;
+            yield [];
+          } else {
+            yield [previousMessage];
+          }
+        })(),
+      );
+      return jest.fn();
+    });
+    const seekPlayback = jest.fn<void, [Time]>();
+    let currentTime = time(3);
+    const { result, rerender } = renderHook(() => useFrameNavigation({ path }), {
+      wrapper: wrapper({
+        subscribeMessageRange,
+        seekPlayback,
+        currentTime: () => currentTime,
+      }),
+    });
+
+    act(() => {
+      result.current.updateRenderedTime([messageAndData(message(3, 1))]);
+      result.current.handlePreviousFrame();
+    });
+    currentTime = time(4);
+    rerender();
+    act(() => {
+      result.current.updateRenderedTime([messageAndData(message(4, 1))]);
+    });
+    await act(async () => {
+      release.resolve();
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(result.current.isFrameNavigationPending).toBe(false);
+    });
+
+    act(() => {
+      result.current.handlePreviousFrame();
+    });
+    await waitFor(() => {
+      expect(seekPlayback).toHaveBeenCalledWith(previousMessage.receiveTime);
     });
   });
 

--- a/packages/studio-base/src/hooks/useFrameNavigation.test.tsx
+++ b/packages/studio-base/src/hooks/useFrameNavigation.test.tsx
@@ -632,6 +632,12 @@ describe("useFrameNavigation", () => {
     expect(mockEnqueueSnackbar).not.toHaveBeenCalled();
     expect(seekPlayback).not.toHaveBeenCalled();
 
+    const requestCount = subscribeMessageRange.mock.calls.length;
+    act(() => {
+      result.current.handleNextFrame([messageAndData(currentMessage)]);
+    });
+    expect(subscribeMessageRange).toHaveBeenCalledTimes(requestCount);
+
     act(() => {
       result.current.onRestore();
     });

--- a/packages/studio-base/src/hooks/useFrameNavigation.test.tsx
+++ b/packages/studio-base/src/hooks/useFrameNavigation.test.tsx
@@ -127,7 +127,7 @@ function wrapper(options: {
   readonly seekPlayback?: (time: Time) => void;
   readonly pausePlayback?: () => void;
   readonly startPlayback?: () => void;
-  readonly currentTime?: Time;
+  readonly currentTime?: Time | (() => Time);
   readonly isPlaying?: boolean;
   readonly requestWindow?: number;
   readonly playerId?: () => string;
@@ -155,7 +155,11 @@ function wrapper(options: {
             pausePlayback={options.pausePlayback}
             startPlayback={options.startPlayback}
             startTime={time(0)}
-            currentTime={options.currentTime ?? time(1)}
+            currentTime={
+              typeof options.currentTime === "function"
+                ? options.currentTime()
+                : (options.currentTime ?? time(1))
+            }
             isPlaying={options.isPlaying}
             endTime={time(5)}
             playerId={options.playerId?.()}
@@ -330,12 +334,14 @@ describe("useFrameNavigation", () => {
 
   it("searches from the playback cursor after a manual seek leaves stale messages", async () => {
     const staleMessage = message(1, 1);
-    const subscribeMessageRange = makeSubscribeMessageRange([message(2, 1)]);
+    const rangeMessages = [message(2, 1)];
+    const subscribeMessageRange = makeSubscribeMessageRange(rangeMessages);
     const seekPlayback = jest.fn<void, [Time]>();
+    let currentTime = time(3);
 
-    const { result } = renderHook(
+    const { result, rerender } = renderHook(
       () => useFrameNavigation({ path, noNextFrameMessage: "No next" }),
-      { wrapper: wrapper({ subscribeMessageRange, seekPlayback, currentTime: time(3) }) },
+      { wrapper: wrapper({ subscribeMessageRange, seekPlayback, currentTime: () => currentTime }) },
     );
 
     act(() => {
@@ -356,6 +362,55 @@ describe("useFrameNavigation", () => {
       expect(result.current.frameNavigationStatusMessage).toBe("No next");
     });
     expect(seekPlayback).not.toHaveBeenCalled();
+
+    currentTime = time(4);
+    rangeMessages.push(messageAt(time(3, 500_000_000), 1));
+    rerender();
+    act(() => {
+      const latestMessage = message(4, 1);
+      result.current.updateRenderedTime([messageAndData(latestMessage)]);
+      result.current.handleNextFrame([messageAndData(latestMessage)]);
+    });
+    await waitFor(() => {
+      expect(result.current.frameNavigationStatusMessage).toBe("No next");
+    });
+    expect(seekPlayback).not.toHaveBeenCalled();
+  });
+
+  it("releases a held frame after playback advances past it", async () => {
+    const heldMessage = message(2, 1);
+    const displayedMessage = message(1, 1);
+    const subscribeMessageRange = makeSubscribeMessageRange([heldMessage]);
+    let currentTime = time(2);
+    const { result, rerender } = renderHook(() => useFrameNavigation({ path }), {
+      wrapper: wrapper({
+        subscribeMessageRange,
+        seekPlayback: jest.fn<void, [Time]>(),
+        currentTime: () => currentTime,
+      }),
+    });
+
+    act(() => {
+      result.current.updateRenderedTime([messageAndData(displayedMessage)]);
+      result.current.handleNextFrame([messageAndData(displayedMessage)]);
+    });
+    await waitFor(() => {
+      expect(result.current.isFrameNavigationPending).toBe(false);
+    });
+    expect(result.current.getEffectiveMessages([messageAndData(displayedMessage)])).toEqual([
+      messageAndData(heldMessage),
+    ]);
+
+    currentTime = time(3);
+    rerender();
+    const playbackMessage = message(3, 1);
+    act(() => {
+      result.current.updateRenderedTime([messageAndData(playbackMessage)]);
+    });
+
+    expect(result.current.getEffectiveMessages([messageAndData(playbackMessage)])).toEqual([
+      messageAndData(playbackMessage),
+    ]);
   });
 
   it("uses rendered history before requesting a previous range", () => {

--- a/packages/studio-base/src/hooks/useFrameNavigation.test.tsx
+++ b/packages/studio-base/src/hooks/useFrameNavigation.test.tsx
@@ -409,6 +409,9 @@ describe("useFrameNavigation", () => {
     currentTime = time(3);
     rerender();
     const playbackMessage = message(3, 1);
+    expect(result.current.getEffectiveMessages([messageAndData(playbackMessage)])).toEqual([
+      messageAndData(playbackMessage),
+    ]);
     act(() => {
       result.current.updateRenderedTime([messageAndData(playbackMessage)]);
     });

--- a/packages/studio-base/src/hooks/useFrameNavigation.test.tsx
+++ b/packages/studio-base/src/hooks/useFrameNavigation.test.tsx
@@ -383,16 +383,24 @@ describe("useFrameNavigation", () => {
     const rangeMessages = [message(2, 1)];
     const subscribeMessageRange = makeSubscribeMessageRange(rangeMessages);
     const seekPlayback = jest.fn<void, [Time]>();
-    let currentTime = time(3);
+    let currentTime = time(1);
 
     const { result, rerender } = renderHook(
       () => useFrameNavigation({ path, noNextFrameMessage: "No next" }),
       { wrapper: wrapper({ subscribeMessageRange, seekPlayback, currentTime: () => currentTime }) },
     );
 
+    const restoreFromPreviousRender = result.current.onRestore;
     act(() => {
       result.current.updateRenderedTime([messageAndData(staleMessage)]);
-      result.current.onRestore();
+    });
+    currentTime = time(3);
+    rerender();
+    await act(async () => {
+      await Promise.resolve();
+    });
+    act(() => {
+      restoreFromPreviousRender();
       result.current.handleNextFrame([messageAndData(staleMessage)]);
     });
 
@@ -421,6 +429,31 @@ describe("useFrameNavigation", () => {
       expect(result.current.frameNavigationStatusMessage).toBe("No next");
     });
     expect(seekPlayback).not.toHaveBeenCalled();
+  });
+
+  it("does not treat an unrelated reducer restore as a manual seek", async () => {
+    const displayedMessage = message(8, 1);
+    const nextMessage = message(9, 1);
+    const subscribeMessageRange = makeSubscribeMessageRange([nextMessage]);
+    const seekPlayback = jest.fn<void, [Time]>();
+    const { result } = renderHook(() => useFrameNavigation({ path }), {
+      wrapper: wrapper({
+        subscribeMessageRange,
+        seekPlayback,
+        currentTime: time(10),
+        endTime: time(10),
+      }),
+    });
+
+    act(() => {
+      result.current.updateRenderedTime([messageAndData(displayedMessage)]);
+      result.current.onRestore();
+      result.current.handleNextFrame([messageAndData(displayedMessage)]);
+    });
+
+    await waitFor(() => {
+      expect(seekPlayback).toHaveBeenCalledWith(nextMessage.receiveTime);
+    });
   });
 
   it("releases a held frame after playback advances past it", async () => {
@@ -779,6 +812,61 @@ describe("useFrameNavigation", () => {
       result.current.handleNextFrame([messageAndData(currentMessage)]);
     });
 
+    await waitFor(() => {
+      expect(seekPlayback).toHaveBeenCalledWith(newMessage.receiveTime);
+    });
+  });
+
+  it("does not cache a no-next result from an older range boundary", async () => {
+    const release = deferred();
+    const newMessage = message(3, 1);
+    let requestCount = 0;
+    const subscribeMessageRange = jest.fn<
+      ReturnType<SubscribeMessageRange>,
+      Parameters<SubscribeMessageRange>
+    >(({ onNewRangeIterator }) => {
+      const requestIndex = requestCount++;
+      void onNewRangeIterator(
+        (async function* () {
+          if (requestIndex === 0) {
+            await release.promise;
+            yield [];
+          } else {
+            yield [newMessage];
+          }
+        })(),
+      );
+      return jest.fn();
+    });
+    const seekPlayback = jest.fn<void, [Time]>();
+    let endTime = time(2);
+    const { result, rerender } = renderHook(() => useFrameNavigation({ path }), {
+      wrapper: wrapper({
+        subscribeMessageRange,
+        seekPlayback,
+        currentTime: time(1),
+        endTime: () => endTime,
+      }),
+    });
+    const currentMessage = message(1, 1);
+
+    act(() => {
+      result.current.updateRenderedTime([messageAndData(currentMessage)]);
+      result.current.handleNextFrame([messageAndData(currentMessage)]);
+    });
+    endTime = time(3);
+    rerender();
+    await act(async () => {
+      release.resolve();
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(result.current.isFrameNavigationPending).toBe(false);
+    });
+
+    act(() => {
+      result.current.handleNextFrame([messageAndData(currentMessage)]);
+    });
     await waitFor(() => {
       expect(seekPlayback).toHaveBeenCalledWith(newMessage.receiveTime);
     });

--- a/packages/studio-base/src/hooks/useFrameNavigation.test.tsx
+++ b/packages/studio-base/src/hooks/useFrameNavigation.test.tsx
@@ -300,7 +300,8 @@ describe("useFrameNavigation", () => {
     const currentTime = time(2);
     const displayedMessage = message(1, 1);
     const currentMessage = messageAt(currentTime, 1);
-    const subscribeMessageRange = makeSubscribeMessageRange([currentMessage]);
+    const nextMessage = message(3, 1);
+    const subscribeMessageRange = makeSubscribeMessageRange([currentMessage, nextMessage]);
     const seekPlayback = jest.fn<void, [Time]>();
 
     const { result } = renderHook(() => useFrameNavigation({ path }), {
@@ -318,7 +319,13 @@ describe("useFrameNavigation", () => {
     expect(result.current.getEffectiveMessages([messageAndData(displayedMessage)])).toEqual([
       messageAndData(currentMessage),
     ]);
-    expect(seekPlayback).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.handleNextFrame([messageAndData(displayedMessage)]);
+    });
+    await waitFor(() => {
+      expect(seekPlayback).toHaveBeenCalledWith(nextMessage.receiveTime);
+    });
   });
 
   it("searches from the playback cursor after a manual seek leaves stale messages", async () => {

--- a/packages/studio-base/src/hooks/useFrameNavigation.test.tsx
+++ b/packages/studio-base/src/hooks/useFrameNavigation.test.tsx
@@ -288,6 +288,12 @@ describe("useFrameNavigation", () => {
     expect(result.current.isFrameNavigationPending).toBe(false);
     expect(result.current.hasPreFrame).toBe(false);
     expect(seekPlayback).not.toHaveBeenCalled();
+
+    const requestCount = subscribeMessageRange.mock.calls.length;
+    act(() => {
+      result.current.handlePreviousFrame();
+    });
+    expect(subscribeMessageRange).toHaveBeenCalledTimes(requestCount);
   });
 
   it("finishes next navigation when the matching frame is already current", async () => {
@@ -309,7 +315,31 @@ describe("useFrameNavigation", () => {
     await waitFor(() => {
       expect(result.current.isFrameNavigationPending).toBe(false);
     });
-    expect(result.current.getEffectiveMessages([])).toEqual([messageAndData(currentMessage)]);
+    expect(result.current.getEffectiveMessages([messageAndData(displayedMessage)])).toEqual([
+      messageAndData(currentMessage),
+    ]);
+    expect(seekPlayback).not.toHaveBeenCalled();
+  });
+
+  it("searches from the playback cursor after a manual seek leaves stale messages", async () => {
+    const staleMessage = message(1, 1);
+    const subscribeMessageRange = makeSubscribeMessageRange([message(2, 1)]);
+    const seekPlayback = jest.fn<void, [Time]>();
+
+    const { result } = renderHook(
+      () => useFrameNavigation({ path, noNextFrameMessage: "No next" }),
+      { wrapper: wrapper({ subscribeMessageRange, seekPlayback, currentTime: time(3) }) },
+    );
+
+    act(() => {
+      result.current.updateRenderedTime([messageAndData(staleMessage)]);
+      result.current.onRestore();
+      result.current.handleNextFrame([messageAndData(staleMessage)]);
+    });
+
+    await waitFor(() => {
+      expect(result.current.frameNavigationStatusMessage).toBe("No next");
+    });
     expect(seekPlayback).not.toHaveBeenCalled();
   });
 
@@ -457,6 +487,9 @@ describe("useFrameNavigation", () => {
       result.current.first.handleNextFrame([currentMessage]);
       result.current.second.handleNextFrame([currentMessage]);
     });
+
+    expect(result.current.first.isFrameNavigationPending).toBe(false);
+    expect(result.current.second.isFrameNavigationPending).toBe(true);
 
     await act(async () => {
       firstRelease.resolve();
@@ -1340,6 +1373,45 @@ describe("useFrameNavigation", () => {
     });
   });
 
+  it("ends completed range navigation when unmounted before restore", async () => {
+    jest.useFakeTimers();
+    const firstSeekPlayback = jest.fn<void, [Time]>();
+    const firstHook = renderHook(() => useFrameNavigation({ path }), {
+      wrapper: wrapper({
+        subscribeMessageRange: makeSubscribeMessageRange([message(2, 1)]),
+        seekPlayback: firstSeekPlayback,
+      }),
+    });
+
+    act(() => {
+      const currentMessage = messageAndData(message(1, 1));
+      firstHook.result.current.updateRenderedTime([currentMessage]);
+      firstHook.result.current.handleNextFrame([currentMessage]);
+    });
+    await waitFor(() => {
+      expect(firstSeekPlayback).toHaveBeenCalledWith(time(2));
+    });
+
+    firstHook.unmount();
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    const secondSeekPlayback = jest.fn<void, [Time]>();
+    const secondHook = renderHook(() => useFrameNavigation({ path }), {
+      wrapper: wrapper({ seekPlayback: secondSeekPlayback }),
+    });
+    act(() => {
+      secondHook.result.current.updateRenderedTime([messageAndData(message(1, 1))]);
+      secondHook.result.current.updateRenderedTime([messageAndData(message(2, 1))]);
+      secondHook.result.current.onRestore();
+      secondHook.result.current.handlePreviousFrame();
+    });
+
+    expect(secondSeekPlayback).not.toHaveBeenCalled();
+    secondHook.unmount();
+  });
+
   it("handles keyboard frame navigation and clears repeat timers", () => {
     jest.useFakeTimers();
     const startPlayback = jest.fn<void, []>();
@@ -1403,6 +1475,10 @@ describe("useFrameNavigation", () => {
 
     unmount();
 
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    expect(startPlayback).toHaveBeenCalledTimes(1);
     expect(jest.getTimerCount()).toBe(0);
     panelElement.remove();
   });

--- a/packages/studio-base/src/hooks/useFrameNavigation.test.tsx
+++ b/packages/studio-base/src/hooks/useFrameNavigation.test.tsx
@@ -341,6 +341,7 @@ describe("useFrameNavigation", () => {
     ]);
 
     act(() => {
+      result.current.updateRenderedTime([messageAndData(displayedMessage)]);
       result.current.handleNextFrame([messageAndData(displayedMessage)]);
     });
     await waitFor(() => {
@@ -450,6 +451,58 @@ describe("useFrameNavigation", () => {
     expect(seekPlayback).not.toHaveBeenCalled();
   });
 
+  it("keeps the manual seek cursor when it cancels an in-flight search", async () => {
+    const staleMessage = message(1, 1);
+    const candidates = [message(2, 1), message(4, 1)];
+    let requestCount = 0;
+    const subscribeMessageRange = jest.fn<
+      ReturnType<SubscribeMessageRange>,
+      Parameters<SubscribeMessageRange>
+    >(({ timeRange, onNewRangeIterator }) => {
+      if (requestCount++ > 0) {
+        void onNewRangeIterator(
+          (async function* () {
+            yield candidates.filter((candidate) =>
+              inRange(candidate, timeRange.start, timeRange.end),
+            );
+          })(),
+        );
+      }
+      return jest.fn();
+    });
+    const seekPlayback = jest.fn<void, [Time]>();
+    let currentTime = time(1);
+    let lastSeekTime = 0;
+    const { result, rerender } = renderHook(() => useFrameNavigation({ path }), {
+      wrapper: wrapper({
+        subscribeMessageRange,
+        seekPlayback,
+        currentTime: () => currentTime,
+        lastSeekTime: () => lastSeekTime,
+      }),
+    });
+
+    act(() => {
+      result.current.updateRenderedTime([messageAndData(staleMessage)]);
+      result.current.handleNextFrame([messageAndData(staleMessage)]);
+    });
+    expect(result.current.isFrameNavigationPending).toBe(true);
+
+    currentTime = time(3);
+    lastSeekTime++;
+    rerender();
+    act(() => {
+      result.current.onRestore();
+      result.current.updateRenderedTime([messageAndData(staleMessage)]);
+      result.current.handleNextFrame([messageAndData(staleMessage)]);
+    });
+
+    await waitFor(() => {
+      expect(seekPlayback).toHaveBeenCalledWith(time(4));
+    });
+    expect(seekPlayback).toHaveBeenCalledTimes(1);
+  });
+
   it("does not treat an unrelated reducer restore as a manual seek", async () => {
     const displayedMessage = message(8, 1);
     const nextMessage = message(9, 1);
@@ -473,6 +526,36 @@ describe("useFrameNavigation", () => {
     await waitFor(() => {
       expect(seekPlayback).toHaveBeenCalledWith(nextMessage.receiveTime);
     });
+  });
+
+  it("ignores frame navigation when seeking is unavailable", () => {
+    const pausePlayback = jest.fn<void, []>();
+    const startPlayback = jest.fn<void, []>();
+    const previousHook = renderHook(() => useFrameNavigation({ path }), {
+      wrapper: wrapper({ pausePlayback, startPlayback }),
+    });
+
+    act(() => {
+      previousHook.result.current.updateRenderedTime([messageAndData(message(1, 1))]);
+      previousHook.result.current.updateRenderedTime([messageAndData(message(2, 1))]);
+      previousHook.result.current.handlePreviousFrame();
+    });
+    expect(pausePlayback).not.toHaveBeenCalled();
+    previousHook.unmount();
+
+    const nextHook = renderHook(() => useFrameNavigation({ path }), {
+      wrapper: wrapper({ pausePlayback, startPlayback }),
+    });
+    const currentMessage = messageAndData(message(1, 1));
+    act(() => {
+      nextHook.result.current.updateRenderedTime([currentMessage]);
+      nextHook.result.current.handleNextFrame([currentMessage]);
+    });
+    expect(startPlayback).not.toHaveBeenCalled();
+    expect(nextHook.result.current.getEffectiveMessages([currentMessage])).toEqual([
+      currentMessage,
+    ]);
+    nextHook.unmount();
   });
 
   it("releases a held frame after playback advances past it", async () => {
@@ -678,6 +761,33 @@ describe("useFrameNavigation", () => {
     expect(seekPlayback).toHaveBeenCalledWith(time(3));
   });
 
+  it("lets the most recently started fallback navigation win across panels", () => {
+    const seekPlayback = jest.fn<void, [Time]>();
+    const pausePlayback = jest.fn<void, []>();
+    const startPlayback = jest.fn<void, []>();
+    const { result } = renderHook(
+      () => ({ first: useFrameNavigation({ path }), second: useFrameNavigation({ path }) }),
+      { wrapper: wrapper({ pausePlayback, seekPlayback, startPlayback }) },
+    );
+    const currentMessage = messageAndData(message(1, 1));
+
+    act(() => {
+      result.current.first.updateRenderedTime([currentMessage]);
+      result.current.second.updateRenderedTime([currentMessage]);
+      result.current.first.handleNextFrame([currentMessage]);
+      result.current.second.handleNextFrame([currentMessage]);
+    });
+    expect(startPlayback).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      result.current.first.updateRenderedTime([messageAndData(message(2, 1))]);
+      result.current.second.updateRenderedTime([messageAndData(message(3, 1))]);
+    });
+
+    expect(seekPlayback).toHaveBeenCalledTimes(1);
+    expect(seekPlayback).toHaveBeenCalledWith(time(3));
+  });
+
   it("clears a completed seek when another panel supersedes it before restore", async () => {
     const secondRelease = deferred();
     let requestIndex = 0;
@@ -790,9 +900,15 @@ describe("useFrameNavigation", () => {
 
     const requestCount = subscribeMessageRange.mock.calls.length;
     act(() => {
+      result.current.cancelFrameNavigation();
+    });
+    expect(result.current.frameNavigationStatusMessage).toBeUndefined();
+
+    act(() => {
       result.current.handleNextFrame([messageAndData(currentMessage)]);
     });
     expect(subscribeMessageRange).toHaveBeenCalledTimes(requestCount);
+    expect(result.current.frameNavigationStatusMessage).toBe("No next");
 
     act(() => {
       result.current.onRestore();

--- a/packages/studio-base/src/hooks/useFrameNavigation.test.tsx
+++ b/packages/studio-base/src/hooks/useFrameNavigation.test.tsx
@@ -679,6 +679,43 @@ describe("useFrameNavigation", () => {
     expect(requestedRanges).toHaveLength(3);
   });
 
+  it("continues previous navigation from a held frame while rendered messages are stale", async () => {
+    const firstPrevious = message(4, 1);
+    const secondPrevious = message(3, 1);
+    const subscribeMessageRange = makeSubscribeMessageRange([secondPrevious, firstPrevious]);
+    const seekPlayback = jest.fn<void, [Time]>();
+    let currentTime = time(5);
+    const { result, rerender } = renderHook(() => useFrameNavigation({ path }), {
+      wrapper: wrapper({
+        subscribeMessageRange,
+        seekPlayback,
+        currentTime: () => currentTime,
+      }),
+    });
+    const staleCurrentFrame = messageAndData(message(5, 1));
+
+    act(() => {
+      result.current.updateRenderedTime([staleCurrentFrame]);
+      result.current.handlePreviousFrame();
+    });
+    await waitFor(() => {
+      expect(seekPlayback).toHaveBeenLastCalledWith(firstPrevious.receiveTime);
+    });
+
+    currentTime = firstPrevious.receiveTime;
+    rerender();
+    act(() => {
+      result.current.onRestore();
+      result.current.updateRenderedTime([staleCurrentFrame]);
+      result.current.handlePreviousFrame();
+    });
+
+    await waitFor(() => {
+      expect(seekPlayback).toHaveBeenLastCalledWith(secondPrevious.receiveTime);
+    });
+    expect(seekPlayback).toHaveBeenCalledTimes(2);
+  });
+
   it("keeps previous navigation enabled after rendered history is exhausted in range mode", async () => {
     const rangeFrame = messageAt(time(0, 500_000_000), 1);
     const subscribeMessageRange = makeSubscribeMessageRange([rangeFrame]);
@@ -786,6 +823,55 @@ describe("useFrameNavigation", () => {
 
     expect(seekPlayback).toHaveBeenCalledTimes(1);
     expect(seekPlayback).toHaveBeenCalledWith(time(3));
+  });
+
+  it("releases a held frame when another panel navigates backward", async () => {
+    const currentFrame = messageAndData(message(1, 1));
+    const heldFrame = messageAndData(message(2, 1));
+    const subscribeMessageRange = makeSubscribeMessageRange([heldFrame.messageEvent]);
+    const seekPlayback = jest.fn<void, [Time]>();
+    let currentTime = time(1);
+    const { result, rerender } = renderHook(
+      () => ({ first: useFrameNavigation({ path }), second: useFrameNavigation({ path }) }),
+      {
+        wrapper: wrapper({
+          subscribeMessageRange,
+          seekPlayback,
+          currentTime: () => currentTime,
+        }),
+      },
+    );
+
+    act(() => {
+      result.current.first.updateRenderedTime([currentFrame]);
+      result.current.second.updateRenderedTime([currentFrame]);
+      result.current.first.handleNextFrame([currentFrame]);
+    });
+    await waitFor(() => {
+      expect(seekPlayback).toHaveBeenLastCalledWith(heldFrame.messageEvent.receiveTime);
+    });
+
+    currentTime = heldFrame.messageEvent.receiveTime;
+    rerender();
+    act(() => {
+      result.current.first.onRestore();
+      result.current.first.updateRenderedTime([currentFrame]);
+      result.current.second.updateRenderedTime([heldFrame]);
+    });
+    expect(result.current.first.getEffectiveMessages([currentFrame])).toEqual([heldFrame]);
+
+    act(() => {
+      result.current.second.handlePreviousFrame();
+    });
+    expect(seekPlayback).toHaveBeenLastCalledWith(currentFrame.messageEvent.receiveTime);
+
+    currentTime = currentFrame.messageEvent.receiveTime;
+    rerender();
+    act(() => {
+      result.current.first.onRestore();
+      result.current.first.updateRenderedTime([currentFrame]);
+    });
+    expect(result.current.first.getEffectiveMessages([currentFrame])).toEqual([currentFrame]);
   });
 
   it("clears a completed seek when another panel supersedes it before restore", async () => {
@@ -1905,8 +1991,10 @@ describe("useFrameNavigation", () => {
     const pausePlayback = jest.fn<void, []>();
     const panelElement = document.createElement("div");
     const focusedElement = document.createElement("button");
+    const outsideInput = document.createElement("input");
     panelElement.appendChild(focusedElement);
     document.body.appendChild(panelElement);
+    document.body.appendChild(outsideInput);
 
     const { result, unmount } = renderHook(
       () =>
@@ -1939,15 +2027,14 @@ describe("useFrameNavigation", () => {
     expect(jest.getTimerCount()).toBe(1);
 
     act(() => {
-      requiredKeyHandler(
-        result.current.keyUpHandlers,
-        "ArrowUp",
-      )(new KeyboardEvent("keyup", { key: "ArrowUp" }));
+      outsideInput.focus();
+      outsideInput.dispatchEvent(new KeyboardEvent("keyup", { key: "ArrowUp", bubbles: true }));
     });
 
     expect(jest.getTimerCount()).toBe(0);
 
     act(() => {
+      focusedElement.focus();
       result.current.onRestore();
       jest.runOnlyPendingTimers();
       requiredKeyHandler(
@@ -1959,6 +2046,20 @@ describe("useFrameNavigation", () => {
     expect(startPlayback).toHaveBeenCalledTimes(1);
     expect(jest.getTimerCount()).toBe(1);
 
+    act(() => {
+      window.dispatchEvent(new Event("blur"));
+    });
+    expect(jest.getTimerCount()).toBe(0);
+
+    act(() => {
+      focusedElement.focus();
+      requiredKeyHandler(
+        result.current.keyDownHandlers,
+        "ArrowDown",
+      )(new KeyboardEvent("keydown", { key: "ArrowDown" }));
+    });
+    expect(jest.getTimerCount()).toBe(1);
+
     unmount();
 
     act(() => {
@@ -1967,5 +2068,6 @@ describe("useFrameNavigation", () => {
     expect(startPlayback).toHaveBeenCalledTimes(1);
     expect(jest.getTimerCount()).toBe(0);
     panelElement.remove();
+    outsideInput.remove();
   });
 });

--- a/packages/studio-base/src/hooks/useFrameNavigation.ts
+++ b/packages/studio-base/src/hooks/useFrameNavigation.ts
@@ -255,7 +255,11 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
           currentMessagesRef.current = [result.message];
           holdNavigationMessages([result.message]);
           const targetTime = result.message.messageEvent.receiveTime;
-          if (activeData != undefined && compare(targetTime, activeData.currentTime) === 0) {
+          const latestActiveData = selectActiveData(getMessagePipelineState());
+          if (
+            latestActiveData != undefined &&
+            compare(targetTime, latestActiveData.currentTime) === 0
+          ) {
             onRestore();
             return;
           }
@@ -301,12 +305,12 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
       }
     },
     [
-      activeData,
       currentMessagesRef,
       clearFrozenMessages,
       clearSearchFeedback,
       enqueueSnackbar,
       finishFrameNavigation,
+      getMessagePipelineState,
       holdNavigationMessages,
       markPreviousFrameUnavailable,
       noNextFrameMessage,

--- a/packages/studio-base/src/hooks/useFrameNavigation.ts
+++ b/packages/studio-base/src/hooks/useFrameNavigation.ts
@@ -420,7 +420,18 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
         return;
       }
       if (currentMessages) {
-        currentMessagesRef.current = currentMessages;
+        const heldTime = currentMessagesRef.current.at(-1)?.messageEvent.receiveTime;
+        const holdsPlaybackCursor =
+          heldTime != undefined &&
+          activeData != undefined &&
+          compare(heldTime, activeData.currentTime) === 0;
+        const includesHeldTime = currentMessages.some(
+          (message) =>
+            heldTime != undefined && compare(message.messageEvent.receiveTime, heldTime) === 0,
+        );
+        if (!holdsPlaybackCursor || includesHeldTime) {
+          currentMessagesRef.current = currentMessages;
+        }
       }
 
       if (
@@ -465,7 +476,7 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
   useEffect(() => {
     return () => {
       if (cancelActiveRangeNavigation() || frameState.current !== "current") {
-        frameNavigationNotifier.endNavigation(navigationId.current);
+        frameNavigationNotifier.cancelNavigation(navigationId.current);
       }
     };
   }, [cancelActiveRangeNavigation]);

--- a/packages/studio-base/src/hooks/useFrameNavigation.ts
+++ b/packages/studio-base/src/hooks/useFrameNavigation.ts
@@ -24,6 +24,7 @@ import {
 } from "@foxglove/studio-base/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
 import {
   useMessagePipeline,
+  useMessagePipelineGetter,
   MessagePipelineContext,
 } from "@foxglove/studio-base/components/MessagePipeline";
 import { getRequestWindowDefaultTime } from "@foxglove/studio-base/constants/appSettingsDefaults";
@@ -97,6 +98,7 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
   const subscribeMessageRange = useMessagePipeline(selectSubscribeMessageRange);
   const activeData = useMessagePipeline(selectActiveData);
   const playerId = useMessagePipeline(selectPlayerId);
+  const getMessagePipelineState = useMessagePipelineGetter();
   const getMessagePathDataItems = useCachedGetMessagePathDataItems(path.length > 0 ? [path] : []);
   const { enqueueSnackbar } = useSnackbar();
 
@@ -118,6 +120,7 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
   const frameState = useRef<FrameNavigationState>("current");
   const activeRangeNavigation = useRef<AbortController | undefined>();
   const manualSeekTime = useRef<Time | undefined>();
+  const nextRangeExhausted = useRef(false);
   const previousRangeExhausted = useRef(false);
   const searchFeedbackTimer = useRef<ReturnType<typeof setTimeout> | undefined>();
 
@@ -224,17 +227,17 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
         setIsFrameNavigationPending(false);
         return;
       case "manual-seek":
-        manualSeekTime.current = activeData?.currentTime;
+        manualSeekTime.current = selectActiveData(getMessagePipelineState())?.currentTime;
         currentMessagesRef.current = [];
         return;
       case "other-navigation":
         return;
     }
   }, [
-    activeData?.currentTime,
     clearSearchFeedback,
     currentMessagesRef,
     finishFrameNavigation,
+    getMessagePipelineState,
     resetRenderedHistory,
     restoreFallbackState,
   ]);
@@ -262,6 +265,8 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
           if (direction === "previous") {
             previousRangeExhausted.current = true;
             markPreviousFrameUnavailable();
+          } else {
+            nextRangeExhausted.current = true;
           }
           finishFrameNavigation();
           setFrameNavigationStatusMessage(
@@ -418,6 +423,9 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
 
   const handleNextFrame = useCallback(
     (currentMessages?: MessageAndData[]) => {
+      if (nextRangeExhausted.current) {
+        return;
+      }
       if (frameState.current !== "current") {
         return;
       }
@@ -472,6 +480,7 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
   const { panelRef, keyDownHandlers, keyUpHandlers } = useFrameNavigationKeyboard(keyboardActions);
 
   useEffect(() => {
+    nextRangeExhausted.current = false;
     previousRangeExhausted.current = false;
   }, [activeData?.currentTime.nsec, activeData?.currentTime.sec]);
 
@@ -485,6 +494,7 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
 
   useEffect(() => {
     manualSeekTime.current = undefined;
+    nextRangeExhausted.current = false;
     previousRangeExhausted.current = false;
     finishFrameNavigation();
     resetRenderedHistory();

--- a/packages/studio-base/src/hooks/useFrameNavigation.ts
+++ b/packages/studio-base/src/hooks/useFrameNavigation.ts
@@ -446,6 +446,7 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
     if (seekPlayback == undefined || previousRangeExhausted.current) {
       return;
     }
+    currentMessagesRef.current = getEffectiveMessages(currentMessagesRef.current);
     if (subscribeMessageRange != undefined && activeData != undefined && path.length > 0) {
       const latestMessage = currentMessagesRef.current[currentMessagesRef.current.length - 1];
       const fromTime =
@@ -461,6 +462,7 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
   }, [
     activeData,
     currentMessagesRef,
+    getEffectiveMessages,
     path,
     runFallbackPreviousFrame,
     runPreviousFrameFromRenderedHistory,

--- a/packages/studio-base/src/hooks/useFrameNavigation.ts
+++ b/packages/studio-base/src/hooks/useFrameNavigation.ts
@@ -117,6 +117,8 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
   // Flag bit to indicate that the next message is the previous frame, current frame, next frame.
   const frameState = useRef<FrameNavigationState>("current");
   const activeRangeNavigation = useRef<AbortController | undefined>();
+  const manualSeekTime = useRef<Time | undefined>();
+  const previousRangeExhausted = useRef(false);
   const searchFeedbackTimer = useRef<ReturnType<typeof setTimeout> | undefined>();
 
   const activeTimes = useMemo(() => {
@@ -178,7 +180,11 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
       activeRangeNavigation.current = controller;
       freezeCurrentMessages();
       pausePlayback?.();
-      frameNavigationNotifier.startNavigation(navigationId.current);
+      frameNavigationNotifier.startNavigation(navigationId.current, () => {
+        if (activeRangeNavigation.current === controller) {
+          finishFrameNavigation();
+        }
+      });
       frameState.current = direction;
       setIsFrameNavigationPending(true);
       searchFeedbackTimer.current = setTimeout(() => {
@@ -194,6 +200,7 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
     [
       clearSearchFeedback,
       freezeCurrentMessages,
+      finishFrameNavigation,
       pausePlayback,
       searchingNextFrameMessage,
       searchingPreviousFrameMessage,
@@ -213,11 +220,20 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
         setIsFrameNavigationPending(false);
         return;
       case "manual-seek":
+        manualSeekTime.current = activeData?.currentTime;
+        currentMessagesRef.current = [];
         return;
       case "other-navigation":
         return;
     }
-  }, [clearSearchFeedback, finishFrameNavigation, resetRenderedHistory, restoreFallbackState]);
+  }, [
+    activeData?.currentTime,
+    clearSearchFeedback,
+    currentMessagesRef,
+    finishFrameNavigation,
+    resetRenderedHistory,
+    restoreFallbackState,
+  ]);
 
   const handleRangeNavigationResult = useCallback(
     (
@@ -240,6 +256,7 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
         }
         case "notFound":
           if (direction === "previous") {
+            previousRangeExhausted.current = true;
             markPreviousFrameUnavailable();
           }
           finishFrameNavigation();
@@ -308,8 +325,13 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
       }
 
       const latestMessage = currentMessagesRef.current[currentMessagesRef.current.length - 1];
+      const restoredSeekTime = manualSeekTime.current;
+      manualSeekTime.current = undefined;
       const fromTime =
-        rangeFromTime ?? latestMessage?.messageEvent.receiveTime ?? activeData.currentTime;
+        rangeFromTime ??
+        restoredSeekTime ??
+        latestMessage?.messageEvent.receiveTime ??
+        activeData.currentTime;
       const controller = new AbortController();
       const wasPlaying = activeData.isPlaying;
 
@@ -360,6 +382,9 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
   );
 
   const handlePreviousFrame = useCallback(() => {
+    if (previousRangeExhausted.current) {
+      return;
+    }
     if (
       subscribeMessageRange != undefined &&
       activeData != undefined &&
@@ -367,7 +392,9 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
       path.length > 0
     ) {
       const latestMessage = currentMessagesRef.current[currentMessagesRef.current.length - 1];
-      const fromTime = latestMessage?.messageEvent.receiveTime ?? activeData.currentTime;
+      const fromTime =
+        manualSeekTime.current ?? latestMessage?.messageEvent.receiveTime ?? activeData.currentTime;
+      manualSeekTime.current = undefined;
       if (runPreviousFrameFromRenderedHistory(fromTime)) {
         return;
       }
@@ -432,14 +459,20 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
   const { panelRef, keyDownHandlers, keyUpHandlers } = useFrameNavigationKeyboard(keyboardActions);
 
   useEffect(() => {
+    previousRangeExhausted.current = false;
+  }, [activeData?.currentTime.nsec, activeData?.currentTime.sec]);
+
+  useEffect(() => {
     return () => {
-      if (cancelActiveRangeNavigation()) {
+      if (cancelActiveRangeNavigation() || frameState.current !== "current") {
         frameNavigationNotifier.endNavigation(navigationId.current);
       }
     };
   }, [cancelActiveRangeNavigation]);
 
   useEffect(() => {
+    manualSeekTime.current = undefined;
+    previousRangeExhausted.current = false;
     finishFrameNavigation();
     resetRenderedHistory();
   }, [

--- a/packages/studio-base/src/hooks/useFrameNavigation.ts
+++ b/packages/studio-base/src/hooks/useFrameNavigation.ts
@@ -493,6 +493,10 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
   }, [activeData?.currentTime.nsec, activeData?.currentTime.sec]);
 
   useEffect(() => {
+    nextRangeExhausted.current = false;
+  }, [activeData?.endTime.nsec, activeData?.endTime.sec]);
+
+  useEffect(() => {
     return () => {
       if (cancelActiveRangeNavigation() || frameState.current !== "current") {
         frameNavigationNotifier.cancelNavigation(navigationId.current);

--- a/packages/studio-base/src/hooks/useFrameNavigation.ts
+++ b/packages/studio-base/src/hooks/useFrameNavigation.ts
@@ -181,7 +181,10 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
       freezeCurrentMessages();
       pausePlayback?.();
       frameNavigationNotifier.startNavigation(navigationId.current, () => {
-        if (activeRangeNavigation.current === controller) {
+        if (
+          activeRangeNavigation.current === controller ||
+          (activeRangeNavigation.current == undefined && frameState.current !== "current")
+        ) {
           finishFrameNavigation();
         }
       });
@@ -217,6 +220,7 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
     clearSearchFeedback();
     switch (restoreFallbackState()) {
       case "restored":
+        manualSeekTime.current = undefined;
         setIsFrameNavigationPending(false);
         return;
       case "manual-seek":
@@ -326,7 +330,6 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
 
       const latestMessage = currentMessagesRef.current[currentMessagesRef.current.length - 1];
       const restoredSeekTime = manualSeekTime.current;
-      manualSeekTime.current = undefined;
       const fromTime =
         rangeFromTime ??
         restoredSeekTime ??
@@ -394,7 +397,6 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
       const latestMessage = currentMessagesRef.current[currentMessagesRef.current.length - 1];
       const fromTime =
         manualSeekTime.current ?? latestMessage?.messageEvent.receiveTime ?? activeData.currentTime;
-      manualSeekTime.current = undefined;
       if (runPreviousFrameFromRenderedHistory(fromTime)) {
         return;
       }

--- a/packages/studio-base/src/hooks/useFrameNavigation.ts
+++ b/packages/studio-base/src/hooks/useFrameNavigation.ts
@@ -120,6 +120,10 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
   const frameState = useRef<FrameNavigationState>("current");
   const activeRangeNavigation = useRef<AbortController | undefined>();
   const manualSeekTime = useRef<Time | undefined>();
+  const lastRestoreContext = useRef({
+    playerId,
+    lastSeekTime: activeData?.lastSeekTime,
+  });
   const nextRangeExhausted = useRef(false);
   const previousRangeExhausted = useRef(false);
   const searchFeedbackTimer = useRef<ReturnType<typeof setTimeout> | undefined>();
@@ -215,6 +219,15 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
   );
 
   const onRestore = useCallback(() => {
+    const latestPipelineState = getMessagePipelineState();
+    const latestActiveData = selectActiveData(latestPipelineState);
+    const latestRestoreContext = {
+      playerId: selectPlayerId(latestPipelineState),
+      lastSeekTime: latestActiveData?.lastSeekTime,
+    };
+    const previousRestoreContext = lastRestoreContext.current;
+    lastRestoreContext.current = latestRestoreContext;
+
     if (activeRangeNavigation.current != undefined) {
       finishFrameNavigation();
       resetRenderedHistory();
@@ -227,12 +240,12 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
         manualSeekTime.current = undefined;
         setIsFrameNavigationPending(false);
         return;
-      case "manual-seek": {
-        const latestActiveData = selectActiveData(getMessagePipelineState());
+      case "manual-seek":
         if (
-          activeData != undefined &&
           latestActiveData != undefined &&
-          compare(activeData.currentTime, latestActiveData.currentTime) !== 0
+          previousRestoreContext.playerId === latestRestoreContext.playerId &&
+          previousRestoreContext.lastSeekTime != undefined &&
+          latestRestoreContext.lastSeekTime !== previousRestoreContext.lastSeekTime
         ) {
           manualSeekTime.current = latestActiveData.currentTime;
           currentMessagesRef.current = [];
@@ -240,12 +253,10 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
           manualSeekTime.current = undefined;
         }
         return;
-      }
       case "other-navigation":
         return;
     }
   }, [
-    activeData,
     clearSearchFeedback,
     currentMessagesRef,
     finishFrameNavigation,
@@ -258,7 +269,12 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
     (
       direction: FrameNavigationDirection,
       result: AdjacentMessagePathMatchResult,
-      context: { readonly rangeEndTime: Time; readonly wasPlaying: boolean },
+      context: {
+        readonly rangeStartTime: Time;
+        readonly rangeCurrentTime: Time;
+        readonly rangeEndTime: Time;
+        readonly wasPlaying: boolean;
+      },
     ) => {
       clearSearchFeedback();
       switch (result.type) {
@@ -277,14 +293,21 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
           seekPlayback?.(targetTime);
           return;
         }
-        case "notFound":
+        case "notFound": {
+          const latestActiveData = selectActiveData(getMessagePipelineState());
           if (direction === "previous") {
-            previousRangeExhausted.current = true;
-            markPreviousFrameUnavailable();
-          } else {
-            const latestActiveData = selectActiveData(getMessagePipelineState());
             if (
               latestActiveData != undefined &&
+              compare(latestActiveData.startTime, context.rangeStartTime) === 0 &&
+              compare(latestActiveData.currentTime, context.rangeCurrentTime) === 0
+            ) {
+              previousRangeExhausted.current = true;
+              markPreviousFrameUnavailable();
+            }
+          } else {
+            if (
+              latestActiveData != undefined &&
+              compare(latestActiveData.currentTime, context.rangeCurrentTime) === 0 &&
               compare(latestActiveData.endTime, context.rangeEndTime) === 0
             ) {
               nextRangeExhausted.current = true;
@@ -295,6 +318,7 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
             direction === "previous" ? noPreviousFrameMessage : noNextFrameMessage,
           );
           return;
+        }
         case "unsupported": {
           frameState.current = "current";
           clearFrozenMessages();
@@ -396,6 +420,8 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
       }
       activeRangeNavigation.current = undefined;
       handleRangeNavigationResult(direction, result, {
+        rangeStartTime: activeData.startTime,
+        rangeCurrentTime: activeData.currentTime,
         rangeEndTime: activeData.endTime,
         wasPlaying,
       });

--- a/packages/studio-base/src/hooks/useFrameNavigation.ts
+++ b/packages/studio-base/src/hooks/useFrameNavigation.ts
@@ -166,12 +166,10 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
     setFrameNavigationStatusMessage(undefined);
   }, []);
 
-  const cancelActiveRangeNavigation = useCallback((): boolean => {
-    const hadActiveRangeNavigation = activeRangeNavigation.current != undefined;
+  const cancelActiveRangeNavigation = useCallback(() => {
     activeRangeNavigation.current?.abort();
     activeRangeNavigation.current = undefined;
     clearSearchFeedback();
-    return hadActiveRangeNavigation;
   }, [clearSearchFeedback]);
 
   const finishFrameNavigation = useCallback(() => {
@@ -227,8 +225,17 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
     };
     const previousRestoreContext = lastRestoreContext.current;
     lastRestoreContext.current = latestRestoreContext;
+    const restoredAfterSeek =
+      latestActiveData != undefined &&
+      previousRestoreContext.playerId === latestRestoreContext.playerId &&
+      previousRestoreContext.lastSeekTime != undefined &&
+      latestRestoreContext.lastSeekTime !== previousRestoreContext.lastSeekTime;
 
     if (activeRangeNavigation.current != undefined) {
+      if (restoredAfterSeek) {
+        manualSeekTime.current = latestActiveData.currentTime;
+        currentMessagesRef.current = [];
+      }
       finishFrameNavigation();
       resetRenderedHistory();
       return;
@@ -241,12 +248,7 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
         setIsFrameNavigationPending(false);
         return;
       case "manual-seek":
-        if (
-          latestActiveData != undefined &&
-          previousRestoreContext.playerId === latestRestoreContext.playerId &&
-          previousRestoreContext.lastSeekTime != undefined &&
-          latestRestoreContext.lastSeekTime !== previousRestoreContext.lastSeekTime
-        ) {
+        if (restoredAfterSeek) {
           manualSeekTime.current = latestActiveData.currentTime;
           currentMessagesRef.current = [];
         } else {
@@ -441,13 +443,12 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
   );
 
   const handlePreviousFrame = useCallback(() => {
-    if (previousRangeExhausted.current) {
+    if (seekPlayback == undefined || previousRangeExhausted.current) {
       return;
     }
     if (
       subscribeMessageRange != undefined &&
       activeData != undefined &&
-      seekPlayback != undefined &&
       path.length > 0
     ) {
       const latestMessage = currentMessagesRef.current[currentMessagesRef.current.length - 1];
@@ -474,41 +475,35 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
 
   const handleNextFrame = useCallback(
     (currentMessages?: MessageAndData[]) => {
+      if (seekPlayback == undefined) {
+        return;
+      }
       if (nextRangeExhausted.current) {
+        setFrameNavigationStatusMessage(noNextFrameMessage);
         return;
       }
       if (frameState.current !== "current") {
         return;
       }
       if (currentMessages) {
-        const heldTime = currentMessagesRef.current.at(-1)?.messageEvent.receiveTime;
-        const holdsPlaybackCursor =
-          heldTime != undefined &&
-          activeData != undefined &&
-          compare(heldTime, activeData.currentTime) === 0;
-        const includesHeldTime = currentMessages.some(
-          (message) =>
-            heldTime != undefined && compare(message.messageEvent.receiveTime, heldTime) === 0,
-        );
-        if (!holdsPlaybackCursor || includesHeldTime) {
-          currentMessagesRef.current = currentMessages;
-        }
+        currentMessagesRef.current = getEffectiveMessages(currentMessages);
       }
 
       if (
         subscribeMessageRange != undefined &&
         activeData != undefined &&
-        seekPlayback != undefined &&
         path.length > 0
       ) {
         void runRangeFrameNavigation("next");
         return;
       }
 
-      runFallbackNextFrame(currentMessages);
+      runFallbackNextFrame(currentMessagesRef.current);
     },
     [
       activeData,
+      getEffectiveMessages,
+      noNextFrameMessage,
       path,
       runFallbackNextFrame,
       runRangeFrameNavigation,
@@ -548,9 +543,8 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
 
   useEffect(() => {
     return () => {
-      if (cancelActiveRangeNavigation() || frameState.current !== "current") {
-        frameNavigationNotifier.cancelNavigation(navigationId.current);
-      }
+      cancelActiveRangeNavigation();
+      frameNavigationNotifier.cancelNavigation(navigationId.current);
     };
   }, [cancelActiveRangeNavigation]);
 

--- a/packages/studio-base/src/hooks/useFrameNavigation.ts
+++ b/packages/studio-base/src/hooks/useFrameNavigation.ts
@@ -130,6 +130,7 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
     freezeCurrentMessages,
     clearFrozenMessages,
     holdNavigationMessages,
+    markPreviousFrameUnavailable,
     resetRenderedHistory,
     restoreFallbackState,
     runPreviousFrameFromRenderedHistory,
@@ -219,15 +220,28 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
   }, [clearSearchFeedback, finishFrameNavigation, resetRenderedHistory, restoreFallbackState]);
 
   const handleRangeNavigationResult = useCallback(
-    (direction: FrameNavigationDirection, result: AdjacentMessagePathMatchResult) => {
+    (
+      direction: FrameNavigationDirection,
+      result: AdjacentMessagePathMatchResult,
+      context: { readonly wasPlaying: boolean },
+    ) => {
       clearSearchFeedback();
       switch (result.type) {
-        case "found":
+        case "found": {
           currentMessagesRef.current = [result.message];
           holdNavigationMessages([result.message]);
-          seekPlayback?.(result.message.messageEvent.receiveTime);
+          const targetTime = result.message.messageEvent.receiveTime;
+          if (activeData != undefined && compare(targetTime, activeData.currentTime) === 0) {
+            onRestore();
+            return;
+          }
+          seekPlayback?.(targetTime);
           return;
+        }
         case "notFound":
+          if (direction === "previous") {
+            markPreviousFrameUnavailable();
+          }
           finishFrameNavigation();
           setFrameNavigationStatusMessage(
             direction === "previous" ? noPreviousFrameMessage : noNextFrameMessage,
@@ -244,6 +258,9 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
           if (!fallbackHandled) {
             resetRenderedHistory();
             frameNavigationNotifier.endNavigation(navigationId.current);
+            if (context.wasPlaying) {
+              startPlayback?.();
+            }
           }
           return;
         }
@@ -257,18 +274,22 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
       }
     },
     [
+      activeData,
       currentMessagesRef,
       clearFrozenMessages,
       clearSearchFeedback,
       enqueueSnackbar,
       finishFrameNavigation,
       holdNavigationMessages,
+      markPreviousFrameUnavailable,
       noNextFrameMessage,
       noPreviousFrameMessage,
+      onRestore,
       resetRenderedHistory,
       runFallbackNextFrame,
       runFallbackPreviousFrame,
       seekPlayback,
+      startPlayback,
     ],
   );
 
@@ -290,6 +311,7 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
       const fromTime =
         rangeFromTime ?? latestMessage?.messageEvent.receiveTime ?? activeData.currentTime;
       const controller = new AbortController();
+      const wasPlaying = activeData.isPlaying;
 
       beginRangeFrameNavigation(direction, controller);
       let searchFromTime = fromTime;
@@ -321,7 +343,7 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
         return;
       }
       activeRangeNavigation.current = undefined;
-      handleRangeNavigationResult(direction, result);
+      handleRangeNavigationResult(direction, result, { wasPlaying });
     },
     [
       activeData,

--- a/packages/studio-base/src/hooks/useFrameNavigation.ts
+++ b/packages/studio-base/src/hooks/useFrameNavigation.ts
@@ -227,14 +227,25 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
         manualSeekTime.current = undefined;
         setIsFrameNavigationPending(false);
         return;
-      case "manual-seek":
-        manualSeekTime.current = selectActiveData(getMessagePipelineState())?.currentTime;
-        currentMessagesRef.current = [];
+      case "manual-seek": {
+        const latestActiveData = selectActiveData(getMessagePipelineState());
+        if (
+          activeData != undefined &&
+          latestActiveData != undefined &&
+          compare(activeData.currentTime, latestActiveData.currentTime) !== 0
+        ) {
+          manualSeekTime.current = latestActiveData.currentTime;
+          currentMessagesRef.current = [];
+        } else {
+          manualSeekTime.current = undefined;
+        }
         return;
+      }
       case "other-navigation":
         return;
     }
   }, [
+    activeData,
     clearSearchFeedback,
     currentMessagesRef,
     finishFrameNavigation,
@@ -247,7 +258,7 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
     (
       direction: FrameNavigationDirection,
       result: AdjacentMessagePathMatchResult,
-      context: { readonly wasPlaying: boolean },
+      context: { readonly rangeEndTime: Time; readonly wasPlaying: boolean },
     ) => {
       clearSearchFeedback();
       switch (result.type) {
@@ -271,7 +282,13 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
             previousRangeExhausted.current = true;
             markPreviousFrameUnavailable();
           } else {
-            nextRangeExhausted.current = true;
+            const latestActiveData = selectActiveData(getMessagePipelineState());
+            if (
+              latestActiveData != undefined &&
+              compare(latestActiveData.endTime, context.rangeEndTime) === 0
+            ) {
+              nextRangeExhausted.current = true;
+            }
           }
           finishFrameNavigation();
           setFrameNavigationStatusMessage(
@@ -378,7 +395,10 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
         return;
       }
       activeRangeNavigation.current = undefined;
-      handleRangeNavigationResult(direction, result, { wasPlaying });
+      handleRangeNavigationResult(direction, result, {
+        rangeEndTime: activeData.endTime,
+        wasPlaying,
+      });
     },
     [
       activeData,

--- a/packages/studio-base/src/hooks/useFrameNavigation.ts
+++ b/packages/studio-base/src/hooks/useFrameNavigation.ts
@@ -446,11 +446,7 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
     if (seekPlayback == undefined || previousRangeExhausted.current) {
       return;
     }
-    if (
-      subscribeMessageRange != undefined &&
-      activeData != undefined &&
-      path.length > 0
-    ) {
+    if (subscribeMessageRange != undefined && activeData != undefined && path.length > 0) {
       const latestMessage = currentMessagesRef.current[currentMessagesRef.current.length - 1];
       const fromTime =
         manualSeekTime.current ?? latestMessage?.messageEvent.receiveTime ?? activeData.currentTime;
@@ -489,11 +485,7 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
         currentMessagesRef.current = getEffectiveMessages(currentMessages);
       }
 
-      if (
-        subscribeMessageRange != undefined &&
-        activeData != undefined &&
-        path.length > 0
-      ) {
+      if (subscribeMessageRange != undefined && activeData != undefined && path.length > 0) {
         void runRangeFrameNavigation("next");
         return;
       }

--- a/packages/studio-base/src/hooks/useFrameNavigation.ts
+++ b/packages/studio-base/src/hooks/useFrameNavigation.ts
@@ -151,6 +151,7 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
     startPlayback,
     pausePlayback,
     activeTimes: subscribeMessageRange != undefined && path.length > 0 ? activeTimes : undefined,
+    playbackTime: activeData?.currentTime,
   });
 
   const clearSearchFeedback = useCallback(() => {
@@ -480,6 +481,13 @@ export function useFrameNavigation(options: UseFrameNavigationOptions = {}): Fra
   const { panelRef, keyDownHandlers, keyUpHandlers } = useFrameNavigationKeyboard(keyboardActions);
 
   useEffect(() => {
+    if (
+      manualSeekTime.current != undefined &&
+      activeData != undefined &&
+      compare(manualSeekTime.current, activeData.currentTime) !== 0
+    ) {
+      manualSeekTime.current = undefined;
+    }
     nextRangeExhausted.current = false;
     previousRangeExhausted.current = false;
   }, [activeData?.currentTime.nsec, activeData?.currentTime.sec]);

--- a/packages/studio-base/src/hooks/useFrameNavigationKeyboard.ts
+++ b/packages/studio-base/src/hooks/useFrameNavigationKeyboard.ts
@@ -134,7 +134,17 @@ export function useFrameNavigationKeyboard(args: UseFrameNavigationKeyboardArgs)
   );
 
   useEffect(() => {
+    const stopRepeatOnKeyUp = (event: KeyboardEvent) => {
+      if (keyRepeatState.current.key === event.key || keyRepeatState.current.key === event.code) {
+        clearRepeatTimers();
+      }
+    };
+
+    document.addEventListener("keyup", stopRepeatOnKeyUp, true);
+    window.addEventListener("blur", clearRepeatTimers);
     return () => {
+      document.removeEventListener("keyup", stopRepeatOnKeyUp, true);
+      window.removeEventListener("blur", clearRepeatTimers);
       clearRepeatTimers();
     };
   }, [clearRepeatTimers]);

--- a/packages/studio-base/src/players/IterablePlayer/PrefetchingMessageCursor.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/PrefetchingMessageCursor.test.ts
@@ -164,6 +164,21 @@ describe("PrefetchingMessageCursor", () => {
     await expect(cursor.next()).resolves.toEqual(stamp(3));
   });
 
+  it("returns EOF from readUntil when the prefetched batch is exhausted", async () => {
+    const nextBatch = jest
+      .fn<Promise<IteratorResult[] | undefined>, [number]>()
+      .mockResolvedValueOnce([stamp(1)])
+      .mockResolvedValueOnce(undefined);
+    const readUntil = jest.fn(async () => []);
+    const underlying = { ...makeCursor(nextBatch), readUntil };
+    const cursor = new PrefetchingMessageCursor(underlying);
+
+    await cursor.nextBatch(100);
+
+    await expect(cursor.readUntil({ sec: 2, nsec: 0 } as Time)).resolves.toBeUndefined();
+    expect(readUntil).not.toHaveBeenCalled();
+  });
+
   it("delegates direct reads before batch prefetching starts", async () => {
     const nextBatch = jest
       .fn<Promise<IteratorResult[] | undefined>, [number]>()

--- a/packages/studio-base/src/players/IterablePlayer/PrefetchingMessageCursor.ts
+++ b/packages/studio-base/src/players/IterablePlayer/PrefetchingMessageCursor.ts
@@ -84,7 +84,8 @@ export class PrefetchingMessageCursor<
   }
 
   public async readUntil(end: Time): ReturnType<IMessageCursor<MessageType>["readUntil"]> {
-    this.#bufferPendingBatch(await this.#consumePendingBatch());
+    const pendingBatch = await this.#consumePendingBatch();
+    this.#bufferPendingBatch(pendingBatch);
 
     const results: IteratorResult<MessageType>[] = [];
     while (this.#bufferedResults.length > 0) {
@@ -93,6 +94,10 @@ export class PrefetchingMessageCursor<
         return results;
       }
       results.push(this.#bufferedResults.shift()!);
+    }
+
+    if (pendingBatch.status === "done") {
+      return results.length === 0 ? undefined : results;
     }
 
     const remainingResults = await this.#cursor.readUntil(end);


### PR DESCRIPTION
## Summary

- complete frame navigation locally when the matching frame is already at the player's current time
- resume playback after an unsupported previous-frame lookup when playback was active
- disable repeated previous-frame scans after the range boundary is exhausted

## Scope

This intentionally does not add another worker-cursor abort layer: Honeybee already propagates cancellation through its current iterable/cache path, so duplicating that Bombus compatibility fix here would add complexity without fixing an observed gap.

## Validation

- `yarn jest packages/studio-base/src/hooks/useFrameNavigation.test.tsx --runInBand`
- `yarn eslint --report-unused-disable-directives packages/studio-base/src/hooks/useFallbackFrameNavigation.ts packages/studio-base/src/hooks/useFrameNavigation.ts packages/studio-base/src/hooks/useFrameNavigation.test.tsx`
- `yarn run tsc --noEmit`
- Prettier and `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1412"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787211578&installation_model_id=425002&pr_number=1412&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1412&signature=0f9b6423a1d8718e8a2ccfb7bce7915c9ff33b4ce3974dca2da57da768d2e055"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->