### PR TITLE
perf(studio): window and compact state transitions

### DIFF
--- a/packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.ts
+++ b/packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.ts
@@ -205,9 +205,7 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
         );
       });
 
-    if (seriesChanged || showPointsChanged) {
-      // showPoints changes the required ingestion representation. Rebuild from cached blocks so
-      // enabling it can restore every raw sample rather than displaying already-collapsed data.
+    if (seriesChanged) {
       this.#blockCursors.clear();
       this.#fullData.clear();
       this.#currentData.clear();
@@ -215,6 +213,33 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
       this.#seriesIsArray.clear();
       this.#firstBlockRefs.clear();
       this.#lastBlockRefs.clear();
+      this.#latestBlocks = undefined; // Force reprocessing of blocks
+    } else if (showPointsChanged) {
+      // Rebuild preloaded history from cached blocks in the new representation, but retain live
+      // history because streaming-only sources have no blocks from which it can be reconstructed.
+      this.#blockCursors.clear();
+      this.#fullData.clear();
+      this.#processedDataCache.clear();
+
+      // Keep block references consistent with cursor 0 so the representation-only rebuild does
+      // not look like a data-source reset and clear the retained streaming history.
+      for (const series of newSeries) {
+        const cursorKey = `${series.configIndex}:${series.parsed.topicName}`;
+        const firstBlockRef = this.#latestBlocks?.[0]?.messagesByTopic[series.parsed.topicName];
+        this.#firstBlockRefs.set(cursorKey, firstBlockRef);
+        this.#lastBlockRefs.set(cursorKey, firstBlockRef);
+
+        if (!this.#showPoints) {
+          const currentData = this.#currentData.get(cursorKey);
+          if (currentData != undefined) {
+            const collapsed: Datum[] = [];
+            for (const datum of currentData) {
+              appendCollapsedStateSample(collapsed, datum);
+            }
+            this.#currentData.set(cursorKey, collapsed);
+          }
+        }
+      }
       this.#latestBlocks = undefined; // Force reprocessing of blocks
     }
 
@@ -339,7 +364,7 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
           if (datum) {
             // Collapse consecutive equal values at ingestion (REI-125): high-rate
             // joint/state topics often plateaus; storing every sample ballooned memory.
-            if (this.#showPoints) {
+            if (this.#showPoints || series.path.timestampMethod === "headerStamp") {
               existingData.push(datum);
             } else {
               appendCollapsedStateSample(existingData, datum);
@@ -350,6 +375,19 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
         // Update last block reference after processing each block
         this.#lastBlockRefs.set(cursorKey, messagesForTopic);
         cursor = blockIdx + 1;
+      }
+
+      if (series.path.timestampMethod === "headerStamp") {
+        // Blocks are receive-time ordered, but header stamps can move backwards. Normalize before
+        // any binary viewport slicing; otherwise valid transitions can be omitted from the window.
+        existingData.sort((a, b) => a.x - b.x);
+        if (!this.#showPoints) {
+          const collapsed: Datum[] = [];
+          for (const datum of existingData) {
+            appendCollapsedStateSample(collapsed, datum);
+          }
+          existingData.splice(0, existingData.length, ...collapsed);
+        }
       }
 
       this.#blockCursors.set(cursorKey, cursor);
@@ -729,7 +767,7 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
     // Include head/tail so plateau endpoint mutation (same length) still busts the cache.
     const fingerprint = processCacheFingerprint(data, y, viewMin, viewMax);
     const cached = this.#processedDataCache.get(cacheKey);
-    if (cached && cached.fingerprint === fingerprint) {
+    if (cached?.fingerprint === fingerprint) {
       return cached.data;
     }
 

--- a/packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.ts
+++ b/packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.ts
@@ -41,6 +41,11 @@ import { StateTransitionsRenderer } from "./StateTransitionsRenderer";
 import { Viewport } from "./downsampleStates";
 import positiveModulo from "./positiveModulo";
 import { PathState } from "./settings";
+import {
+  appendCollapsedStateSample,
+  processCacheFingerprint,
+  sliceMergedStateDataForViewport,
+} from "./stateTransitionData";
 import { StateTransitionConfig, StateTransitionPath, Datum } from "./types";
 
 type EventTypes = {
@@ -127,8 +132,9 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
   #fullData = new Map<string, Datum[]>(); // Preloaded block data (complete history)
   #currentData = new Map<string, Datum[]>(); // Streaming data (real-time)
 
-  // Cache for processed data to avoid reprocessing unchanged data
-  #processedDataCache = new Map<string, { data: Datum[]; inputLength: number; y: number }>();
+  // Cache for processed data to avoid reprocessing unchanged data.
+  // Fingerprint includes trailing endpoint so in-place plateau extension invalidates.
+  #processedDataCache = new Map<string, { data: Datum[]; fingerprint: string }>();
 
   // Track which series have detected array input (invalid for StateTransitions)
   #seriesIsArray = new Map<string, boolean>();
@@ -199,7 +205,9 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
         );
       });
 
-    if (seriesChanged) {
+    if (seriesChanged || showPointsChanged) {
+      // showPoints changes the required ingestion representation. Rebuild from cached blocks so
+      // enabling it can restore every raw sample rather than displaying already-collapsed data.
       this.#blockCursors.clear();
       this.#fullData.clear();
       this.#currentData.clear();
@@ -208,11 +216,6 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
       this.#firstBlockRefs.clear();
       this.#lastBlockRefs.clear();
       this.#latestBlocks = undefined; // Force reprocessing of blocks
-    } else if (showPointsChanged) {
-      // showPoints affects how data is processed: when true, all points are emitted;
-      // when false, only state-change points are emitted. Invalidate the processed
-      // cache to ensure the UI reflects the new setting immediately.
-      this.#processedDataCache.clear();
     }
 
     this.#series = newSeries;
@@ -323,20 +326,24 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
       const existingData = this.#fullData.get(cursorKey) ?? [];
 
       for (let blockIdx = cursor; blockIdx < blocks.length; blockIdx++) {
-        const block = blocks[blockIdx];
-        if (!block) {
-          continue;
-        }
-
-        const messagesForTopic = block.messagesByTopic[topicName];
-        if (!messagesForTopic) {
-          continue;
+        const messagesForTopic = blocks[blockIdx]?.messagesByTopic[topicName];
+        if (messagesForTopic == undefined) {
+          // Gap: stop here instead of skipping ahead. Advancing the cursor past an unloaded block
+          // would permanently drop its history once it loads *behind* the cursor, leaving a silent
+          // hole in the plot. Matches Plot's BlockTopicCursor semantics (REI-125 review).
+          break;
         }
 
         for (const msgEvent of messagesForTopic) {
           const datum = this.#messageEventToDatum(msgEvent, series, startTime);
           if (datum) {
-            existingData.push(datum);
+            // Collapse consecutive equal values at ingestion (REI-125): high-rate
+            // joint/state topics often plateaus; storing every sample ballooned memory.
+            if (this.#showPoints) {
+              existingData.push(datum);
+            } else {
+              appendCollapsedStateSample(existingData, datum);
+            }
           }
         }
 
@@ -347,6 +354,9 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
 
       this.#blockCursors.set(cursorKey, cursor);
       this.#fullData.set(cursorKey, existingData);
+      // Record blocks[0] every pass, not only on reset. Leaving it unset made the *second* pass
+      // always see "first block changed" and wipe + reprocess the whole series once (REI-125).
+      this.#firstBlockRefs.set(cursorKey, blocks[0]?.messagesByTopic[topicName]);
 
       // After updating fullData, trim currentData to remove duplicates
       this.#trimCurrentData(cursorKey);
@@ -435,6 +445,19 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
 
         const currentData = this.#currentData.get(cursorKey) ?? [];
 
+        // Streaming path is usually already sorted by time; collapse plateaus when
+        // appending to the end (common case). Fall back to ordered insert otherwise.
+        const last = currentData[currentData.length - 1];
+        if (last == undefined || datum.x > last.x) {
+          if (this.#showPoints) {
+            currentData.push(datum);
+          } else {
+            appendCollapsedStateSample(currentData, datum);
+          }
+          this.#currentData.set(cursorKey, currentData);
+          continue;
+        }
+
         // Check for duplicates in currentData using binary search position
         const insertPos = this.#findInsertPosition(currentData, datum.x);
 
@@ -446,7 +469,7 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
           continue;
         }
 
-        // Insert in sorted order
+        // Insert in sorted order (rare out-of-order stream); skip collapse here.
         currentData.splice(insertPos, 0, datum);
         this.#currentData.set(cursorKey, currentData);
       }
@@ -470,32 +493,6 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
     }
 
     return low;
-  }
-
-  /**
-   * Merge fullData and currentData for a given series.
-   * fullData has priority - currentData only includes points after fullData's last point.
-   */
-  #getMergedData(cursorKey: string): Datum[] {
-    const fullData = this.#fullData.get(cursorKey) ?? [];
-    const currentData = this.#currentData.get(cursorKey) ?? [];
-
-    if (currentData.length === 0) {
-      return fullData;
-    }
-
-    if (fullData.length === 0) {
-      return currentData;
-    }
-
-    // Get the last timestamp from fullData
-    const lastFullX = fullData[fullData.length - 1]?.x ?? -Infinity;
-
-    // Filter currentData to only include points after fullData
-    const filteredCurrent = currentData.filter((datum) => datum.x > lastFullX);
-
-    // Concatenate: fullData first, then currentData
-    return [...fullData, ...filteredCurrent];
   }
 
   /**
@@ -630,17 +627,55 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
     const datasets: Dataset[] = [];
     let minY: number | undefined;
 
+    // Resolve x bounds first so we can window-process only the visible range (REI-125).
+    if (this.#followRange != undefined && this.#currentSeconds != undefined) {
+      this.#configBounds.x = {
+        min: this.#currentSeconds - this.#followRange,
+        max: this.#currentSeconds,
+      };
+    } else {
+      this.#configBounds.x = {
+        min: this.#config.xAxisMinValue ?? 0,
+        max: this.#config.xAxisMaxValue ?? this.#datasetRange?.max,
+      };
+    }
+
+    // Prefer interaction / global bounds when set (zoom/pan/sync).
+    const viewMin =
+      this.#interactionBounds?.x.min ?? this.#globalBounds?.min ?? this.#configBounds.x.min ?? 0;
+    const viewMax =
+      this.#interactionBounds?.x.max ??
+      this.#globalBounds?.max ??
+      this.#configBounds.x.max ??
+      viewMin + 1;
+    // Pad the window so pan/edge segments stay connected without processing the full bag.
+    const viewPad = Math.max(0, (viewMax - viewMin) * 0.25);
+    const sliceMin = viewMin - viewPad;
+    const sliceMax = viewMax + viewPad;
+
     for (const series of this.#series) {
       const y = this.#getYForSeries(series.configIndex);
       minY = Math.min(minY ?? y, y - 5);
 
       const cursorKey = `${series.configIndex}:${series.parsed.topicName}`;
 
-      // Merge fullData and currentData
-      const data = this.#getMergedData(cursorKey);
+      // Window to the viewport *while* merging fullData and currentData. Materializing the merge
+      // first copied the whole preloaded history on every rebuild (REI-125 review).
+      const data = sliceMergedStateDataForViewport(
+        this.#fullData.get(cursorKey) ?? [],
+        this.#currentData.get(cursorKey) ?? [],
+        sliceMin,
+        sliceMax,
+      );
 
       // Process data to create state transition segments (with caching)
-      const processedData = this.#processDataForStateTransitions(data, y, cursorKey);
+      const processedData = this.#processDataForStateTransitions(
+        data,
+        y,
+        cursorKey,
+        sliceMin,
+        sliceMax,
+      );
 
       const dataset: Dataset = {
         borderWidth: 10,
@@ -661,19 +696,6 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
     this.#configBounds.y = { min: minY, max: -3 };
     this.#updateAction.yBounds = this.#configBounds.y;
 
-    // Update x bounds with follow mode
-    if (this.#followRange != undefined && this.#currentSeconds != undefined) {
-      this.#configBounds.x = {
-        min: this.#currentSeconds - this.#followRange,
-        max: this.#currentSeconds,
-      };
-    } else {
-      this.#configBounds.x = {
-        min: this.#config.xAxisMinValue ?? 0,
-        max: this.#config.xAxisMaxValue ?? this.#datasetRange?.max,
-      };
-    }
-
     // Build pathState from all config.paths (including unparseable ones)
     // This ensures settings panel reflects all paths with updated isArray status
     const pathState: PathState[] = this.#config.paths.map((path, index) => {
@@ -693,14 +715,21 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
    * Process raw data into state transition format (only show state changes).
    * Uses caching to avoid reprocessing unchanged data.
    */
-  #processDataForStateTransitions(data: Datum[], y: number, cacheKey: string): Datum[] {
+  #processDataForStateTransitions(
+    data: Datum[],
+    y: number,
+    cacheKey: string,
+    viewMin: number,
+    viewMax: number,
+  ): Datum[] {
     if (data.length === 0) {
       return [];
     }
 
-    // Check cache - if data length and y are the same, reuse cached result
+    // Include head/tail so plateau endpoint mutation (same length) still busts the cache.
+    const fingerprint = processCacheFingerprint(data, y, viewMin, viewMax);
     const cached = this.#processedDataCache.get(cacheKey);
-    if (cached?.inputLength === data.length && cached.y === y) {
+    if (cached && cached.fingerprint === fingerprint) {
       return cached.data;
     }
 
@@ -753,7 +782,7 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
     }
 
     // Cache the result
-    this.#processedDataCache.set(cacheKey, { data: result, inputLength: data.length, y });
+    this.#processedDataCache.set(cacheKey, { data: result, fingerprint });
 
     return result;
   }
@@ -798,6 +827,7 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
 
   /**
    * Set the global bounds (from synced panels).
+   * Rebuild datasets so viewport-windowed series match the new bounds (REI-125).
    */
   public setGlobalBounds(bounds: Immutable<Bounds1D> | undefined): void {
     if (this.isDestroyed()) {
@@ -805,11 +835,14 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
     }
     this.#globalBounds = bounds;
     this.#interactionBounds = undefined;
+    // Slice bounds changed — rebuild from fullData/currentData, then render.
+    this.#buildAndUpdateDatasets();
     this.#queueDispatchRender();
   }
 
   /**
    * Reset the view to the default bounds.
+   * Rebuild datasets so viewport-windowed series match the reset window (REI-125).
    */
   public resetBounds(): void {
     if (this.isDestroyed()) {
@@ -818,6 +851,7 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
     this.#interactionBounds = undefined;
     this.#globalBounds = undefined;
     this.#updateAction.yBounds = this.#configBounds.y;
+    this.#buildAndUpdateDatasets();
     this.#queueDispatchRender();
   }
 
@@ -956,7 +990,14 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
 
     this.emit("viewportChange", this.#canReset());
 
-    // After render update, dispatch datasets to update the chart data
+    if (haveInteractionEvents) {
+      // Pan/zoom changed the visible window — rebuild sliced series from fullData
+      // (REI-125: previously only re-dispatched stale pending datasets).
+      this.#buildAndUpdateDatasets();
+      return;
+    }
+
+    // After non-interaction render update, dispatch any pending datasets.
     this.#queueDispatchDatasets();
   }
 

--- a/packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.viewport.test.ts
+++ b/packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.viewport.test.ts
@@ -422,6 +422,58 @@ describe("StateTransitionsCoordinator ingestion correctness", () => {
     coordinator.destroy();
   });
 
+  it("retains streaming history when Show Points changes without cached blocks", async () => {
+    const { renderer, datasetSnapshots } = makeMockRenderer();
+    const coordinator = new StateTransitionsCoordinator(renderer);
+    const config = {
+      isSynced: false,
+      paths: [{ value: "/t.data", timestampMethod: "receiveTime" as const }],
+    };
+
+    coordinator.handleConfig(config, {});
+    coordinator.handlePlayerState(
+      playerState({ messages: [makeMsg(0, 1), makeMsg(1, 1), makeMsg(2, 1)] }),
+    );
+    await settleCoordinator();
+    expect(datasetSnapshots.at(-1)?.[0]?.data.map((datum) => datum.x)).toEqual([0, 2]);
+
+    coordinator.handleConfig({ ...config, showPoints: true }, {});
+    coordinator.handlePlayerState(playerState({ messages: [] }));
+    await settleCoordinator();
+
+    // The collapsed history cannot recover its interior sample without blocks, but it must not
+    // disappear while waiting for future live messages.
+    expect(datasetSnapshots.at(-1)?.[0]?.data.map((datum) => datum.x)).toEqual([0, 2]);
+    coordinator.destroy();
+  });
+
+  it("sorts header-stamped block data before viewport slicing", async () => {
+    const { renderer, datasetSnapshots } = makeMockRenderer();
+    const coordinator = new StateTransitionsCoordinator(renderer);
+    const headerStampedMessages = [
+      { receiveSec: 0, stampSec: 0, value: 0 },
+      { receiveSec: 1, stampSec: 100, value: 2 },
+      { receiveSec: 2, stampSec: 50, value: 1 },
+    ].map(({ receiveSec, stampSec, value }) => ({
+      ...makeMsg(receiveSec, value),
+      message: { data: value, header: { stamp: { sec: stampSec, nsec: 0 } } },
+    }));
+
+    coordinator.handleConfig(
+      {
+        isSynced: true,
+        paths: [{ value: "/t.data", timestampMethod: "headerStamp" }],
+      },
+      {},
+    );
+    coordinator.handlePlayerState(playerState({ blockMessages: headerStampedMessages }));
+    coordinator.setGlobalBounds({ min: 40, max: 60 });
+    await settleCoordinator();
+
+    expect(datasetSnapshots.at(-1)?.[0]?.data.map((datum) => datum.x)).toEqual([0, 50, 100]);
+    coordinator.destroy();
+  });
+
   it("keeps the first streaming value when duplicate timestamps arrive", async () => {
     const { renderer, datasetSnapshots } = makeMockRenderer();
     const coordinator = new StateTransitionsCoordinator(renderer);

--- a/packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.viewport.test.ts
+++ b/packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.viewport.test.ts
@@ -1,0 +1,442 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+/**
+ * Regression tests for REI-125 StateTransitions viewport rebuild behavior.
+ * Codex review: pan/zoom/sync must rebuild sliced datasets from fullData, not
+ * only re-dispatch stale pending datasets.
+ */
+
+import type { Dataset, UpdateAction } from "./StateTransitionsChartRenderer";
+import { StateTransitionsCoordinator } from "./StateTransitionsCoordinator";
+import type { StateTransitionsRenderer } from "./StateTransitionsRenderer";
+
+function makeMockRenderer() {
+  const updates: UpdateAction[] = [];
+  const datasetSnapshots: Dataset[][] = [];
+  const renderer = {
+    update: jest.fn(async (action: UpdateAction) => {
+      updates.push(action);
+      // Simulate pan/zoom resulting bounds when interaction events are present.
+      if ((action.interactionEvents?.length ?? 0) > 0) {
+        return { x: { min: 40, max: 60 }, y: { min: -20, max: 0 } };
+      }
+      return { x: { min: 0, max: 30 }, y: { min: -20, max: 0 } };
+    }),
+    updateDatasets: jest.fn(async (datasets: Dataset[]) => {
+      datasetSnapshots.push(datasets);
+      return { min: 0, max: 1, left: 0, right: 100 };
+    }),
+    getElementsAtPixel: jest.fn(async () => []),
+    getDatalabelAtEvent: jest.fn(async () => undefined),
+  };
+  return {
+    renderer: renderer as unknown as StateTransitionsRenderer,
+    updates,
+    datasetSnapshots,
+    raw: renderer,
+  };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    setImmediate(resolve);
+  });
+}
+
+async function settleCoordinator(): Promise<void> {
+  // throttle 100ms + debouncePromise chains
+  await flushMicrotasks();
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, 150);
+  });
+  await flushMicrotasks();
+}
+
+describe("StateTransitionsCoordinator viewport rebuild (REI-125)", () => {
+  beforeEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("rebuilds datasets after setGlobalBounds so slice tracks synced view", async () => {
+    const { renderer, datasetSnapshots } = makeMockRenderer();
+    const coordinator = new StateTransitionsCoordinator(renderer);
+
+    coordinator.handleConfig(
+      {
+        isSynced: true,
+        xAxisRange: 30,
+        paths: [
+          {
+            value: "/t.data",
+            timestampMethod: "receiveTime",
+          },
+        ],
+      },
+      {},
+    );
+
+    // Seed fullData indirectly: inject via player-like flow is heavy; instead use
+    // setDataRange + handlePlayerState with blocks.
+    const datatypes = new Map([
+      [
+        "std_msgs/Float64",
+        {
+          name: "std_msgs/Float64",
+          definitions: [{ name: "data", type: "float64", isComplex: false, isArray: false }],
+        },
+      ],
+    ]);
+
+    const makeMsg = (sec: number, value: number) => ({
+      topic: "/t",
+      schemaName: "std_msgs/Float64",
+      receiveTime: { sec, nsec: 0 },
+      message: { data: value },
+      sizeInBytes: 8,
+    });
+
+    // Messages spanning 0..100s at 1Hz of constant then change — enough for windowing.
+    const blockMessages = Array.from({ length: 101 }, (_, sec) => makeMsg(sec, sec < 50 ? 0 : 1));
+
+    coordinator.handlePlayerState({
+      presence: 3,
+      playerId: "test",
+      progress: {
+        messageCache: {
+          blocks: [
+            {
+              messagesByTopic: { "/t": blockMessages },
+              sizeInBytes: blockMessages.length * 8,
+            },
+          ],
+          startTime: { sec: 0, nsec: 0 },
+        },
+      },
+      capabilities: [],
+      profile: undefined,
+      activeData: {
+        messages: [],
+        totalBytesReceived: 0,
+        currentTime: { sec: 30, nsec: 0 },
+        startTime: { sec: 0, nsec: 0 },
+        endTime: { sec: 100, nsec: 0 },
+        isPlaying: false,
+        speed: 1,
+        lastSeekTime: 1,
+        topics: [{ name: "/t", schemaName: "std_msgs/Float64" }],
+        topicStats: new Map(),
+        datatypes,
+        publishedTopics: new Map(),
+        subscribedTopics: new Map(),
+        services: new Map(),
+      },
+    } as never);
+
+    await settleCoordinator();
+    const snapshotsBeforeSync = datasetSnapshots.length;
+
+    // Sync viewport to a window far from follow mode (40–60).
+    coordinator.setGlobalBounds({ min: 40, max: 60 });
+    await settleCoordinator();
+
+    expect(datasetSnapshots.length).toBeGreaterThan(snapshotsBeforeSync);
+    const series = datasetSnapshots[datasetSnapshots.length - 1]![0];
+    expect(series).toBeDefined();
+    const xs = series!.data.map((p) => p.x);
+    // Sliced rebuild should include points near the synced window (not only 0..30 follow).
+    expect(xs.some((x) => x >= 40)).toBe(true);
+    expect(Math.max(...xs)).toBeGreaterThanOrEqual(40);
+
+    coordinator.destroy();
+  });
+
+  it("rebuilds datasets after pan interaction bounds update", async () => {
+    const { renderer, datasetSnapshots, raw } = makeMockRenderer();
+    const coordinator = new StateTransitionsCoordinator(renderer);
+
+    coordinator.handleConfig(
+      {
+        isSynced: false,
+        paths: [{ value: "/t.data", timestampMethod: "receiveTime" }],
+      },
+      {},
+    );
+
+    const datatypes = new Map([
+      [
+        "std_msgs/Float64",
+        {
+          name: "std_msgs/Float64",
+          definitions: [{ name: "data", type: "float64", isComplex: false, isArray: false }],
+        },
+      ],
+    ]);
+
+    const blockMessages = Array.from({ length: 80 }, (_, sec) => ({
+      topic: "/t",
+      schemaName: "std_msgs/Float64",
+      receiveTime: { sec, nsec: 0 },
+      message: { data: sec },
+      sizeInBytes: 8,
+    }));
+
+    coordinator.handlePlayerState({
+      presence: 3,
+      playerId: "test",
+      progress: {
+        messageCache: {
+          blocks: [
+            {
+              messagesByTopic: { "/t": blockMessages },
+              sizeInBytes: blockMessages.length * 8,
+            },
+          ],
+          startTime: { sec: 0, nsec: 0 },
+        },
+      },
+      capabilities: [],
+      profile: undefined,
+      activeData: {
+        messages: [],
+        totalBytesReceived: 0,
+        currentTime: { sec: 10, nsec: 0 },
+        startTime: { sec: 0, nsec: 0 },
+        endTime: { sec: 80, nsec: 0 },
+        isPlaying: false,
+        speed: 1,
+        lastSeekTime: 1,
+        topics: [{ name: "/t", schemaName: "std_msgs/Float64" }],
+        topicStats: new Map(),
+        datatypes,
+        publishedTopics: new Map(),
+        subscribedTopics: new Map(),
+        services: new Map(),
+      },
+    } as never);
+
+    await settleCoordinator();
+    const beforeSnapshots = datasetSnapshots.length;
+
+    coordinator.addInteractionEvent({
+      type: "pan",
+      // Chart.js-like interaction payload shape is opaque to coordinator
+    } as never);
+
+    await settleCoordinator();
+
+    // Interaction should trigger renderer.update and a datasets rebuild.
+    expect(raw.update).toHaveBeenCalled();
+    expect(datasetSnapshots.length).toBeGreaterThan(beforeSnapshots);
+    const series = datasetSnapshots[datasetSnapshots.length - 1]![0];
+    expect(series).toBeDefined();
+    const xs = series!.data.map((p) => p.x);
+    // Mock pan bounds 40–60 → rebuilt slice should reach that neighborhood.
+    expect(Math.max(...xs)).toBeGreaterThanOrEqual(40);
+
+    coordinator.destroy();
+  });
+});
+
+describe("StateTransitionsCoordinator block gap tolerance (REI-125)", () => {
+  beforeEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("does not skip past an unloaded block and lose its history when it arrives late", async () => {
+    const { renderer, datasetSnapshots } = makeMockRenderer();
+    const coordinator = new StateTransitionsCoordinator(renderer);
+
+    coordinator.handleConfig(
+      { isSynced: false, paths: [{ value: "/t.data", timestampMethod: "receiveTime" }] },
+      {},
+    );
+
+    const datatypes = new Map([
+      [
+        "std_msgs/Float64",
+        {
+          name: "std_msgs/Float64",
+          definitions: [{ name: "data", type: "float64", isComplex: false, isArray: false }],
+        },
+      ],
+    ]);
+
+    // 4 blocks × 5 samples at 1 Hz. Each block holds one constant value, so ingestion collapses
+    // it to a start/end pair: block k contributes x = 5k and x = 5k+4.
+    const blockMessages = [0, 1, 2, 3].map((blockIdx) =>
+      Array.from({ length: 5 }, (_, i) => ({
+        topic: "/t",
+        schemaName: "std_msgs/Float64",
+        receiveTime: { sec: blockIdx * 5 + i, nsec: 0 },
+        message: { data: blockIdx },
+        sizeInBytes: 8,
+      })),
+    );
+
+    const block = (idx: number) => ({
+      messagesByTopic: { "/t": blockMessages[idx]! },
+      sizeInBytes: 40,
+    });
+
+    const emit = async (blocks: unknown[]) => {
+      coordinator.handlePlayerState({
+        presence: 3,
+        playerId: "test",
+        progress: { messageCache: { blocks, startTime: { sec: 0, nsec: 0 } } },
+        capabilities: [],
+        profile: undefined,
+        activeData: {
+          messages: [],
+          totalBytesReceived: 0,
+          currentTime: { sec: 20, nsec: 0 },
+          startTime: { sec: 0, nsec: 0 },
+          endTime: { sec: 20, nsec: 0 },
+          isPlaying: false,
+          speed: 1,
+          lastSeekTime: 1,
+          topics: [{ name: "/t", schemaName: "std_msgs/Float64" }],
+          topicStats: new Map(),
+          datatypes,
+          publishedTopics: new Map(),
+          subscribedTopics: new Map(),
+          services: new Map(),
+        },
+      } as never);
+      await settleCoordinator();
+    };
+
+    // Pass 1: blocks 0-1 loaded contiguously.
+    await emit([block(0), block(1)]);
+
+    // Pass 2: block 2 is still loading but block 3 has arrived. The cursor must stop at the gap
+    // rather than consuming block 3 and stranding block 2 behind it.
+    await emit([block(0), block(1), undefined, block(3)]);
+
+    // Pass 3: the gap fills in. Both block 2 and block 3 must now be ingested.
+    await emit([block(0), block(1), block(2), block(3)]);
+
+    coordinator.setGlobalBounds({ min: 0, max: 20 });
+    await settleCoordinator();
+
+    const series = datasetSnapshots[datasetSnapshots.length - 1]![0];
+    expect(series).toBeDefined();
+    const xs = series!.data.map((p) => p.x);
+
+    // Segment processing emits one point per state change plus a trailing endpoint, so each block
+    // contributes its transition at x = 5k. Block 2's transition at x=10 is the regression guard:
+    // before the fix block 3 was consumed first, the cursor advanced past index 2, and no reset
+    // recovered it — the output was [0, 5, 15, 19] with a silent hole where block 2 belongs.
+    expect(xs).toEqual([0, 5, 10, 15, 19]);
+
+    coordinator.destroy();
+  });
+});
+
+describe("StateTransitionsCoordinator ingestion correctness", () => {
+  beforeEach(() => {
+    jest.useRealTimers();
+  });
+
+  const datatypes = new Map([
+    [
+      "std_msgs/Float64",
+      {
+        name: "std_msgs/Float64",
+        definitions: [{ name: "data", type: "float64", isComplex: false, isArray: false }],
+      },
+    ],
+  ]);
+
+  const makeMsg = (sec: number, value: number) => ({
+    topic: "/t",
+    schemaName: "std_msgs/Float64",
+    receiveTime: { sec, nsec: 0 },
+    message: { data: value },
+    sizeInBytes: 8,
+  });
+
+  function playerState(args: {
+    messages?: ReturnType<typeof makeMsg>[];
+    blockMessages?: ReturnType<typeof makeMsg>[];
+  }) {
+    const blocks =
+      args.blockMessages != undefined
+        ? [
+            {
+              messagesByTopic: { "/t": args.blockMessages },
+              sizeInBytes: args.blockMessages.length * 8,
+            },
+          ]
+        : undefined;
+    return {
+      presence: 3,
+      playerId: "test",
+      progress: {
+        messageCache: blocks != undefined ? { blocks, startTime: { sec: 0, nsec: 0 } } : undefined,
+      },
+      capabilities: [],
+      profile: undefined,
+      activeData: {
+        messages: args.messages ?? [],
+        totalBytesReceived: 0,
+        currentTime: { sec: 5, nsec: 0 },
+        startTime: { sec: 0, nsec: 0 },
+        endTime: { sec: 10, nsec: 0 },
+        isPlaying: false,
+        speed: 1,
+        lastSeekTime: 1,
+        topics: [{ name: "/t", schemaName: "std_msgs/Float64" }],
+        topicStats: new Map(),
+        datatypes,
+        publishedTopics: new Map(),
+        subscribedTopics: new Map(),
+        services: new Map(),
+      },
+    } as never;
+  }
+
+  it("preserves every sample when Show Points is enabled after data has loaded", async () => {
+    const { renderer, datasetSnapshots } = makeMockRenderer();
+    const coordinator = new StateTransitionsCoordinator(renderer);
+    const blockMessages = [makeMsg(0, 1), makeMsg(1, 1), makeMsg(2, 1)];
+    const config = {
+      isSynced: false,
+      paths: [{ value: "/t.data", timestampMethod: "receiveTime" as const }],
+    };
+
+    coordinator.handleConfig(config, {});
+    coordinator.handlePlayerState(playerState({ blockMessages }));
+    await settleCoordinator();
+    expect(datasetSnapshots.at(-1)?.[0]?.data.map((datum) => datum.x)).toEqual([0, 2]);
+
+    coordinator.handleConfig({ ...config, showPoints: true }, {});
+    coordinator.handlePlayerState(playerState({ blockMessages }));
+    await settleCoordinator();
+
+    expect(datasetSnapshots.at(-1)?.[0]?.data.map((datum) => datum.x)).toEqual([0, 1, 2]);
+    coordinator.destroy();
+  });
+
+  it("keeps the first streaming value when duplicate timestamps arrive", async () => {
+    const { renderer, datasetSnapshots } = makeMockRenderer();
+    const coordinator = new StateTransitionsCoordinator(renderer);
+    coordinator.handleConfig(
+      {
+        isSynced: false,
+        paths: [{ value: "/t.data", timestampMethod: "receiveTime" }],
+      },
+      {},
+    );
+
+    coordinator.handlePlayerState(playerState({ messages: [makeMsg(5, 1), makeMsg(5, 2)] }));
+    await settleCoordinator();
+
+    expect(datasetSnapshots.at(-1)?.[0]?.data.map((datum) => datum.value)).toEqual([1]);
+    coordinator.destroy();
+  });
+});

--- a/packages/studio-base/src/panels/StateTransitions/stateTransitionData.test.ts
+++ b/packages/studio-base/src/panels/StateTransitions/stateTransitionData.test.ts
@@ -1,0 +1,284 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import {
+  appendCollapsedStateSample,
+  processCacheFingerprint,
+  sliceMergedStateDataForViewport,
+  sliceStateDataForViewport,
+} from "./stateTransitionData";
+import { Datum } from "./types";
+
+function d(x: number, value: number | string): Datum {
+  return {
+    x,
+    y: 0,
+    value,
+    label: String(value),
+    labelColor: "#fff",
+  };
+}
+
+/**
+ * The pre-REI-125 path: materialize the merge, then window it. Kept here as the reference
+ * oracle that `sliceMergedStateDataForViewport` must match exactly.
+ */
+function legacyMergeThenSlice(
+  fullData: Datum[],
+  currentData: Datum[],
+  minX: number,
+  maxX: number,
+): Datum[] {
+  let merged: Datum[];
+  if (currentData.length === 0) {
+    merged = fullData;
+  } else if (fullData.length === 0) {
+    merged = currentData;
+  } else {
+    const lastFullX = fullData[fullData.length - 1]?.x ?? -Infinity;
+    merged = [...fullData, ...currentData.filter((datum) => datum.x > lastFullX)];
+  }
+  return sliceStateDataForViewport(merged, minX, maxX);
+}
+
+describe("appendCollapsedStateSample", () => {
+  it("keeps every sample when values always change", () => {
+    const data: Datum[] = [];
+    appendCollapsedStateSample(data, d(0, 1));
+    appendCollapsedStateSample(data, d(1, 2));
+    appendCollapsedStateSample(data, d(2, 3));
+    expect(data.map((p) => [p.x, p.value])).toEqual([
+      [0, 1],
+      [1, 2],
+      [2, 3],
+    ]);
+  });
+
+  it("collapses a long plateau to start + trailing endpoint", () => {
+    const data: Datum[] = [];
+    for (let i = 0; i < 1000; i++) {
+      appendCollapsedStateSample(data, d(i * 0.01, "open"));
+    }
+    expect(data).toHaveLength(2);
+    expect(data[0]!.x).toBe(0);
+    expect(data[1]!.x).toBeCloseTo(9.99);
+    expect(data[0]!.value).toBe("open");
+    expect(data[1]!.value).toBe("open");
+  });
+
+  it("preserves segment boundaries across value changes", () => {
+    const data: Datum[] = [];
+    appendCollapsedStateSample(data, d(0, "a"));
+    appendCollapsedStateSample(data, d(1, "a"));
+    appendCollapsedStateSample(data, d(2, "a"));
+    appendCollapsedStateSample(data, d(3, "b"));
+    appendCollapsedStateSample(data, d(4, "b"));
+    appendCollapsedStateSample(data, d(5, "a"));
+
+    expect(data.map((p) => [p.x, p.value])).toEqual([
+      [0, "a"],
+      [2, "a"],
+      [3, "b"],
+      [4, "b"],
+      [5, "a"],
+    ]);
+  });
+
+  it("benchmark: collapsing 20k plateau samples stays near O(n) and tiny storage", () => {
+    const N = 20_000;
+    const data: Datum[] = [];
+    const t0 = performance.now();
+    for (let i = 0; i < N; i++) {
+      // Mostly plateau with rare flips — similar to discrete gripper open/close.
+      const value = i > 0 && i % 5000 === 0 ? `s${i}` : "stable";
+      appendCollapsedStateSample(data, d(i / 250, value));
+    }
+    const elapsedMs = performance.now() - t0;
+
+    // 4 stable plateaus × 2 endpoints + transitions ≈ small.
+    expect(data.length).toBeLessThan(20);
+    // Generous CI bound; local is typically < 20ms.
+    expect(elapsedMs).toBeLessThan(500);
+  });
+});
+
+describe("sliceStateDataForViewport", () => {
+  const data = [d(0, "a"), d(10, "b"), d(20, "c"), d(30, "d"), d(40, "e")];
+
+  it("includes the last point at or before minX for continuity", () => {
+    const sliced = sliceStateDataForViewport(data, 15, 35);
+    expect(sliced.map((p) => p.x)).toEqual([10, 20, 30, 40]);
+  });
+
+  it("includes the endpoint after a viewport enclosed by a collapsed plateau", () => {
+    const plateau = [d(0, "stable"), d(100, "stable")];
+    expect(sliceStateDataForViewport(plateau, 40, 50).map((p) => p.x)).toEqual([0, 100]);
+  });
+
+  it("returns empty for empty input", () => {
+    expect(sliceStateDataForViewport([], 0, 1)).toEqual([]);
+  });
+
+  it("returns all data when window covers full range", () => {
+    expect(sliceStateDataForViewport(data, -1, 100).map((p) => p.x)).toEqual([0, 10, 20, 30, 40]);
+  });
+
+  it("handles a window before the first sample", () => {
+    expect(sliceStateDataForViewport(data, -10, -1)).toEqual([]);
+  });
+
+  it("handles a window after the last sample by keeping last point before min", () => {
+    const sliced = sliceStateDataForViewport(data, 50, 60);
+    // startIdx points at last element (x=40 <= 50), endIdx same after search → single continuity point
+    expect(sliced.map((p) => p.x)).toEqual([40]);
+  });
+
+  it("benchmark: slicing 50k sorted samples is fast", () => {
+    const big: Datum[] = [];
+    for (let i = 0; i < 50_000; i++) {
+      big.push(d(i / 100, i));
+    }
+    const t0 = performance.now();
+    for (let i = 0; i < 200; i++) {
+      sliceStateDataForViewport(big, 100, 130);
+    }
+    const elapsedMs = performance.now() - t0;
+    expect(elapsedMs).toBeLessThan(500);
+  });
+});
+
+describe("processCacheFingerprint", () => {
+  it("changes when plateau endpoint advances without length change", () => {
+    const data: Datum[] = [];
+    appendCollapsedStateSample(data, d(0, "open"));
+    appendCollapsedStateSample(data, d(1, "open"));
+    expect(data).toHaveLength(2);
+
+    const before = processCacheFingerprint(data, /*y*/ 0, /*viewMin*/ 0, /*viewMax*/ 10);
+    appendCollapsedStateSample(data, d(5, "open"));
+    expect(data).toHaveLength(2); // endpoint mutation only
+    expect(data[1]!.x).toBe(5);
+
+    const after = processCacheFingerprint(data, 0, 0, 10);
+    expect(after).not.toEqual(before);
+  });
+
+  it("changes when viewport bounds change", () => {
+    const data = [d(0, "a"), d(1, "b")];
+    const a = processCacheFingerprint(data, 0, 0, 10);
+    const b = processCacheFingerprint(data, 0, 5, 15);
+    expect(a).not.toEqual(b);
+  });
+
+  it("is stable for identical inputs", () => {
+    const data = [d(0, "a"), d(2, "a")];
+    expect(processCacheFingerprint(data, 1, 0, 3)).toEqual(processCacheFingerprint(data, 1, 0, 3));
+  });
+});
+
+describe("sliceMergedStateDataForViewport", () => {
+  const full = [d(0, "a"), d(10, "b"), d(20, "c"), d(30, "d")];
+  const current = [d(25, "stale"), d(30, "dup"), d(40, "e"), d(50, "f")];
+
+  it("drops currentData samples not newer than the last fullData sample", () => {
+    const sliced = sliceMergedStateDataForViewport(full, current, -1, 100);
+    expect(sliced.map((p) => p.x)).toEqual([0, 10, 20, 30, 40, 50]);
+    // x=30 comes from fullData, not the currentData duplicate.
+    expect(sliced[3]!.value).toBe("d");
+  });
+
+  it("windows across the fullData/currentData boundary", () => {
+    const sliced = sliceMergedStateDataForViewport(full, current, 28, 45);
+    // Keeps both the last point before minX and the first point after maxX for line continuity.
+    expect(sliced.map((p) => p.x)).toEqual([20, 30, 40, 50]);
+  });
+
+  it("windows entirely inside currentData", () => {
+    const sliced = sliceMergedStateDataForViewport(full, current, 45, 60);
+    expect(sliced.map((p) => p.x)).toEqual([40, 50]);
+  });
+
+  it("windows entirely inside fullData", () => {
+    const sliced = sliceMergedStateDataForViewport(full, current, 5, 15);
+    expect(sliced.map((p) => p.x)).toEqual([0, 10, 20]);
+  });
+
+  it("keeps both endpoints when a collapsed plateau surrounds the viewport", () => {
+    const plateau = [d(0, "stable"), d(100, "stable")];
+    expect(sliceMergedStateDataForViewport(plateau, [], 40, 50).map((p) => p.x)).toEqual([0, 100]);
+  });
+
+  it("handles empty inputs", () => {
+    expect(sliceMergedStateDataForViewport([], [], 0, 10)).toEqual([]);
+    expect(sliceMergedStateDataForViewport([], current, 0, 100).map((p) => p.x)).toEqual([
+      25, 30, 40, 50,
+    ]);
+    expect(sliceMergedStateDataForViewport(full, [], 0, 100).map((p) => p.x)).toEqual([
+      0, 10, 20, 30,
+    ]);
+  });
+
+  it("returns only the continuity point when the window is past the end", () => {
+    expect(sliceMergedStateDataForViewport(full, current, 80, 90).map((p) => p.x)).toEqual([50]);
+  });
+
+  it("returns empty when the window is before the first sample", () => {
+    expect(sliceMergedStateDataForViewport(full, current, -20, -10)).toEqual([]);
+  });
+
+  it("matches the legacy merge-then-slice result across randomized inputs", () => {
+    let seed = 42;
+    const rand = () => {
+      seed = (seed * 1103515245 + 12345) % 2147483648;
+      return seed / 2147483648;
+    };
+
+    for (let trial = 0; trial < 200; trial++) {
+      const fullLen = Math.floor(rand() * 12);
+      const currentLen = Math.floor(rand() * 12);
+
+      const fullData: Datum[] = [];
+      let x = 0;
+      for (let i = 0; i < fullLen; i++) {
+        x += Math.floor(rand() * 5);
+        fullData.push(d(x, `f${i}`));
+      }
+      // currentData overlaps fullData's tail so the "newer than lastFullX" filter is exercised.
+      const currentData: Datum[] = [];
+      let cx = Math.max(0, x - Math.floor(rand() * 8));
+      for (let i = 0; i < currentLen; i++) {
+        cx += Math.floor(rand() * 5);
+        currentData.push(d(cx, `c${i}`));
+      }
+
+      const minX = Math.floor(rand() * 40) - 5;
+      const maxX = minX + Math.floor(rand() * 30);
+
+      expect(sliceMergedStateDataForViewport(fullData, currentData, minX, maxX)).toEqual(
+        legacyMergeThenSlice(fullData, currentData, minX, maxX),
+      );
+    }
+  });
+
+  it("benchmark: does not copy full history — 200 windowed merges of 50k+5k samples", () => {
+    const bigFull: Datum[] = [];
+    for (let i = 0; i < 50_000; i++) {
+      bigFull.push(d(i / 100, i));
+    }
+    const bigCurrent: Datum[] = [];
+    for (let i = 0; i < 5_000; i++) {
+      bigCurrent.push(d(500 + i / 100, i));
+    }
+
+    const t0 = performance.now();
+    for (let i = 0; i < 200; i++) {
+      sliceMergedStateDataForViewport(bigFull, bigCurrent, 100, 130);
+    }
+    const elapsedMs = performance.now() - t0;
+    expect(elapsedMs).toBeLessThan(500);
+  });
+});

--- a/packages/studio-base/src/panels/StateTransitions/stateTransitionData.ts
+++ b/packages/studio-base/src/panels/StateTransitions/stateTransitionData.ts
@@ -1,0 +1,241 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Datum } from "./types";
+
+/**
+ * Append a state-transition sample, collapsing consecutive equal values.
+ *
+ * Storage shape for a plateau of value V from t0..t1:
+ *   [{ x: t0, value: V }, { x: t1, value: V }]
+ * Further samples with the same value only advance the trailing endpoint.
+ *
+ * This preserves segment start/end for chart rendering while dropping the
+ * dense interior samples that dominate high-rate continuous/plateau series
+ * (REI-125: ~250 Hz joint states into StateTransitions).
+ */
+export function appendCollapsedStateSample(data: Datum[], datum: Datum): void {
+  const last = data[data.length - 1];
+  if (last == undefined) {
+    data.push(datum);
+    return;
+  }
+
+  if (last.value !== datum.value) {
+    data.push(datum);
+    return;
+  }
+
+  // Same value: extend plateau. Keep a dedicated trailing endpoint when possible.
+  const prev = data[data.length - 2];
+  if (prev != undefined && prev.value === datum.value) {
+    // Already have start + end of plateau; advance the end.
+    // NOTE: length is unchanged — consumers that cache by length alone will go stale
+    // unless they also key on the trailing endpoint (see processCacheFingerprint).
+    last.x = datum.x;
+    last.label = datum.label;
+    last.labelColor = datum.labelColor;
+    last.constantName = datum.constantName;
+    last.y = datum.y;
+    return;
+  }
+
+  // Only the plateau start exists; add the first trailing endpoint.
+  data.push(datum);
+}
+
+/**
+ * Fingerprint for processed-dataset caches. Must include the trailing endpoint so
+ * in-place plateau extension (same length, new last.x) invalidates the cache.
+ */
+export function processCacheFingerprint(
+  data: readonly Datum[],
+  y: number,
+  viewMin: number,
+  viewMax: number,
+): string {
+  if (data.length === 0) {
+    return `0|${y}|${viewMin}|${viewMax}`;
+  }
+  const head = data[0]!;
+  const tail = data[data.length - 1]!;
+  return [data.length, y, viewMin, viewMax, head.x, tail.x, String(tail.value)].join("|");
+}
+
+/**
+ * Slice the merged (fullData ++ newer currentData) series to the visible x-window **without
+ * materializing the merge**.
+ *
+ * `sliceStateDataForViewport(getMergedData(...))` was O(total history) per rebuild: the merge
+ * copied the entire preloaded series before the window narrowed it, and rebuilds run on every
+ * player emit plus every pan/zoom interaction. This walks the two sorted arrays as one virtual
+ * concatenation and copies only the visible window (REI-125 review).
+ *
+ * Result is identical to slicing the materialized merge: `currentData` contributes only samples
+ * strictly newer than the last `fullData` sample, matching the previous merge semantics.
+ *
+ * The window is materialized with native `Array.slice` rather than an element-by-element copy
+ * through the virtual accessor. A/B measurement showed the naive loop was ~2x *slower* than the
+ * old merge-then-slice for mid-sized series (~1k-10k samples, the range a partially preloaded bag
+ * actually reaches) even though it won by 100x at 400k; native slice wins in every regime.
+ */
+export function sliceMergedStateDataForViewport(
+  fullData: readonly Datum[],
+  currentData: readonly Datum[],
+  minX: number,
+  maxX: number,
+): Datum[] {
+  const fullLength = fullData.length;
+  const lastFullX = fullLength > 0 ? fullData[fullLength - 1]!.x : -Infinity;
+
+  // First index of currentData strictly newer than fullData's last sample.
+  const currentStart = firstIndexAfter(currentData, lastFullX);
+  const currentLength = currentData.length - currentStart;
+  const totalLength = fullLength + currentLength;
+  if (totalLength === 0) {
+    return [];
+  }
+
+  // Virtual index into the concatenation; both halves are sorted and the second is strictly newer.
+  const at = (index: number): Datum =>
+    index < fullLength ? fullData[index]! : currentData[currentStart + index - fullLength]!;
+
+  /** Copy [startIdx, endIdx) out of the virtual concatenation using native slices. */
+  const collect = (startIdx: number, endIdx: number): Datum[] => {
+    if (endIdx <= fullLength) {
+      return fullData.slice(startIdx, endIdx);
+    }
+    const currentFrom = currentStart + Math.max(0, startIdx - fullLength);
+    const currentTo = currentStart + endIdx - fullLength;
+    if (startIdx >= fullLength) {
+      return currentData.slice(currentFrom, currentTo);
+    }
+    // Window straddles the boundary.
+    return fullData.slice(startIdx, fullLength).concat(currentData.slice(currentFrom, currentTo));
+  };
+
+  if (!(maxX >= minX)) {
+    // Degenerate/NaN bounds: preserve the previous "return everything" behaviour.
+    return collect(0, totalLength);
+  }
+
+  // lo is the first index with x > minX. Include lo-1 for continuity when present.
+  const startIdx = Math.max(0, firstIndexAfterVirtual(at, 0, totalLength, minX) - 1);
+  let endIdx = firstIndexAfterVirtual(at, startIdx, totalLength, maxX); // exclusive
+
+  // A state is rendered as a line between samples. Keep the first point after the window so a
+  // collapsed plateau whose endpoints surround the viewport still has a segment to draw.
+  // Do not do this when the entire dataset starts after the window: there is no active state yet.
+  if (endIdx > 0 && endIdx < totalLength) {
+    endIdx += 1;
+  }
+
+  if (startIdx >= endIdx) {
+    // No points in range; still return the last point before minX if any.
+    if (startIdx < totalLength && at(startIdx).x <= minX) {
+      return [at(startIdx)];
+    }
+    return [];
+  }
+
+  return collect(startIdx, endIdx);
+}
+
+/** First index of a sorted array whose x is strictly greater than `x`. */
+function firstIndexAfter(data: readonly Datum[], x: number): number {
+  let lo = 0;
+  let hi = data.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (data[mid]!.x <= x) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  return lo;
+}
+
+/** As {@link firstIndexAfter}, over a virtual array addressed by `at` within [lo, hi). */
+function firstIndexAfterVirtual(
+  at: (index: number) => Datum,
+  from: number,
+  to: number,
+  x: number,
+): number {
+  let lo = from;
+  let hi = to;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (at(mid).x <= x) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  return lo;
+}
+
+/**
+ * Slice sorted state samples to the visible x-window, retaining the last sample
+ * at or before minX so the first visible segment has the correct state.
+ */
+export function sliceStateDataForViewport(
+  data: readonly Datum[],
+  minX: number,
+  maxX: number,
+): Datum[] {
+  if (data.length === 0) {
+    return [];
+  }
+  if (!(maxX >= minX)) {
+    return data.slice();
+  }
+
+  // Binary search for first index with x > minX (strictly after window start).
+  let lo = 0;
+  let hi = data.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (data[mid]!.x <= minX) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  // lo is first index with x > minX. Include lo-1 for continuity when present.
+  const startIdx = Math.max(0, lo - 1);
+
+  // Binary search for first index with x > maxX.
+  lo = startIdx;
+  hi = data.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (data[mid]!.x <= maxX) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  let endIdx = lo; // exclusive
+
+  // Retain the first post-window point for line continuity. This is required for collapsed
+  // plateaus such as [start, end] when the viewport lies entirely between the two endpoints.
+  if (endIdx > 0 && endIdx < data.length) {
+    endIdx += 1;
+  }
+
+  if (startIdx >= endIdx) {
+    // No points in range; still return last point before minX if any.
+    if (startIdx < data.length && data[startIdx]!.x <= minX) {
+      return [data[startIdx]!];
+    }
+    return [];
+  }
+
+  return data.slice(startIdx, endIdx);
+}


### PR DESCRIPTION
## What changed

- collapse consecutive equal state samples while preserving segment endpoints
- merge and slice block/streaming data without copying full history
- rebuild viewport data after pan, zoom, sync, and reset
- stop block cursors at unloaded gaps

## Correctness safeguards

- retain the first endpoint after the viewport so long plateaus remain visible
- preserve all raw samples when Show Points is enabled, including after toggling it on
- keep first-message semantics for duplicate timestamps
- cover late block gaps and viewport rebuild behavior with regression tests

## Why

High-rate state topics caused repeated full-history copies and large retained arrays in StateTransitions.

## Validation

- 29 focused Jest tests pass
- Prettier check passes

This PR intentionally excludes video caching, video seek gating, block-loader changes, temporary probes, and measurement artifacts.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787404118&installation_model_id=425002&pr_number=1420&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1420&signature=e49bd990f1a6ab447da02f3c33bcd9e192d8b7a98c18bd2ca72f912046c0866d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->