### PR TITLE
Upgrade idb to 8.0.3

### DIFF
--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -122,7 +122,7 @@
     "hammerjs": "2.0.8",
     "i18next": "26.3.1",
     "i18next-browser-languagedetector": "8.0.2",
-    "idb": "8.0.0",
+    "idb": "8.0.3",
     "idb-keyval": "6.2.1",
     "immer": "10.0.3",
     "intervals-fn": "3.0.3",

--- a/packages/studio-base/src/persistence/IndexedDbMessageStore.test.ts
+++ b/packages/studio-base/src/persistence/IndexedDbMessageStore.test.ts
@@ -13,6 +13,7 @@ import {
   type CacheSessionKind,
   type CacheSessionMetadata,
   clearIndexedDbMessageStoreDatabase,
+  indexedDbMessageCacheApi,
   IndexedDbMessageStore,
   LEGACY_MESSAGE_CACHE_DB_NAME,
   PLAYBACK_MESSAGE_CACHE_DB_NAME,
@@ -269,9 +270,11 @@ describe("IndexedDbMessageStore", () => {
   });
 
   it("rejects touchSession when IndexedDB open fails", async () => {
-    const openDBSpy = jest.spyOn(IDB, "openDB").mockImplementation(async () => {
-      throw new Error("open failed");
-    });
+    const openDBSpy = jest
+      .spyOn(indexedDbMessageCacheApi, "openDB")
+      .mockImplementation(async () => {
+        throw new Error("open failed");
+      });
     const store = new IndexedDbMessageStore({ sessionId: "touch-open-error" });
 
     try {
@@ -827,7 +830,7 @@ describe("IndexedDbMessageStore", () => {
       rejectTransaction?.(new Error("aborted stalled append transaction"));
     });
     const openDBSpy = jest
-      .spyOn(IDB, "openDB")
+      .spyOn(indexedDbMessageCacheApi, "openDB")
       .mockImplementation(async (...args: Parameters<typeof IDB.openDB>) => {
         const openedDb = await originalOpenDB(...args);
         if (args[0] !== REALTIME_MESSAGE_CACHE_DB_NAME) {
@@ -913,7 +916,7 @@ describe("IndexedDbMessageStore", () => {
       rejectTransaction?.(new Error("aborted stalled readonly transaction"));
     });
     const openDBSpy = jest
-      .spyOn(IDB, "openDB")
+      .spyOn(indexedDbMessageCacheApi, "openDB")
       .mockImplementation(async (...args: Parameters<typeof IDB.openDB>) => {
         const openedDb = await originalOpenDB(...args);
         if (args[0] !== PLAYBACK_MESSAGE_CACHE_DB_NAME) {
@@ -1535,7 +1538,7 @@ describe("IndexedDbMessageStore", () => {
     const originalOpenDB = IDB.openDB;
     let injectedFailure = false;
     const openDBSpy = jest
-      .spyOn(IDB, "openDB")
+      .spyOn(indexedDbMessageCacheApi, "openDB")
       .mockImplementation(async (...args: Parameters<typeof IDB.openDB>) => {
         const openedDb = await originalOpenDB(...args);
         if (args[0] !== PLAYBACK_MESSAGE_CACHE_DB_NAME) {
@@ -1656,7 +1659,7 @@ describe("IndexedDbMessageStore", () => {
     const originalOpenDB = IDB.openDB;
     let touchedAfterScan = false;
     const openDBSpy = jest
-      .spyOn(IDB, "openDB")
+      .spyOn(indexedDbMessageCacheApi, "openDB")
       .mockImplementation(async (...args: Parameters<typeof IDB.openDB>) => {
         const openedDb = await originalOpenDB(...args);
         if (touchedAfterScan || args[0] !== PLAYBACK_MESSAGE_CACHE_DB_NAME) {
@@ -1775,7 +1778,7 @@ describe("IndexedDbMessageStore", () => {
     await tx.done;
     v1.close();
 
-    const openDBSpy = jest.spyOn(IDB, "openDB");
+    const openDBSpy = jest.spyOn(indexedDbMessageCacheApi, "openDB");
     const store = new IndexedDbMessageStore({ sessionId: "new-realtime" });
     try {
       await store.init();
@@ -1812,7 +1815,7 @@ describe("IndexedDbMessageStore", () => {
     });
     const onBlocked = jest.fn();
     const secondOnBlocked = jest.fn();
-    const deleteDBSpy = jest.spyOn(IDB, "deleteDB");
+    const deleteDBSpy = jest.spyOn(indexedDbMessageCacheApi, "deleteDB");
 
     try {
       const cancelFirst = scheduleLegacyMessageCacheDatabaseDeletion({ onBlocked });
@@ -2049,7 +2052,7 @@ describe("IndexedDbMessageStore", () => {
       rejectTransaction?.(new Error("aborted stalled maintenance transaction"));
     });
     const openDBSpy = jest
-      .spyOn(IDB, "openDB")
+      .spyOn(indexedDbMessageCacheApi, "openDB")
       .mockImplementation(async (...args: Parameters<typeof IDB.openDB>) => {
         const openedDb = await originalOpenDB(...args);
         if (args[0] !== PLAYBACK_MESSAGE_CACHE_DB_NAME) {
@@ -2221,7 +2224,7 @@ describe("IndexedDbMessageStore", () => {
       rejectTransaction?.(new Error("aborted stalled maintenance retry scan"));
     });
     const openDBSpy = jest
-      .spyOn(IDB, "openDB")
+      .spyOn(indexedDbMessageCacheApi, "openDB")
       .mockImplementation(async (...args: Parameters<typeof IDB.openDB>) => {
         const openedDb = await originalOpenDB(...args);
         if (args[0] !== PLAYBACK_MESSAGE_CACHE_DB_NAME) {
@@ -2311,7 +2314,9 @@ describe("IndexedDbMessageStore", () => {
       resolveOpen = resolve;
     });
     const lateDb = { close: jest.fn() } as unknown as IDB.IDBPDatabase;
-    const openDBSpy = jest.spyOn(IDB, "openDB").mockImplementation(async () => await pendingOpen);
+    const openDBSpy = jest
+      .spyOn(indexedDbMessageCacheApi, "openDB")
+      .mockImplementation(async () => await pendingOpen);
     const store = new IndexedDbMessageStore({ sessionId: "late-open", openTimeoutMs: 10 });
 
     try {
@@ -2336,7 +2341,7 @@ describe("IndexedDbMessageStore", () => {
       rejectTransaction?.(new Error("aborted stalled initialization transaction"));
     });
     const openDBSpy = jest
-      .spyOn(IDB, "openDB")
+      .spyOn(indexedDbMessageCacheApi, "openDB")
       .mockImplementation(async (...args: Parameters<typeof IDB.openDB>) => {
         const db = await originalOpenDB(...args);
         return new Proxy(db, {
@@ -2397,7 +2402,7 @@ describe("IndexedDbMessageStore", () => {
     const originalOpenDB = IDB.openDB;
     const initializationError = new Error("message statistics failed");
     const openDBSpy = jest
-      .spyOn(IDB, "openDB")
+      .spyOn(indexedDbMessageCacheApi, "openDB")
       .mockImplementation(async (...args: Parameters<typeof IDB.openDB>) => {
         const db = await originalOpenDB(...args);
         return new Proxy(db, {
@@ -2444,7 +2449,7 @@ describe("IndexedDbMessageStore", () => {
     const statusError = new Error("closed status update failed");
     let sessionWriteTransactions = 0;
     const openDBSpy = jest
-      .spyOn(IDB, "openDB")
+      .spyOn(indexedDbMessageCacheApi, "openDB")
       .mockImplementation(async (...args: Parameters<typeof IDB.openDB>) => {
         const db = await originalOpenDB(...args);
         return new Proxy(db, {

--- a/packages/studio-base/src/persistence/IndexedDbMessageStore.ts
+++ b/packages/studio-base/src/persistence/IndexedDbMessageStore.ts
@@ -27,6 +27,11 @@ import type {
   PersistentMessageCacheAppendOptions,
 } from "./PersistentMessageCache";
 
+export const indexedDbMessageCacheApi = {
+  openDB: IDB.openDB,
+  deleteDB: IDB.deleteDB,
+};
+
 const log = Log.getLogger(__filename);
 
 export const LEGACY_MESSAGE_CACHE_DB_NAME = "studio-realtime-cache";
@@ -660,7 +665,7 @@ export class IndexedDbMessageStore implements PersistentMessageCache {
     const openStartedAt = performance.now();
     this.#initializationDeadlineAt = openStartedAt + openTimeoutMs;
     let openStage: "opening" | "blocked" | "upgrading" = "opening";
-    const rawDbPromise = IDB.openDB<MessagesDB>(this.#dbName, DB_VERSION, {
+    const rawDbPromise = indexedDbMessageCacheApi.openDB<MessagesDB>(this.#dbName, DB_VERSION, {
       upgrade: (db, oldVersion, _newVersion, transaction) => {
         openStage = "upgrading";
         this.#reportMetric("upgrade", { status: "started", oldVersion });
@@ -3916,9 +3921,9 @@ export function scheduleMessageCacheMaintenance(metricSink?: MessageCacheMetricS
 
 export async function clearIndexedDbMessageStoreDatabase(): Promise<void> {
   await Promise.all([
-    IDB.deleteDB(REALTIME_MESSAGE_CACHE_DB_NAME),
-    IDB.deleteDB(PLAYBACK_MESSAGE_CACHE_DB_NAME),
-    IDB.deleteDB(LEGACY_MESSAGE_CACHE_DB_NAME),
+    indexedDbMessageCacheApi.deleteDB(REALTIME_MESSAGE_CACHE_DB_NAME),
+    indexedDbMessageCacheApi.deleteDB(PLAYBACK_MESSAGE_CACHE_DB_NAME),
+    indexedDbMessageCacheApi.deleteDB(LEGACY_MESSAGE_CACHE_DB_NAME),
   ]);
 }
 
@@ -3959,34 +3964,36 @@ export function scheduleLegacyMessageCacheDatabaseDeletion(
       }
       task.phase = "running";
       task.cancelSchedule = undefined;
-      void IDB.deleteDB(LEGACY_MESSAGE_CACHE_DB_NAME, {
-        blocked(currentVersion) {
-          task!.blocked = true;
-          log.warn("Legacy message cache deletion is blocked by another tab", {
-            dbName: LEGACY_MESSAGE_CACHE_DB_NAME,
-            currentVersion,
-          });
-          for (const currentSubscriber of task!.subscribers) {
-            currentSubscriber.onBlocked?.();
-          }
-        },
-      }).then(
-        () => {
-          task!.phase = "settled";
-          task!.subscribers.clear();
-          log.info("Legacy message cache database deleted", {
-            dbName: LEGACY_MESSAGE_CACHE_DB_NAME,
-          });
-        },
-        (error: unknown) => {
-          task!.phase = "settled";
-          task!.subscribers.clear();
-          log.warn("Legacy message cache database deletion failed", {
-            dbName: LEGACY_MESSAGE_CACHE_DB_NAME,
-            error,
-          });
-        },
-      );
+      void indexedDbMessageCacheApi
+        .deleteDB(LEGACY_MESSAGE_CACHE_DB_NAME, {
+          blocked(currentVersion) {
+            task!.blocked = true;
+            log.warn("Legacy message cache deletion is blocked by another tab", {
+              dbName: LEGACY_MESSAGE_CACHE_DB_NAME,
+              currentVersion,
+            });
+            for (const currentSubscriber of task!.subscribers) {
+              currentSubscriber.onBlocked?.();
+            }
+          },
+        })
+        .then(
+          () => {
+            task!.phase = "settled";
+            task!.subscribers.clear();
+            log.info("Legacy message cache database deleted", {
+              dbName: LEGACY_MESSAGE_CACHE_DB_NAME,
+            });
+          },
+          (error: unknown) => {
+            task!.phase = "settled";
+            task!.subscribers.clear();
+            log.warn("Legacy message cache database deletion failed", {
+              dbName: LEGACY_MESSAGE_CACHE_DB_NAME,
+              error,
+            });
+          },
+        );
     };
 
     const { requestIdleCallback, cancelIdleCallback } = getIdleSchedulingGlobal();

--- a/yarn.lock
+++ b/yarn.lock
@@ -5512,7 +5512,7 @@ __metadata:
     hammerjs: 2.0.8
     i18next: 26.3.1
     i18next-browser-languagedetector: 8.0.2
-    idb: 8.0.0
+    idb: 8.0.3
     idb-keyval: 6.2.1
     immer: 10.0.3
     intervals-fn: 3.0.3
@@ -17669,10 +17669,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"idb@npm:8.0.0":
-  version: 8.0.0
-  resolution: "idb@npm:8.0.0"
-  checksum: a9c6176c176dc1a73520ae906d33fcda8a6f6068cf64027e196763d4ad70b088b7141650ed68f3604e0f0ccd1a123f6b8a435ba5e4514f42ada3460c23b6747a
+"idb@npm:8.0.3":
+  version: 8.0.3
+  resolution: "idb@npm:8.0.3"
+  checksum: e0f160be2b9a3b031db25a3bd134b5187f1b51d7e2cdc85a0e5ec62b0f635a7e37847d4888c9d919e7de1e9d8646a9390ce42d249b6a0b30d538c651ab1c3852
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- upgrade `idb` from 8.0.0 to 8.0.3
- route message-cache `openDB` and `deleteDB` calls through a small mutable API seam
- update IndexedDB fault-injection tests so they remain effective with the newer module export behavior
- refresh the Yarn lockfile

## Why

`idb` 8.0.3 exposes module exports in a way that prevents the existing `jest.spyOn(IDB, ...)` calls from intercepting cache operations. The compatibility seam preserves production behavior while keeping blocked, stalled, and rejected IndexedDB paths testable.

## Validation

- `yarn install --immutable`
- `yarn test packages/studio-base/src/persistence/IndexedDbMessageStore.test.ts --runInBand --silent` (64 tests)
- `yarn run tsc --noEmit`
- `yarn lint`
- `yarn format:check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787308529&installation_model_id=425002&pr_number=1414&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1414&signature=c3d21ae864ee336484d39481e888ba61629da2b129daed8e124ce611783c43e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->