### PR TITLE
docs: add data viewing methods and layout system reference

### DIFF
--- a/docs/data-viewing-and-layouts.md
+++ b/docs/data-viewing-and-layouts.md
@@ -129,7 +129,7 @@ A layout is a serializable workspace (`LayoutData`): mosaic arrangement, per-pan
 | --- | --- | --- |
 | Personal layout | `PERSONAL_WRITE` | Private workspace; may be created offline and synced later |
 | Project layout | `PROJECT_WRITE` | Shared project template; requires online access and project write permission |
-| Read-only project layout | `PROJECT_READ` | May be opened for viewing; client blocks overwrite save (compatibility) |
+| Read-only project layout | `PROJECT_READ` | May be opened for viewing; the current layout UI blocks overwrite save, while direct layout-manager callers must enforce read-only access |
 
 The create UI type selector currently offers **personal** and **project** (`PROJECT_WRITE`) only.
 
@@ -146,7 +146,6 @@ The create UI type selector currently offers **personal** and **project** (`PROJ
 | URL `layoutId` | Deep-link to an existing personal or project layout |
 | Layout history | Restore the last used layout |
 | Folders | Organization only; no permission change |
-| Desktop `~/.coStudio/layouts/*.json` | Local preset files on desktop |
 
 #### Shipped default and sample compositions
 

--- a/docs/data-viewing-and-layouts.md
+++ b/docs/data-viewing-and-layouts.md
@@ -1,0 +1,235 @@
+# Data Viewing Methods and Layout Support
+
+Product and engineering reference for honeybee (coScene Studio / bombus).
+
+This document inventories **how users view robotics data** in the application and **how the layout system supports those viewing methods**. Claims are grounded in the current codebase. Upstream Foxglove documentation is lineage only, not product authority for coScene.
+
+## Related documents
+
+| Document | Scope |
+| --- | --- |
+| [`docs/layouts.md`](./layouts.md) | Layout ownership, permissions, sync lifecycle |
+| `packages/studio-base/src/panels/index.ts` | Builtin panel catalog (`getBuiltin`) |
+| `packages/studio-base/src/services/CoSceneILayoutStorage.ts` | `LayoutPermission` model |
+
+---
+
+## Summary
+
+| Concept | Role |
+| --- | --- |
+| **Data viewing method** | A **panel** (or extension panel) that renders topics and messages—for example 3D, image, plot, table—or a small set of control/auxiliary panels that act on the data path |
+| **Layout** | A workspace that **arranges, configures, persists, shares, and pre-selects** panels; it does **not** define a separate visualization algorithm |
+
+Conceptual stack:
+
+```text
+Data source (file | connection | sample | persistent-cache | share-manifest)
+        → topics / messages
+Panels  → data viewing methods
+        ↑ arrangement, config, variables, user scripts
+Layout  → reusable workspace that supports those methods
+```
+
+---
+
+## 1. Data viewing methods
+
+### 1.1 Builtin panels
+
+Source: `getBuiltin()` in `packages/studio-base/src/panels/index.ts`  
+Display names: `packages/studio-base/src/i18n/{en,zh}/panels.ts`
+
+There are **23** builtin panel types (including Tab for organization):
+
+| # | Display name (EN / ZH) | Type id | Purpose |
+| --- | --- | --- | --- |
+| 1 | 3D / 三维 | `3D` | Markers, point clouds, meshes, URDFs, camera imagery in a 3D scene |
+| 2 | Image / 图像 | `Image` | Annotated images (implemented as the 3D renderer image mode) |
+| 3 | Plot / 图表 | `Plot` | Numerical series over time or another axis |
+| 4 | State Transitions / 状态转换 | `StateTransitions` | Discrete value changes over time |
+| 5 | Raw Messages / 原始消息 | `RawMessages` | Field-level topic message inspection |
+| 6 | Table / 表格 | `Table` | Tabular message browsing |
+| 7 | Log / 日志 | `RosOut` | Logs by node and severity |
+| 8 | Diagnostics – Detail (ROS) | `DiagnosticStatusPanel` | `DiagnosticArray` detail for a hardware id |
+| 9 | Diagnostics – Summary (ROS) | `DiagnosticSummary` | Summary of all diagnostic messages |
+| 10 | Map / 地图 | `map` | Geographic map with points / trajectories |
+| 11 | Gauge / 仪表 | `Gauge` | Continuous-value gauge |
+| 12 | Indicator / 指示器 | `Indicator` | Threshold-driven color/text status |
+| 13 | Data Source Info / 数据源信息 | `SourceInfo` | Topics, timestamps, and related source metadata |
+| 14 | Moments / 一刻 | `MomentsBar` | Moment/event cards (coScene) |
+| 15 | Topic Graph / 主题图 | `TopicGraph` | Graph of nodes, topics, and services |
+| 16 | Parameters / 参数 | `Parameters` | Read and write data-source parameters |
+| 17 | Publish / 发布 | `Publish` | Publish messages on live connections |
+| 18 | Service Call / 调用服务 | `CallService` | Invoke services and inspect results |
+| 19 | Teleop / 远程操纵 | `Teleop` | Live robot teleoperation |
+| 20 | Data Collection / 数据采集 | `DataCollection` | Live collection commands to device services (coScene) |
+| 21 | User Scripts / 用户脚本 | `NodePlayground` | TypeScript transforms that feed other panels |
+| 22 | Variable Slider / 变量滑块 | `GlobalVariableSliderPanel` | Layout-scoped numeric variables |
+| 23 | Tab / 选项卡 | `Tab` | Groups panels into tabs; does not render message data itself |
+
+#### Selection guide by task
+
+| Task | Preferred panels |
+| --- | --- |
+| Spatial / robot / point cloud / sensor frames | `3D` |
+| Camera frames and annotations | `Image` (cameras may also appear inside `3D`) |
+| Time-series metrics | `Plot` |
+| State machines / enums over time | `StateTransitions` |
+| Message content debugging | `RawMessages`, `Table` |
+| Logs and health | `RosOut`, `DiagnosticSummary`, `DiagnosticStatusPanel` |
+| Localization on a map | `map` |
+| Thresholds / status lights | `Gauge`, `Indicator` |
+| System topology | `TopicGraph`, `SourceInfo` |
+| Moments / events | `MomentsBar` |
+| Live interaction and capture | `Publish`, `CallService`, `Teleop`, `DataCollection`, `Parameters` |
+| Derived topics | `NodePlayground` plus downstream panels |
+
+### 1.2 Extension panels (optional)
+
+`PanelCatalogProvider` merges:
+
+1. Builtin panels from `getBuiltin`
+2. Panels registered by **installed extensions** (`type = {extensionName}.{registration.name}`)
+3. App-injected `extraPanels`
+
+Extension availability depends on deployment and tenant configuration. The fixed product catalog is the **23** builtin types above.
+
+### 1.3 Data sources (input path, not viewing methods)
+
+Data sources supply messages to panels. They are not visualization methods:
+
+| `DataSourceFactoryType` | Description |
+| --- | --- |
+| `file` | Local or remote files (for example MCAP) |
+| `connection` | Live connections |
+| `sample` | Sample datasets (may include a `sampleLayout`) |
+| `persistent-cache` | Playback from persistent cache |
+
+Share-manifest links additionally load shared data and, when present, a layout definition.
+
+---
+
+## 2. Layout support mechanisms
+
+A layout is a serializable workspace (`LayoutData`): mosaic arrangement, per-panel configuration, global variables, and user scripts. Ownership and sync details are in [`docs/layouts.md`](./layouts.md). This section focuses on how layouts support data viewing.
+
+### 2.1 Spatial arrangement
+
+| Mechanism | Support for viewing |
+| --- | --- |
+| Single panel | Full-screen focus on one method |
+| Row / column split (react-mosaic) | Side-by-side comparison (for example `3D` + `Image` + `Plot`) |
+| Nested splits | Multi-sensor dashboards |
+| `Tab` panel | Multi-page workflows within one layout |
+
+### 2.2 Ownership and sharing
+
+| Kind | Permission | Support for viewing |
+| --- | --- | --- |
+| Personal layout | `PERSONAL_WRITE` | Private workspace; may be created offline and synced later |
+| Project layout | `PROJECT_WRITE` | Shared project template; requires online access and project write permission |
+| Read-only project layout | `PROJECT_READ` | May be opened for viewing; client blocks overwrite save (compatibility) |
+
+The create UI type selector currently offers **personal** and **project** (`PROJECT_WRITE`) only.
+
+### 2.3 How a workspace is obtained
+
+| Mechanism | Support for viewing |
+| --- | --- |
+| Blank layout | Build any panel combination from scratch |
+| Copy / copy from project | Reuse panel placement and topic bindings |
+| Import / export JSON | Move complete workspaces across environments |
+| Builtin default layout | Fallback when none is selected (`3D` + `Image` + `RawMessages` by default; brand variants below) |
+| Sample layout | Sample data sources may ship a ready workspace (NuScenes uses tabs and multiple panels) |
+| Share-manifest transient layout | Apply a shared arrangement without storing a personal/project entry (`transient`) |
+| URL `layoutId` | Deep-link to an existing personal or project layout |
+| Layout history | Restore the last used layout |
+| Folders | Organization only; no permission change |
+| Desktop `~/.coStudio/layouts/*.json` | Local preset files on desktop |
+
+#### Shipped default and sample compositions
+
+| Artifact | Panel types used |
+| --- | --- |
+| `defaultLayout.ts` | `3D`, `Image`, `RawMessages` |
+| `defaultLayoutKeenon.ts` | `3D`, `Plot`, `RosOut` |
+| `defaultLayoutGaussian.ts` | `3D`, `Plot`, `RawMessages`, `RosOut` |
+| `SampleNuscenesLayout.json` | Includes `Tab`, `3D`, `Image`, `Plot`, `map`, diagnostics, `RawMessages` (14 panel instances) |
+
+### 2.4 Preferred / recommended layouts
+
+| Concept | i18n key | Notes |
+| --- | --- | --- |
+| Project preferred | `projectRecommandedLayout` | Intended default workspace at project scope |
+| Record preferred | `recordDefaultLayout` | Intended default for a single record; may be removed when switching records (layout manager comments) |
+
+**Known limitations (do not over-claim):**
+
+- App bar logic that ranked `isProjectRecommended` / `isRecordRecommended` and split “public layouts” is **currently commented out**.
+- “Public” / organization layout copy remains in i18n, but the permission model remains **personal vs project**—not a stable third ownership class.
+
+### 2.5 Edit lifecycle
+
+| State | Meaning |
+| --- | --- |
+| `baseline` | Last explicitly saved workspace |
+| `working` | Unsaved local edits |
+| Save / Revert | Commit or discard working changes |
+| Make personal copy | Move shared edits into a personal layout |
+
+---
+
+## 3. Mapping: viewing goals to layouts
+
+| Viewing goal | Typical panels | Layout support |
+| --- | --- | --- |
+| Single-sensor check | One `Image` or `3D` | Blank or personal single-panel layout |
+| Multi-camera + point cloud | Multiple `Image` + `3D` + `Plot` | Mosaic splits; often saved as a **project** layout |
+| Metrics + logs | `Plot` + `StateTransitions` + `RosOut` | Personal iteration, then copy to project |
+| Onboarding / sample tour | Sample data + sample layout | `sample` factory `sampleLayout` |
+| Share “view it this way” | Shared panel arrangement | Share-manifest **transient** layout plus data link |
+| Fixed deep-link board | Any stored layout | URL `layoutId` |
+| Non-empty first open | Default layout triad | Automatic default when no layout is selected |
+| Multi-page workflow | Multiple panel groups | `Tab` within one layout |
+| Derived then visualize | `NodePlayground` + consumers | Persist `userNodes` and panel configs in the layout |
+| Custom viz | Extension panel types | Same layout system; type ids are extension-qualified |
+
+**Principle:** Builtin and extension panels may appear in personal or project layouts. Layout permission controls **ownership and save/share**, not whether a panel type can render.
+
+---
+
+## 4. Boundaries and non-claims
+
+| Statement | Status |
+| --- | --- |
+| “A layout is a data viewing method” | **False.** Layouts are workspace containers; panels view data |
+| “Only personal and project layouts exist” | **Mostly true for create UX**; also: `PROJECT_READ`, transient share, default/sample |
+| “Public/organization is a third ownership type” | **Not a stable product claim** under the current permission model |
+| “Project/record preferred layouts are fully productized” | **Partial**—i18n and historical intent exist; ranking UI is commented |
+| “Extension panel count is fixed” | **False**—depends on installed extensions |
+
+---
+
+## 5. Source index
+
+| Topic | Path |
+| --- | --- |
+| Builtin panel catalog | `packages/studio-base/src/panels/index.ts` |
+| Panel display strings | `packages/studio-base/src/i18n/en/panels.ts`, `zh/panels.ts` |
+| Catalog merge (builtin + extension) | `packages/studio-base/src/providers/PanelCatalogProvider.tsx` |
+| Layout data shape | `packages/studio-base/src/context/CurrentLayoutContext/actions.ts` (`LayoutData`) |
+| Layout permissions | `packages/studio-base/src/services/CoSceneILayoutStorage.ts` (`LayoutPermission`) |
+| Default layouts | `packages/studio-base/src/providers/CurrentLayoutProvider/defaultLayout*.ts` |
+| Sample layout | `packages/studio-base/src/dataSources/SampleNuscenesLayout.json` |
+| Share-manifest layout | `packages/studio-base/src/components/ShareManifestLayoutSyncAdapter.tsx` |
+| Layout UI strings | `packages/studio-base/src/i18n/en/layout.ts`, `zh/layout.ts` |
+| Ownership reference | `docs/layouts.md` |
+
+---
+
+## 6. Executive brief
+
+**Data viewing methods** are the **panels** users add to a workspace: twenty-three builtin types covering spatial visualization, imagery, time series, message inspection, diagnostics, maps, live controls, scripts, and organization via tabs, plus optional extension panels.
+
+**Layouts support those methods** by composing panels into a reusable workspace: personal or project ownership, row/column and tab arrangement, default and sample templates, import/export, URL selection, share-manifest application, and save/revert of configuration. Layout type governs collaboration and persistence—not which visualization algorithms are available.

--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -1,0 +1,268 @@
+# Layout Types
+
+This document describes every **layout type** currently supported by honeybee (coScene Studio / bombus). A *layout* is a named, persistable arrangement of panels, panel configs, global variables, and user scripts used when visualizing data.
+
+For the inventory of **data viewing methods** (panels) and how layouts support them, see [`docs/data-viewing-and-layouts.md`](./data-viewing-and-layouts.md).
+
+Primary code references:
+
+| Area | Path |
+| --- | --- |
+| Permission model | `packages/studio-base/src/services/CoSceneILayoutStorage.ts` |
+| Layout manager API | `packages/studio-base/src/services/CoSceneILayoutManager.ts` |
+| Layout data shape | `packages/studio-base/src/context/CurrentLayoutContext/actions.ts` |
+| Mosaic / tab types | `packages/studio-base/src/types/layouts.ts` |
+| Create-layout UI | `packages/studio-base/src/components/CoSceneLayout/createLayout/` |
+| Layout browser UI | `packages/studio-base/src/components/CoSceneLayout/` |
+| Backend resource | `@coscene-io/cosceneapis-es-v2` → `Layout` + `LayoutScope` |
+
+---
+
+## 1. Core types by ownership / permission
+
+The product type system is `LayoutPermission`:
+
+```ts
+type LayoutPermission = "PERSONAL_WRITE" | "PROJECT_READ" | "PROJECT_WRITE";
+```
+
+This maps to the backend `LayoutScope`:
+
+| Frontend permission | Backend scope | Resource name pattern | Who can edit |
+| --- | --- | --- | --- |
+| `PERSONAL_WRITE` | `LAYOUT_SCOPE_PERSONAL` | `users/{user}/layouts/{layout}` | Owning user |
+| `PROJECT_WRITE` | `LAYOUT_SCOPE_PROJECT` | `warehouses/{wh}/projects/{project}/layouts/{layout}` | Project members with write permission |
+| `PROJECT_READ` | (project scope, read-only client flag) | project layout name pattern | **Read-only** in the client |
+
+### 1.1 Personal layout (`PERSONAL_WRITE`)
+
+- Owned by a single user.
+- Default type when creating a blank layout, importing a file, or duplicating into personal space.
+- Stored under the user parent (`users/{userId}`).
+- Can be created while offline (queued as `syncInfo.status = "new"` and synced later when online).
+- Shown under the **Personal** sidebar category in the layout drawer.
+- Icon: person.
+
+### 1.2 Project layout (`PROJECT_WRITE`)
+
+- Shared with all members of a project.
+- Requires remote layout storage (`supportsSharing`) and an online connection to create/share.
+- Creating/updating project layouts requires the corresponding Console API permission (`createProjectLayout` / `updateProjectLayout` / `deleteProjectLayout`).
+- Renames and folder moves for project layouts go directly to the server.
+- Shown under the **Project** sidebar category.
+- Icon: business / briefcase.
+
+### 1.3 Read-only project layout (`PROJECT_READ`)
+
+- Still part of the client type union.
+- Treated as project-scoped via `layoutIsProject()`, but `layoutIsRead()` disables rename, move, delete, and save-overwrite actions.
+- Not offered as a create option in the current create/copy dialogs (only `PERSONAL_WRITE` and `PROJECT_WRITE` appear in the **Type** selector).
+- Kept for compatibility with older shared/read layouts and permission checks.
+
+**Create-UI “Type” field (user-facing):**
+
+| Label | Value |
+| --- | --- |
+| Personal layout | `PERSONAL_WRITE` |
+| Project layout | `PROJECT_WRITE` (disabled when `supportsProjectWrite` is false) |
+
+---
+
+## 2. UI categories in the layout browser
+
+The layout drawer (`CoSceneLayoutContent`) filters by category, independent of folders:
+
+| Category | Filter | Notes |
+| --- | --- | --- |
+| **All layouts** | no permission filter | Default browse view |
+| **Personal** | `permission === "PERSONAL_WRITE"` | Includes personal folders |
+| **Project** | `layoutIsProject(layout)` | Includes both `PROJECT_WRITE` and `PROJECT_READ` |
+
+Older app-bar menu code also had sections for:
+
+| Section (i18n) | Meaning |
+| --- | --- |
+| Personal | User layouts |
+| Organization | Shared/org layouts when `supportsSharing` |
+| Public layouts | Shown for `AUTHENTICATED_USER` project role |
+
+> Note: logic that split **project preferred / record preferred** into a separate “public” list is currently commented out, but the i18n strings remain.
+
+---
+
+## 3. Preferred / recommended layout designations
+
+These are product concepts for *which* layout should open by default in a context. Strings exist in i18n:
+
+| i18n key | EN | ZH |
+| --- | --- | --- |
+| `projectRecommandedLayout` | Project preferred | 项目推荐布局 |
+| `recordDefaultLayout` | Record preferred | 记录推荐布局 |
+
+Behavior notes from the layout manager:
+
+- **Record preferred** layouts may be ephemeral: when the user opens another record, the layout can disappear from local storage. Updates that miss the layout in that window are expected (`// if this layout is record recommended layout, this error is expected`).
+- Historical UI priority (commented): record recommended weight `2`, project recommended weight `1`.
+
+They are designations / selection rules, not separate `LayoutPermission` values. The underlying layout is still personal or project-scoped.
+
+---
+
+## 4. Creation sources (how a layout enters the system)
+
+Supported ways to create or load a layout:
+
+| Source | Description | Typical permission |
+| --- | --- | --- |
+| **Create blank layout** | Empty `configById` / no panels | Personal (or project if allowed) |
+| **Copy from project** | Clone another project’s layout into personal or project | Chosen in dialog |
+| **Copy / duplicate existing** | Copy dialog or “make a personal copy” of a shared layout | Personal or project |
+| **Import from file** | Load a `.json` layout export | Personal or project |
+| **Export to file** | Download layout JSON (inverse of import) | n/a |
+| **Desktop folder load** | Desktop app loads `~/.coStudio/layouts/*.json` | Local default layouts |
+| **Built-in default** | `defaultLayout` (and brand variants such as Keenon / Gaussian) when nothing is selected | Not a saved remote layout |
+| **Sample data layout** | Data source factories may ship a `sampleLayout` (e.g. NuScenes) | Applied as current layout data |
+| **Share-manifest layout** | Transient layout from a share link / manifest (`share-manifest-layout`) | Transient, not persisted as personal/project |
+| **URL `layoutId`** | Deep link selects an existing layout by id | Existing personal/project layout |
+| **Layout history** | Last-used layout restored via local history (`getHistory` / `putHistory`) | Previous selection |
+
+### 4.1 Transient layouts
+
+Some layouts are applied as the *current* layout without becoming a normal managed personal/project entry:
+
+- **Share-manifest** layouts (`ShareManifestLayoutSyncAdapter`) use a fixed id `share-manifest-layout`, `transient: true`.
+- If the share manifest has no layout URL, a blank shared layout is still applied so the viewer is not empty.
+
+---
+
+## 5. Layout data model (what a layout *contains*)
+
+Regardless of ownership type, the serializable payload is `LayoutData`:
+
+```ts
+type LayoutData = {
+  configById: SavedProps;          // panel id → panel config
+  layout?: MosaicNode<string>;     // panel tree (react-mosaic)
+  globalVariables: GlobalVariables;
+  userNodes: UserScripts;          // user scripts / Node Playground
+  version?: number;                // reject older clients if too new
+};
+```
+
+### 5.1 Mosaic arrangement types
+
+The spatial tree (`layout`) supports:
+
+| Arrangement | Description |
+| --- | --- |
+| **Single panel** | Leaf node: one panel id string |
+| **Row split** | `direction: "row"` with `first` / `second` and `splitPercentage` |
+| **Column split** | `direction: "column"` with the same structure |
+| **Nested splits** | Arbitrary nesting of row/column branches |
+| **Tab panel** | Panel type `Tab` holding multiple named tabs, each with its own nested mosaic |
+
+Tab-related types (`TabConfig`, `TabPanelConfig`, `TabLocation`) live in `types/layouts.ts`.
+
+### 5.2 Baseline vs working copy
+
+Every managed `Layout` record has:
+
+| Field | Meaning |
+| --- | --- |
+| `baseline` | Last explicitly saved version (plus modifier metadata) |
+| `working` | Unsaved local edits since last save; `undefined` when clean |
+
+Unsaved layouts show a working indicator in the UI and offer **Save** / **Revert**.
+
+### 5.3 Sync status
+
+When remote storage is present, `syncInfo.status` can be:
+
+| Status | Meaning |
+| --- | --- |
+| `new` | Created locally, not yet uploaded |
+| `updated` | Local changes pending remote overwrite |
+| `tracked` | In sync with remote baseline |
+| `locally-deleted` | Marked deleted locally; remote delete pending |
+| `remotely-deleted` | Deleted on server; local copy may still show if working edits exist |
+
+---
+
+## 6. Folders
+
+Layouts of either personal or project type can live in a **folder** string:
+
+- Empty string = root of that category.
+- Folders are per-category (personal folders vs project folders).
+- Users can create a new folder name when saving, or **Move to folder** later.
+- Folders are organization metadata only; they do not change permission.
+
+---
+
+## 7. Permissions and capability matrix (summary)
+
+| Action | Personal write | Project write | Project read |
+| --- | --- | --- | --- |
+| Select / use | ✅ | ✅ | ✅ |
+| Edit panels (working copy) | ✅ | ✅ | ✅ (local working only; save blocked) |
+| Save / overwrite baseline | ✅ | ✅ (needs API + online) | ❌ |
+| Revert working | ✅ | ✅ | ✅ |
+| Rename | ✅ | ✅ (needs API) | ❌ |
+| Move folder | ✅ | ✅ (needs API) | ❌ |
+| Delete | ✅ | ✅ (needs API) | ❌ |
+| Export JSON | ✅ | ✅ | ✅ |
+| Copy to personal / project | ✅ | ✅ | ✅ |
+| Create offline | ✅ | ❌ | ❌ |
+
+Exact project write/delete availability is gated by Console API permission helpers and login/project context (`supportsProjectWrite`, role checks).
+
+---
+
+## 8. Brand / product default layout variants
+
+Built-in fallbacks used when no layout is selected (not user-managed types, but supported shipped layouts):
+
+| Module | Use |
+| --- | --- |
+| `defaultLayout.ts` | Default 3D + Image + Raw Messages arrangement |
+| `defaultLayoutKeenon.ts` | Keenon brand default |
+| `defaultLayoutGaussian.ts` | Gaussian brand default |
+
+---
+
+## 9. Quick glossary
+
+| Term | Definition |
+| --- | --- |
+| **Layout** | Named panel arrangement + configs + variables + scripts |
+| **Panel** | One visualization widget inside a layout (3D, Plot, Image, …) |
+| **Permission / scope** | Personal vs project ownership model |
+| **Folder** | Optional grouping within personal or project |
+| **Baseline** | Last saved remote/local version |
+| **Working** | Unsaved edits |
+| **Preferred (project/record)** | Default-selection designation for a project or a record |
+| **Transient layout** | Applied for a session/share without normal persistence |
+| **Mosaic** | Tree that describes row/column panel splits |
+
+---
+
+## 10. What is *not* a separate layout type
+
+These are easy to confuse with layout types but are different concepts:
+
+- **Panel types** (3D, Plot, Log, Tab, Map, …) — contents of a layout, not ownership types.
+- **Data sources** (file, connection, sample, persistent-cache) — how data is loaded, not layouts.
+- **Layout view** (`BASIC` vs `FULL` in the backend API) — whether metadata-only or full data is returned; not a user-facing layout kind.
+
+---
+
+## Changelog notes for maintainers
+
+When adding a new layout type, update:
+
+1. `LayoutPermission` (and helpers) if ownership semantics change.
+2. Backend `LayoutScope` mapping in `CoSceneConsoleApiRemoteLayoutStorage`.
+3. Create/copy dialogs **Type** selectors.
+4. Layout browser filters and icons.
+5. i18n keys under `layout` namespace (`en` / `zh` / `ja` as applicable).
+6. This document.

--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -32,14 +32,14 @@ This maps to the backend `LayoutScope`:
 | --- | --- | --- | --- |
 | `PERSONAL_WRITE` | `LAYOUT_SCOPE_PERSONAL` | `users/{user}/layouts/{layout}` | Owning user |
 | `PROJECT_WRITE` | `LAYOUT_SCOPE_PROJECT` | `warehouses/{wh}/projects/{project}/layouts/{layout}` | Project members with write permission |
-| `PROJECT_READ` | (project scope, read-only client flag) | project layout name pattern | **Read-only** in the client |
+| `PROJECT_READ` | (project scope, read-only client flag) | project layout name pattern | The current layout UI hides or disables editing |
 
 ### 1.1 Personal layout (`PERSONAL_WRITE`)
 
 - Owned by a single user.
 - Default type when creating a blank layout, importing a file, or duplicating into personal space.
-- Stored under the user parent (`users/{userId}`).
-- Can be created while offline (queued as `syncInfo.status = "new"` and synced later when online).
+- When a user is loaded, stored under the user parent (`users/{userId}`).
+- Can be created while offline (queued as `syncInfo.status = "new"` and synced later when online). If no user is loaded yet, the local record has an empty parent and an id such as `/layouts/{layout}` until synchronization assigns its remote user parent.
 - Shown under the **Personal** sidebar category in the layout drawer.
 - Icon: person.
 
@@ -55,7 +55,8 @@ This maps to the backend `LayoutScope`:
 ### 1.3 Read-only project layout (`PROJECT_READ`)
 
 - Still part of the client type union.
-- Treated as project-scoped via `layoutIsProject()`, but `layoutIsRead()` disables rename, move, delete, and save-overwrite actions.
+- Treated as project-scoped via `layoutIsProject()`. Current layout UI call sites use `layoutIsRead()` to disable rename, move, delete, and save-overwrite actions.
+- `CoSceneLayoutManager.overwriteLayout()` does not itself reject `PROJECT_READ`; callers outside those UI paths must enforce the read-only permission before invoking manager mutations.
 - Not offered as a create option in the current create/copy dialogs (only `PERSONAL_WRITE` and `PROJECT_WRITE` appear in the **Type** selector).
 - Kept for compatibility with older shared/read layouts and permission checks.
 
@@ -119,7 +120,6 @@ Supported ways to create or load a layout:
 | **Copy / duplicate existing** | Copy dialog or “make a personal copy” of a shared layout | Personal or project |
 | **Import from file** | Load a `.json` layout export | Personal or project |
 | **Export to file** | Download layout JSON (inverse of import) | n/a |
-| **Desktop folder load** | Desktop app loads `~/.coStudio/layouts/*.json` | Local default layouts |
 | **Built-in default** | `defaultLayout` (and brand variants such as Keenon / Gaussian) when nothing is selected | Not a saved remote layout |
 | **Sample data layout** | Data source factories may ship a `sampleLayout` (e.g. NuScenes) | Applied as current layout data |
 | **Share-manifest layout** | Transient layout from a share link / manifest (`share-manifest-layout`) | Transient, not persisted as personal/project |

--- a/packages/studio-base/src/panels/getBuiltin.dataViewingDoc.test.ts
+++ b/packages/studio-base/src/panels/getBuiltin.dataViewingDoc.test.ts
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import fs from "fs";
+import path from "path";
+
+import {
+  layoutPermissionIsProject,
+  layoutPermissionIsRead,
+} from "@foxglove/studio-base/services/CoSceneILayoutStorage";
+import { TAB_PANEL_TYPE } from "@foxglove/studio-base/util/globalConstants";
+
+import { getBuiltin } from "./index";
+
+/**
+ * Grounds docs/data-viewing-and-layouts.md in the real builtin panel catalog
+ * and in layout ownership constants used by the product.
+ */
+describe("data viewing methods + layout support (doc inventory)", () => {
+  const identityT = ((key: string) => key) as unknown as Parameters<typeof getBuiltin>[0];
+
+  it("exposes every builtin panel type via getBuiltin (shipped catalog)", () => {
+    const panels = getBuiltin(identityT);
+    const types = panels.map((p) => p.type).sort();
+
+    // Explicit inventory matching docs/data-viewing-and-layouts.md §A.1
+    const expected = [
+      "3D",
+      "CallService",
+      "DataCollection",
+      "DiagnosticStatusPanel",
+      "DiagnosticSummary",
+      "Gauge",
+      "GlobalVariableSliderPanel",
+      "Image",
+      "Indicator",
+      "NodePlayground",
+      "Parameters",
+      "Plot",
+      "Publish",
+      "RawMessages",
+      "RosOut",
+      "SourceInfo",
+      "StateTransitions",
+      "Table",
+      "Teleop",
+      "TopicGraph",
+      "map",
+      "MomentsBar",
+      TAB_PANEL_TYPE,
+    ].sort();
+
+    expect(types).toEqual(expected);
+    expect(types).toHaveLength(23);
+    expect(TAB_PANEL_TYPE).toBe("Tab");
+  });
+
+  it("documents each builtin type and core layout permissions in data-viewing-and-layouts.md", () => {
+    const docPath = path.resolve(__dirname, "../../../../docs/data-viewing-and-layouts.md");
+    expect(fs.existsSync(docPath)).toBe(true);
+    const doc = fs.readFileSync(docPath, "utf8");
+
+    for (const panel of getBuiltin(identityT)) {
+      expect(doc).toContain(`\`${panel.type}\``);
+    }
+
+    // Layout support mechanisms called out in the answer doc
+    for (const token of [
+      "PERSONAL_WRITE",
+      "PROJECT_WRITE",
+      "PROJECT_READ",
+      "share-manifest",
+      "sampleLayout",
+      "layoutId",
+      "defaultLayout",
+      "projectRecommandedLayout",
+      "recordDefaultLayout",
+    ]) {
+      expect(doc).toContain(token);
+    }
+
+    // Must separate viewing methods from layout support (document structure)
+    expect(doc).toMatch(/Data Viewing Methods/);
+    expect(doc).toMatch(/Layout support/i);
+    expect(doc).toMatch(/Mapping: viewing goals to layouts/);
+  });
+
+  it("keeps LayoutPermission union aligned with documented ownership types", () => {
+    // Runtime helpers encode the same personal vs project ownership set documented above.
+    expect(layoutPermissionIsProject("PROJECT_WRITE")).toBe(true);
+    expect(layoutPermissionIsProject("PROJECT_READ")).toBe(true);
+    expect(layoutPermissionIsProject("PERSONAL_WRITE")).toBe(false);
+    expect(layoutPermissionIsRead("PROJECT_READ")).toBe(true);
+    expect(layoutPermissionIsRead("PROJECT_WRITE")).toBe(false);
+    expect(layoutPermissionIsRead("PERSONAL_WRITE")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds an engineering/product reference for **how users view data** (builtin panels and optional extensions) and **how the layout system supports those methods** (ownership, arrangement, defaults, sample/share paths).
- Adds a companion **layout types** document covering personal/project permissions, sync states, and acquisition paths.
- Adds a small inventory test that binds `getBuiltin` panel types and layout permission helpers to the viewing-methods document so the catalog cannot drift silently.

## Documents

| Path | Contents |
| --- | --- |
| `docs/data-viewing-and-layouts.md` | Data viewing methods + layout support mapping |
| `docs/layouts.md` | Layout ownership, permissions, sync lifecycle |

## Test plan

- [x] `yarn jest packages/studio-base/src/panels/getBuiltin.dataViewingDoc.test.ts --runInBand`
- [x] `yarn eslint --config eslint.config.ci.cjs packages/studio-base/src/panels/getBuiltin.dataViewingDoc.test.ts`
- [ ] Skim docs for accuracy against current panel catalog and layout UI

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787333887&installation_model_id=425002&pr_number=1416&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1416&signature=6a9ade57cadc44eba0678057fe991585e1b9b4c0e837f70b38998369f3308242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->