### PR TITLE
perf(studio): share video GOP cache budget

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.test.ts
@@ -25,6 +25,7 @@ import {
   type SetCompressedVideoFramesOptions,
 } from "./Images/ImageRenderable";
 import { AnyImage, CompressedVideo } from "./Images/ImageTypes";
+import { globalVideoGopCacheBudget } from "./Images/videoGopCache";
 
 function timeFromNanoseconds(timestamp: bigint): Time {
   return {
@@ -225,6 +226,45 @@ describe("Images compressed video seek lookback", () => {
     images.handleSeek();
 
     expect(subscribeMessageRange).not.toHaveBeenCalled();
+  });
+
+  it("keeps hidden compressed video topics out of the shared GOP cache budget", () => {
+    const renderer = makeRenderer({
+      topicSettings: {
+        "/video": { visible: false },
+        "/raw": { visible: true },
+      },
+    });
+    const images = new TestImages(renderer);
+    const subscription = compressedVideoSubscription(images);
+    const initialCacheCount = globalVideoGopCacheBudget.getCacheCount();
+
+    expect(subscription.shouldSubscribe?.("/video")).toBe(false);
+    subscription.handler(makeVideoMessage(0n, "key"));
+    expect(globalVideoGopCacheBudget.getCacheCount()).toBe(initialCacheCount);
+
+    images.handleSettingsAction({
+      action: "update",
+      payload: {
+        path: ["topics", "/video", "visible"],
+        input: "boolean",
+        value: true,
+      },
+    });
+    expect(subscription.shouldSubscribe?.("/video")).toBe(true);
+    subscription.handler(makeVideoMessage(0n, "key"));
+    expect(globalVideoGopCacheBudget.getCacheCount()).toBe(initialCacheCount + 1);
+
+    images.handleSettingsAction({
+      action: "update",
+      payload: {
+        path: ["topics", "/video", "visible"],
+        input: "boolean",
+        value: false,
+      },
+    });
+    expect(globalVideoGopCacheBudget.getCacheCount()).toBe(initialCacheCount);
+    images.dispose();
   });
 
   it("registers a compressed video topic when it becomes visible from settings", () => {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.ts
@@ -189,6 +189,7 @@ export class Images extends SceneExtension<ImageRenderable> {
         schemaNames: COMPRESSED_VIDEO_DATATYPES,
         subscription: {
           handler: this.#handleCompressedVideo,
+          shouldSubscribe: this.#compressedVideoTopicShouldSubscribe,
           filterQueue: this.#filterCompressedVideoQueue,
         },
       },
@@ -213,7 +214,7 @@ export class Images extends SceneExtension<ImageRenderable> {
       }
     }
     for (const [topic, controller] of this.#compressedVideoControllers) {
-      if (!compressedVideoTopics.has(topic)) {
+      if (!compressedVideoTopics.has(topic) || !this.#compressedVideoTopicShouldSubscribe(topic)) {
         controller.dispose();
         this.#compressedVideoControllers.delete(topic);
       }
@@ -313,6 +314,12 @@ export class Images extends SceneExtension<ImageRenderable> {
       this.renderer.config.topics[imageTopic];
     const cameraInfoTopic = settings?.cameraInfoTopic;
 
+    // Hidden video layers must not retain a controller or consume a share of the process-wide GOP
+    // cache budget. A fresh controller will be created if the layer becomes visible again.
+    if (settings?.visible !== true) {
+      this.#disposeCompressedVideoController(imageTopic);
+    }
+
     // Add this camera_info_topic -> image_topic mapping
     if (cameraInfoTopic !== prevCameraInfoTopic && cameraInfoTopic != undefined) {
       this.#cameraInfoToImageTopics.set(cameraInfoTopic, imageTopic);
@@ -367,6 +374,11 @@ export class Images extends SceneExtension<ImageRenderable> {
     return false;
   };
 
+  #compressedVideoTopicShouldSubscribe = (topic: string): boolean => {
+    const settings: Partial<LayerSettingsImage> | undefined = this.renderer.config.topics[topic];
+    return settings?.visible === true;
+  };
+
   #handleRosRawImage = (messageEvent: PartialMessageEvent<RosImage>): void => {
     void this.handleImage(messageEvent, normalizeRosImage(messageEvent.message));
   };
@@ -384,6 +396,9 @@ export class Images extends SceneExtension<ImageRenderable> {
   };
 
   #handleCompressedVideo = (messageEvent: PartialMessageEvent<CompressedVideo>): void => {
+    if (!this.#compressedVideoTopicShouldSubscribe(messageEvent.topic)) {
+      return;
+    }
     const normalizedEvent = {
       ...messageEvent,
       message: normalizeCompressedVideo(messageEvent.message),
@@ -419,6 +434,9 @@ export class Images extends SceneExtension<ImageRenderable> {
     queue: Parameters<typeof recordKeyframesAndFilterCompressedVideoQueue>[0],
   ): ReturnType<typeof recordKeyframesAndFilterCompressedVideoQueue> => {
     return recordKeyframesAndFilterCompressedVideoQueue(queue, (topic, receiveTime) => {
+      if (!this.#compressedVideoTopicShouldSubscribe(topic)) {
+        return;
+      }
       this.#compressedVideoControllerForTopic(topic).recordKnownKeyframeReceiveTime(
         topic,
         receiveTime,
@@ -449,6 +467,14 @@ export class Images extends SceneExtension<ImageRenderable> {
       });
     }
     return controller;
+  }
+
+  #disposeCompressedVideoController(topic: string): void {
+    const controller = this.#compressedVideoControllers.get(topic);
+    if (controller != undefined) {
+      controller.dispose();
+      this.#compressedVideoControllers.delete(topic);
+    }
   }
 
   #handleSeekKeyframeSearchChange = ({ active }: SeekKeyframeSearchState): void => {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts
@@ -87,7 +87,9 @@ type ControllerRenderer = Pick<
 export class CompressedVideoController {
   readonly #topic: string;
   readonly #renderer: ControllerRenderer;
-  readonly #cache = new VideoGopCache();
+  // Share one byte ceiling across all active video panels instead of multiplying a per-panel
+  // allocation in multi-camera layouts.
+  readonly #cache = new VideoGopCache({ sharedBudget: true });
   readonly #state: ControllerState = {};
 
   #displayFrames: CompressedVideoDisplayFrames;
@@ -331,6 +333,7 @@ export class CompressedVideoController {
 
   public dispose(): void {
     this.clear();
+    this.#cache.dispose();
   }
 
   #shouldStartImplicitSeekBackfill(args: {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoGopCache.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoGopCache.test.ts
@@ -8,7 +8,12 @@
 import { Time } from "@foxglove/rostime";
 import { MessageEvent } from "@foxglove/studio";
 
-import { VideoGopCache } from "./videoGopCache";
+import {
+  DEFAULT_VIDEO_GOP_CACHE_MAX_BYTES,
+  DEFAULT_VIDEO_GOP_CACHE_TOTAL_MAX_BYTES,
+  VideoGopCache,
+  globalVideoGopCacheBudget,
+} from "./videoGopCache";
 
 const TOPIC = "/camera";
 
@@ -300,5 +305,74 @@ describe("VideoGopCache", () => {
     // ...but its keyframe location survives, so a later seek can read exactly that GOP.
     expect(cache.nearestKeyframeReceiveTimeAtOrBefore(TOPIC, t(2))).toEqual(t(1));
     expect(cache.nearestKeyframeReceiveTimeAtOrBefore(TOPIC, t(4))).toEqual(t(3));
+  });
+});
+
+describe("VideoGopCache shared budget (REI-125)", () => {
+  afterEach(() => {
+    globalVideoGopCacheBudget.resetForTests();
+  });
+
+  it("leaves standalone caches on the fixed per-cache default", () => {
+    const cache = new VideoGopCache();
+    expect(cache.getMaxBytes()).toBe(DEFAULT_VIDEO_GOP_CACHE_MAX_BYTES);
+    expect(globalVideoGopCacheBudget.getCacheCount()).toBe(0);
+  });
+
+  it("divides the shared ceiling across participating caches", () => {
+    const first = new VideoGopCache({ sharedBudget: true });
+    // A single camera still gets the full per-cache default.
+    expect(first.getMaxBytes()).toBe(DEFAULT_VIDEO_GOP_CACHE_MAX_BYTES);
+
+    const rest = [1, 2, 3, 4].map(() => new VideoGopCache({ sharedBudget: true }));
+    const all = [first, ...rest];
+    expect(globalVideoGopCacheBudget.getCacheCount()).toBe(5);
+
+    const share = Math.floor(DEFAULT_VIDEO_GOP_CACHE_TOTAL_MAX_BYTES / 5);
+    for (const cache of all) {
+      expect(cache.getMaxBytes()).toBe(share);
+    }
+    // The whole 5-camera layout now fits the shared ceiling instead of 5 x 64 MB.
+    const total = all.reduce((sum, cache) => sum + cache.getMaxBytes(), 0);
+    expect(total).toBeLessThanOrEqual(DEFAULT_VIDEO_GOP_CACHE_TOTAL_MAX_BYTES);
+    expect(total).toBeLessThan(5 * DEFAULT_VIDEO_GOP_CACHE_MAX_BYTES);
+  });
+
+  it("keeps the aggregate allocation within the ceiling for many cameras", () => {
+    const caches = Array.from({ length: 32 }, () => new VideoGopCache({ sharedBudget: true }));
+    const expectedShare = Math.floor(DEFAULT_VIDEO_GOP_CACHE_TOTAL_MAX_BYTES / caches.length);
+    for (const cache of caches) {
+      expect(cache.getMaxBytes()).toBe(expectedShare);
+    }
+    expect(caches.reduce((sum, cache) => sum + cache.getMaxBytes(), 0)).toBeLessThanOrEqual(
+      DEFAULT_VIDEO_GOP_CACHE_TOTAL_MAX_BYTES,
+    );
+  });
+
+  it("returns a disposed cache's share to the remaining caches", () => {
+    const caches = [1, 2, 3, 4].map(() => new VideoGopCache({ sharedBudget: true }));
+    expect(caches[0]!.getMaxBytes()).toBe(Math.floor(DEFAULT_VIDEO_GOP_CACHE_TOTAL_MAX_BYTES / 4));
+
+    caches[3]!.dispose();
+    expect(globalVideoGopCacheBudget.getCacheCount()).toBe(3);
+    for (const cache of caches.slice(0, 3)) {
+      expect(cache.getMaxBytes()).toBe(Math.floor(DEFAULT_VIDEO_GOP_CACHE_TOTAL_MAX_BYTES / 3));
+    }
+
+    // dispose() is idempotent.
+    caches[3]!.dispose();
+    expect(globalVideoGopCacheBudget.getCacheCount()).toBe(3);
+  });
+
+  it("evicts down to the new ceiling when a later camera joins", () => {
+    const cache = new VideoGopCache({ sharedBudget: true });
+    for (let i = 0; i < 40; i++) {
+      cache.addFrame(h264Frame(i, i, i % 5 === 0 ? "key" : "delta"));
+    }
+    expect(cache.getByteSize()).toBeGreaterThan(0);
+
+    // Frames are ~1 MB each in this harness; force a tiny ceiling and confirm it is honoured.
+    cache.setMaxBytes(4 * 1024 * 1024);
+    expect(cache.getByteSize()).toBeLessThanOrEqual(4 * 1024 * 1024);
   });
 });

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoGopCache.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoGopCache.test.ts
@@ -308,7 +308,7 @@ describe("VideoGopCache", () => {
   });
 });
 
-describe("VideoGopCache shared budget (REI-125)", () => {
+describe("VideoGopCache shared budget", () => {
   afterEach(() => {
     globalVideoGopCacheBudget.resetForTests();
   });
@@ -347,6 +347,51 @@ describe("VideoGopCache shared budget (REI-125)", () => {
     expect(caches.reduce((sum, cache) => sum + cache.getMaxBytes(), 0)).toBeLessThanOrEqual(
       DEFAULT_VIDEO_GOP_CACHE_TOTAL_MAX_BYTES,
     );
+  });
+
+  it("allocates the documented share at every supported camera count", () => {
+    // The quota table reviewers should sanity-check: static equal shares, ceiling wins, no floor.
+    const mib = 1024 * 1024;
+    const expectedShareByCameraCount: Array<[cameras: number, shareBytes: number]> = [
+      [1, 64 * mib],
+      [2, 64 * mib],
+      [5, 25.6 * mib],
+      [8, 16 * mib],
+      [16, 8 * mib],
+      [32, 4 * mib],
+    ];
+
+    for (const [cameras, shareBytes] of expectedShareByCameraCount) {
+      globalVideoGopCacheBudget.resetForTests();
+      const caches = Array.from({ length: cameras }, () => new VideoGopCache({ sharedBudget: true }));
+      for (const cache of caches) {
+        expect(cache.getMaxBytes()).toBe(Math.floor(shareBytes));
+      }
+      const total = caches.reduce((sum, cache) => sum + cache.getMaxBytes(), 0);
+      expect(total).toBeLessThanOrEqual(DEFAULT_VIDEO_GOP_CACHE_TOTAL_MAX_BYTES);
+      for (const cache of caches) {
+        cache.dispose();
+      }
+    }
+  });
+
+  it("prunes existing caches synchronously when a new camera registers", () => {
+    // Use a small budget with 1 MB frames so eviction is exercised quickly.
+    globalVideoGopCacheBudget.resetForTests(8 * 1024 * 1024);
+    const first = new VideoGopCache({ sharedBudget: true });
+    for (let i = 0; i < 12; i++) {
+      first.addFrame(h264Frame(i, i, i % 3 === 0 ? "key" : "delta", 1024 * 1024));
+    }
+    expect(first.getByteSize()).toBeGreaterThan(4 * 1024 * 1024);
+    expect(first.getByteSize()).toBeLessThanOrEqual(8 * 1024 * 1024);
+
+    // Registration rebalances and prunes in the same call stack: by the time the second camera's
+    // constructor returns, the first cache is already under its halved share. No transient
+    // over-budget window exists.
+    const second = new VideoGopCache({ sharedBudget: true });
+    expect(first.getByteSize()).toBeLessThanOrEqual(4 * 1024 * 1024);
+    expect(first.getMaxBytes()).toBe(4 * 1024 * 1024);
+    expect(second.getMaxBytes()).toBe(4 * 1024 * 1024);
   });
 
   it("returns a disposed cache's share to the remaining caches", () => {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoGopCache.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoGopCache.ts
@@ -13,6 +13,69 @@ const VIDEO_FORMATS = new Set(["h264", "h265"]);
 export const DEFAULT_VIDEO_GOP_CACHE_MAX_BYTES = 64 * 1024 * 1024;
 export const DEFAULT_KEYFRAME_INDEX_MAX_ENTRIES_PER_TOPIC = 20_000;
 
+/**
+ * Budget shared by every auto-registered {@link VideoGopCache} (REI-125).
+ *
+ * The per-cache default is 64 MB, but one cache exists per video panel, so a 5-camera layout could
+ * hold 320 MB of compressed frames in the JS heap on top of the 1 GB block cache. Multi-camera
+ * layouts now divide this shared ceiling instead of multiplying the per-cache one; a single-camera
+ * layout still gets the full 64 MB.
+ */
+export const DEFAULT_VIDEO_GOP_CACHE_TOTAL_MAX_BYTES = 128 * 1024 * 1024;
+
+/**
+ * Divides {@link DEFAULT_VIDEO_GOP_CACHE_TOTAL_MAX_BYTES} across the live caches and re-prunes
+ * them whenever the population changes.
+ */
+class VideoGopCacheBudget {
+  readonly #caches = new Set<VideoGopCache>();
+  #totalBytes: number;
+
+  public constructor(totalBytes: number) {
+    this.#totalBytes = totalBytes;
+  }
+
+  public shareBytes(cacheCount: number = this.#caches.size): number {
+    return Math.min(
+      DEFAULT_VIDEO_GOP_CACHE_MAX_BYTES,
+      Math.floor(this.#totalBytes / Math.max(1, cacheCount)),
+    );
+  }
+
+  public register(cache: VideoGopCache): void {
+    this.#caches.add(cache);
+    this.#rebalance();
+  }
+
+  public unregister(cache: VideoGopCache): void {
+    if (this.#caches.delete(cache)) {
+      this.#rebalance();
+    }
+  }
+
+  public getCacheCount(): number {
+    return this.#caches.size;
+  }
+
+  /** Test helper: drop all registrations so suites do not leak shares into each other. */
+  public resetForTests(totalBytes: number = DEFAULT_VIDEO_GOP_CACHE_TOTAL_MAX_BYTES): void {
+    this.#caches.clear();
+    this.#totalBytes = totalBytes;
+  }
+
+  #rebalance(): void {
+    const share = this.shareBytes();
+    for (const cache of this.#caches) {
+      cache.setMaxBytes(share);
+    }
+  }
+}
+
+/** Process-wide budget shared by all auto-registered video GOP caches. */
+export const globalVideoGopCacheBudget = new VideoGopCacheBudget(
+  DEFAULT_VIDEO_GOP_CACHE_TOTAL_MAX_BYTES,
+);
+
 type CompressedVideoLike = {
   timestamp: Time;
   frame_id: string;
@@ -97,17 +160,53 @@ export class VideoGopCache {
   // #pruneToBudget eviction: even after a region's frame data is evicted we still know where the
   // keyframes are, so a later seek can read exactly [keyframe, target] instead of guessing windows.
   readonly #keyframeReceiveTimesByTopic = new Map<string, bigint[]>();
-  readonly #maxBytes: number;
   readonly #maxKeyframeIndexEntriesPerTopic: number;
+  /** When true this cache participates in the shared budget and must be `dispose()`d. */
+  readonly #sharesBudget: boolean;
+  #maxBytes: number;
   #byteSize = 0;
   #targetReceiveTimeNs = 0n;
 
   public constructor(
-    options: { maxBytes?: number; maxKeyframeIndexEntriesPerTopic?: number } = {},
+    options: {
+      maxBytes?: number;
+      maxKeyframeIndexEntriesPerTopic?: number;
+      /**
+       * Join the process-wide budget shared by all video panels (REI-125). Opt-in so standalone
+       * caches keep the fixed per-cache default. Callers must `dispose()` to release their share.
+       */
+      sharedBudget?: boolean;
+    } = {},
   ) {
+    this.#sharesBudget = options.sharedBudget === true && options.maxBytes == undefined;
     this.#maxBytes = options.maxBytes ?? DEFAULT_VIDEO_GOP_CACHE_MAX_BYTES;
     this.#maxKeyframeIndexEntriesPerTopic =
       options.maxKeyframeIndexEntriesPerTopic ?? DEFAULT_KEYFRAME_INDEX_MAX_ENTRIES_PER_TOPIC;
+    if (this.#sharesBudget) {
+      globalVideoGopCacheBudget.register(this);
+    }
+  }
+
+  public getMaxBytes(): number {
+    return this.#maxBytes;
+  }
+
+  public getByteSize(): number {
+    return this.#byteSize;
+  }
+
+  /** Set this cache's byte ceiling and immediately evict down to it. */
+  public setMaxBytes(maxBytes: number): void {
+    this.#maxBytes = maxBytes;
+    this.#pruneToBudget();
+  }
+
+  /** Release this cache's share of the global budget. Safe to call more than once. */
+  public dispose(): void {
+    this.clear();
+    if (this.#sharesBudget) {
+      globalVideoGopCacheBudget.unregister(this);
+    }
   }
 
   public addFrame(msg: MessageEvent): boolean {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoGopCache.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoGopCache.ts
@@ -14,12 +14,24 @@ export const DEFAULT_VIDEO_GOP_CACHE_MAX_BYTES = 64 * 1024 * 1024;
 export const DEFAULT_KEYFRAME_INDEX_MAX_ENTRIES_PER_TOPIC = 20_000;
 
 /**
- * Budget shared by every auto-registered {@link VideoGopCache} (REI-125).
+ * Budget shared by every auto-registered {@link VideoGopCache}.
  *
  * The per-cache default is 64 MB, but one cache exists per video panel, so a 5-camera layout could
  * hold 320 MB of compressed frames in the JS heap on top of the 1 GB block cache. Multi-camera
  * layouts now divide this shared ceiling instead of multiplying the per-cache one; a single-camera
  * layout still gets the full 64 MB.
+ *
+ * Quota semantics (deliberate, see the camera-count matrix test):
+ * - Static equal partition: every registered cache gets `min(64 MB, floor(total / count))`. A
+ *   quiet camera's unused quota is NOT borrowed by a busy one. Elastic sharing was considered
+ *   and rejected for now; revisit only if real usage shows quiet-camera quota stranding matters.
+ * - The ceiling always wins and there is no per-cache floor: 8 cameras get 16 MB each, 32 cameras
+ *   get 4 MB each. Small shares increase seek backfill reads (mitigated by the keyframe index,
+ *   which survives eviction and keeps backfills single-request).
+ * - Rebalancing is synchronous: registering a cache prunes existing caches down to their new
+ *   shares before the constructor returns, so actual bytes never exceed the ceiling.
+ * - The budget holds strong references. A shared cache that is never `dispose()`d permanently
+ *   shrinks every other camera's share and pins its memory.
  */
 export const DEFAULT_VIDEO_GOP_CACHE_TOTAL_MAX_BYTES = 128 * 1024 * 1024;
 
@@ -172,7 +184,7 @@ export class VideoGopCache {
       maxBytes?: number;
       maxKeyframeIndexEntriesPerTopic?: number;
       /**
-       * Join the process-wide budget shared by all video panels (REI-125). Opt-in so standalone
+       * Join the process-wide budget shared by all video panels. Opt-in so standalone
        * caches keep the fixed per-cache default. Callers must `dispose()` to release their share.
        */
       sharedBudget?: boolean;


### PR DESCRIPTION
## Summary

Replaces one independent 64 MiB GOP cache per visible video panel with a process-wide 128 MiB budget divided equally among **active** caches. A 5-camera layout previously allowed 5 × 64 MiB = 320 MiB of compressed frames in the JS heap; it is now bounded by 128 MiB total. Hidden video panels release their share entirely (guarded at all three controller entry points: settings change, topic change, message handler).

## Quota semantics (deliberate, decided)

`share = min(64 MiB, floor(128 MiB / activeCaches))` — static equal partition:

| Visible cameras | 1 | 2 | 5 | 8 | 16 | 32 |
|---|---:|---:|---:|---:|---:|---:|
| Per-cache share | 64 MiB | 64 MiB | 25.6 MiB | 16 MiB | 8 MiB | 4 MiB |

- The ceiling always wins; there is deliberately **no per-cache floor** (a 16 MiB floor at 32 cameras would need 512 MiB, contradicting the ceiling).
- A quiet camera's unused quota is not borrowed by a busy one; elastic sharing was considered and rejected for now — revisit only if real usage shows quota stranding matters.
- Rebalancing is synchronous: a newly registering camera prunes existing caches inside its constructor call, so actual bytes never exceed the ceiling (no transient over-budget window — tested).
- Trade-off: smaller shares can increase seek backfill reads, mitigated by the keyframe index which survives eviction and keeps backfills single-request.

## Claimed scope

Deterministic configured bound only: cache count equals active controllers and the aggregate configured limit is ≤ 128 MiB (both test-enforced, including the camera-count matrix above). No end-to-end memory or latency claim is made here.

## Verification

- Camera-count matrix test (1/2/5/8/16/32) pins the allocation table.
- Synchronous register→prune test proves no transient over-budget state.
- Disposal/idempotence and hidden-topic exclusion tests cover the lifecycle (the earlier review finding about inactive panels is fixed and test-pinned).
