### PR TITLE
Fix unnecessary timeline vertical scrolling

### DIFF
--- a/packages/studio-base/src/components/PlaybackControls/BagsOverlay.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/BagsOverlay.tsx
@@ -18,9 +18,11 @@ import {
   useTimelineInteractionState,
 } from "@foxglove/studio-base/context/TimelineInteractionStateContext";
 
+import { BAG_OVERLAY_HEIGHT_PX } from "./constants";
 import { type TimelineViewport, timelineRangeToStyle } from "./timelineViewport";
 
-export const BAG_OVERLAY_HEIGHT_PX: number = 12;
+export { BAG_OVERLAY_HEIGHT_PX } from "./constants";
+
 const BAG_TICK_HEIGHT_PX: number = 6;
 const BAG_TICK_HOVERED_HEIGHT_PX: number = 12;
 

--- a/packages/studio-base/src/components/PlaybackControls/EventsOverlay.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/EventsOverlay.tsx
@@ -42,11 +42,11 @@ import {
 } from "@foxglove/studio-base/context/TimelineInteractionStateContext";
 import { durationToSeconds } from "@foxglove/studio-base/util/time";
 
+import { EVENT_LANE_HEIGHT_PX } from "./constants";
 import {
   getEventLaneRenderStyle,
   layoutEventLanes,
   EVENT_BAR_HEIGHT_PX,
-  EVENT_LANE_HEIGHT_PX,
   type EventLaneLayout,
   type EventLaneLayoutItem,
 } from "./eventLanes";

--- a/packages/studio-base/src/components/PlaybackControls/Scrubber.test.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Scrubber.test.tsx
@@ -242,6 +242,30 @@ describe("<Scrubber />", () => {
     expect(eventLaneLayerTop).toBeGreaterThanOrEqual(28);
   });
 
+  it("does not reserve event-lane height when events are disabled", () => {
+    render(
+      <Wrapper>
+        <Scrubber onSeek={jest.fn()} />
+      </Wrapper>,
+    );
+
+    const timelineContent = screen.getByTestId("timeline-content");
+    expect(timelineContent.style.minHeight).toBe("26px");
+    expect(getComputedStyle(timelineContent.parentElement!).overflowY).toBe("auto");
+  });
+
+  it("reserves only the rendered event-lane height when events are enabled", async () => {
+    render(
+      <Wrapper eventEnabled>
+        <Scrubber onSeek={jest.fn()} />
+      </Wrapper>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("timeline-content").style.minHeight).toBe("58px");
+    });
+  });
+
   it("shows timeline loading while keyframe search is active", () => {
     render(
       <Wrapper>

--- a/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
@@ -57,7 +57,7 @@ import {
 import { useWorkspaceActions } from "@foxglove/studio-base/context/Workspace/useWorkspaceActions";
 import { PlayerPresence } from "@foxglove/studio-base/players/types";
 
-import { BAG_OVERLAY_HEIGHT_PX, BagsOverlay } from "./BagsOverlay";
+import { BagsOverlay } from "./BagsOverlay";
 import { EventsOverlay } from "./EventsOverlay";
 import { PlaybackBarHoverTicks } from "./PlaybackBarHoverTicks";
 import { PlaybackControlsTooltipContent } from "./PlaybackControlsTooltipContent";
@@ -66,7 +66,14 @@ import { ShortcutsHelpButton } from "./ShortcutsHelpButton";
 import Slider, { type ContextMenuEvent, type HoverOverEvent } from "./Slider";
 import { TIMELINE_POSITION_INDICATOR_HANDLE_HEIGHT_PX } from "./TimelinePositionIndicator";
 import TimelineScrollbar from "./TimelineScrollbar";
-import { layoutEventLanes, EVENT_LANE_HEIGHT_PX } from "./eventLanes";
+import {
+  BAG_OVERLAY_HEIGHT_PX,
+  EVENT_LANE_LAYER_TOP_PX,
+  getTimelineContentHeight,
+  SCRUBBER_TOOLBAR_HEIGHT_PX,
+  TIMELINE_RULER_HEIGHT_PX,
+} from "./constants";
+import { layoutEventLanes } from "./eventLanes";
 import { MOD, SHORTCUTS, ShortcutHint } from "./keyboardShortcuts";
 import { isTimelineKeyboardEvent } from "./timelineKeyboardFocus";
 import {
@@ -88,12 +95,6 @@ import MomentSubtitleInactiveIcon from "../../assets/moment-subtitle-inactive.sv
 import RollingEditActiveIcon from "../../assets/rolling-edit-active.svg";
 import RollingEditInactiveIcon from "../../assets/rolling-edit-inactive.svg";
 
-const SCRUBBER_TOOLBAR_HEIGHT_PX: number = 32;
-const TIMELINE_RULER_HEIGHT_PX: number = 14;
-const TIMELINE_BAG_TO_EVENT_GAP_PX: number = 4;
-const EVENT_LANE_LAYER_TOP_PX: number =
-  TIMELINE_RULER_HEIGHT_PX + BAG_OVERLAY_HEIGHT_PX + TIMELINE_BAG_TO_EVENT_GAP_PX;
-const MIN_TIMELINE_CONTENT_HEIGHT_PX: number = 90;
 // Synthetic wheel delta applied per Ctrl/Cmd +/- keypress, fed into zoomViewportAtTime.
 const ZOOM_KEY_WHEEL_DELTA: number = 300;
 const TIMELINE_TOOLTIP_OFFSET_PX: number = 8;
@@ -964,12 +965,11 @@ export default function Scrubber(props: Props): React.JSX.Element {
 
   const timelineContentHeight = useMemo((): number => {
     const effectiveEventLaneCount = previewEventLaneCount ?? eventLaneCount;
-
-    return Math.max(
-      MIN_TIMELINE_CONTENT_HEIGHT_PX,
-      EVENT_LANE_LAYER_TOP_PX + Math.max(effectiveEventLaneCount, 1) * EVENT_LANE_HEIGHT_PX,
-    );
-  }, [eventLaneCount, previewEventLaneCount]);
+    return getTimelineContentHeight({
+      eventLaneCount: effectiveEventLaneCount,
+      showEventLanes: resolvedViewport != undefined && enableList.event === "ENABLE",
+    });
+  }, [enableList.event, eventLaneCount, previewEventLaneCount, resolvedViewport]);
 
   const toggleRollingEdit = useCallback((): void => {
     setRollingEditEnabled((old) => !old);

--- a/packages/studio-base/src/components/PlaybackControls/TimelinePositionIndicator.test.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/TimelinePositionIndicator.test.tsx
@@ -25,6 +25,7 @@ describe("<TimelinePositionIndicator />", () => {
 
     expect(indicatorStyle.top).toBe("0px");
     expect(indicatorStyle.bottom).toBe("0px");
+    expect(indicatorStyle.overflow).toBe("hidden");
     expect(indicatorStyle.zIndex).toBe("4");
     expect(getComputedStyle(handle!).height).toBe("129px");
     expect(getComputedStyle(line).top).toBe("128px");

--- a/packages/studio-base/src/components/PlaybackControls/TimelinePositionIndicator.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/TimelinePositionIndicator.tsx
@@ -12,6 +12,7 @@ import { makeStyles } from "tss-react/mui";
 const useStyles = makeStyles()(() => ({
   root: {
     bottom: 0,
+    overflow: "hidden",
     pointerEvents: "none",
     position: "absolute",
     top: 0,

--- a/packages/studio-base/src/components/PlaybackControls/TimelineScrollbar.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/TimelineScrollbar.tsx
@@ -12,6 +12,7 @@ import { useResizeDetector } from "react-resize-detector";
 import { useLatest } from "react-use";
 import { makeStyles } from "tss-react/mui";
 
+import { TIMELINE_SCROLLBAR_HEIGHT_PX } from "./constants";
 import {
   getViewportScrollMetrics,
   type TimelineScrollMetrics,
@@ -21,7 +22,7 @@ import {
 // Horizontal scrollbar shown beneath the timeline while it is zoomed in. The thumb mirrors the
 // share of the recording currently visible; dragging it (or clicking the track) pans the viewport.
 
-export const TIMELINE_SCROLLBAR_HEIGHT_PX: number = 12;
+export { TIMELINE_SCROLLBAR_HEIGHT_PX } from "./constants";
 
 // Keep the thumb grabbable even when zoomed in so far that its true proportional width would be a
 // sliver. The drag math accounts for this widened thumb so panning still reaches both ends.

--- a/packages/studio-base/src/components/PlaybackControls/constants.ts
+++ b/packages/studio-base/src/components/PlaybackControls/constants.ts
@@ -10,3 +10,27 @@ export const TIMELINE_MIN_HEIGHT_PX = 126;
 
 /** Maximum height (px) of the bottom timeline / playback panel. */
 export const TIMELINE_MAX_HEIGHT_PX = 360;
+
+export const SCRUBBER_TOOLBAR_HEIGHT_PX = 32;
+export const TIMELINE_RULER_HEIGHT_PX = 14;
+export const BAG_OVERLAY_HEIGHT_PX = 12;
+export const TIMELINE_BAG_TO_EVENT_GAP_PX = 4;
+export const EVENT_LANE_HEIGHT_PX = 28;
+export const TIMELINE_SCROLLBAR_HEIGHT_PX = 12;
+
+export const EVENT_LANE_LAYER_TOP_PX =
+  TIMELINE_RULER_HEIGHT_PX + BAG_OVERLAY_HEIGHT_PX + TIMELINE_BAG_TO_EVENT_GAP_PX;
+
+export function getTimelineContentHeight({
+  eventLaneCount,
+  showEventLanes,
+}: {
+  eventLaneCount: number;
+  showEventLanes: boolean;
+}): number {
+  if (!showEventLanes) {
+    return TIMELINE_RULER_HEIGHT_PX + BAG_OVERLAY_HEIGHT_PX;
+  }
+
+  return EVENT_LANE_LAYER_TOP_PX + Math.max(eventLaneCount, 1) * EVENT_LANE_HEIGHT_PX;
+}

--- a/packages/studio-base/src/components/PlaybackControls/eventLanes.ts
+++ b/packages/studio-base/src/components/PlaybackControls/eventLanes.ts
@@ -11,10 +11,12 @@ import type React from "react";
 import { toSec } from "@foxglove/rostime";
 import type { TimelinePositionedEvent } from "@foxglove/studio-base/context/EventsContext";
 
+import { EVENT_LANE_HEIGHT_PX } from "./constants";
 import { timeToFraction, type TimelineViewport } from "./timelineViewport";
 
+export { EVENT_LANE_HEIGHT_PX } from "./constants";
+
 export const EVENT_LANE_OVERLAP_TOLERANCE_FRACTION: number = 0.002;
-export const EVENT_LANE_HEIGHT_PX: number = 28;
 export const EVENT_BAR_HEIGHT_PX: number = 24;
 export const EVENT_BAR_TOP_OFFSET_PX: number = 2;
 export const EVENT_MIN_WIDTH_PX: number = 4;


### PR DESCRIPTION
## Summary

- calculate timeline content height from the visible ruler, bag bar, and rendered event lanes
- avoid reserving event-lane height when the event feature is disabled
- contain the fixed-height timeline position indicator so it cannot expand the viewport's scrollable overflow
- centralize timeline sizing constants while preserving the existing exports

## Root cause

The timeline content had a fixed 90px minimum height even when less space was required. In addition, the current-time and hover indicators render a 129px SVG whose visible overflow expanded the parent viewport's scroll height. Together these produced a vertical scrollbar when all meaningful content already fit.

## Impact

The vertical scrollbar now appears only when event lanes genuinely exceed the available height. Multi-lane vertical scrolling remains enabled.

## Validation

- `yarn jest packages/studio-base/src/components/PlaybackControls/Scrubber.test.tsx packages/studio-base/src/components/PlaybackControls/TimelinePositionIndicator.test.tsx --runInBand`
- `yarn run tsc --noEmit`
- targeted ESLint for all changed TypeScript files
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787221407&installation_model_id=425002&pr_number=1413&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1413&signature=a098305e44f539e34a671aa1b88f6effb9f21ae6fe6235be92f2bc7cae5a570d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->