### PR TITLE
perf(studio): gate concurrent video seek reads

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.test.ts
@@ -32,6 +32,7 @@ import {
 } from "./MessageHandler";
 import { ConfigWithDefaults } from "./types";
 import { AnyImage, CompressedVideo } from "../Images/ImageTypes";
+import { globalVideoSeekLookbackGate } from "../Images/videoSeekLookbackGate";
 
 function timeFromNanoseconds(timestamp: bigint): Time {
   return {
@@ -61,6 +62,13 @@ function timestampFromImage(image: AnyImage): Time {
 
 async function flushAsyncWork(): Promise<void> {
   await new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
+/** Drain microtasks after range-read lookback (gate finally + display continuation). */
+async function flushLookbackMicrotasks(times: number = 16): Promise<void> {
+  for (let i = 0; i < times; i++) {
+    await Promise.resolve();
+  }
 }
 
 class FakeMessageHandler implements IMessageHandler {
@@ -278,6 +286,7 @@ function compressedVideoSubscription(imageMode: ImageMode) {
 
 describe("ImageMode compressed video seek replay", () => {
   beforeEach(() => {
+    globalVideoSeekLookbackGate.resetForTests();
     jest.spyOn(H264, "IsAnnexB").mockReturnValue(true);
     jest.spyOn(H264, "GetFrameInfo").mockImplementation((data) => ({
       isKeyFrame: data[0] === 0x65,
@@ -287,6 +296,7 @@ describe("ImageMode compressed video seek replay", () => {
 
   afterEach(() => {
     nextMessageHandler = undefined;
+    globalVideoSeekLookbackGate.resetForTests();
     jest.restoreAllMocks();
   });
 
@@ -533,8 +543,8 @@ describe("ImageMode compressed video seek replay", () => {
           yield [keyframe, delta];
         })(),
       );
-      await Promise.resolve();
-      await Promise.resolve();
+      // Lookback continues after range read resolves (gate release finally + displayFrames).
+      await flushLookbackMicrotasks();
 
       const displayedBatches = imageMode.createdRenderables.flatMap((renderable) =>
         renderable.setCompressedVideoFrameBatches.map((batch) => batch.map(timestampFromImage)),

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.test.ts
@@ -25,6 +25,7 @@ import {
   type SetCompressedVideoFramesOptions,
 } from "./Images/ImageRenderable";
 import { AnyImage, CompressedVideo } from "./Images/ImageTypes";
+import { globalVideoSeekLookbackGate } from "./Images/videoSeekLookbackGate";
 
 function timeFromNanoseconds(timestamp: bigint): Time {
   return {
@@ -163,6 +164,7 @@ function makeRenderer(
 
 describe("Images compressed video seek lookback", () => {
   beforeEach(() => {
+    globalVideoSeekLookbackGate.resetForTests();
     jest.spyOn(H264, "IsAnnexB").mockReturnValue(true);
     jest.spyOn(H264, "GetFrameInfo").mockImplementation((data) => ({
       isKeyFrame: data[0] === 0x65,
@@ -171,6 +173,7 @@ describe("Images compressed video seek lookback", () => {
   });
 
   afterEach(() => {
+    globalVideoSeekLookbackGate.resetForTests();
     jest.restoreAllMocks();
   });
 
@@ -329,6 +332,8 @@ describe("Images compressed video seek lookback", () => {
         yield [keyframe, delta, targetDelta];
       })(),
     );
+    // Range-read gate finally + displayFrames continue after the iterator settles.
+    await flushAsyncWork();
     await flushAsyncWork();
 
     expect(

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.test.ts
@@ -34,9 +34,13 @@ function timeFromNanoseconds(timestamp: bigint): Time {
   };
 }
 
-function makeVideoMessage(timestamp: bigint, type: "key" | "delta"): MessageEvent<CompressedVideo> {
+function makeVideoMessage(
+  timestamp: bigint,
+  type: "key" | "delta",
+  topic: string = "/video",
+): MessageEvent<CompressedVideo> {
   return {
-    topic: "/video",
+    topic,
     schemaName: "foxglove.CompressedVideo",
     receiveTime: timeFromNanoseconds(timestamp),
     message: {
@@ -107,11 +111,13 @@ function makeRenderer(
   options: {
     topicSettings?: Record<string, Partial<LayerSettingsImage> | undefined>;
     subscribeMessageRange?: SubscribeMessageRange;
+    videoTopics?: string[];
   } = {},
 ): IRenderer {
   const emitter = new EventEmitter();
+  const videoTopics = options.videoTopics ?? ["/video"];
   const topics = [
-    { name: "/video", schemaName: "foxglove.CompressedVideo" },
+    ...videoTopics.map((name) => ({ name, schemaName: "foxglove.CompressedVideo" })),
     { name: "/raw", schemaName: "foxglove.RawImage" },
   ];
   const config: RendererConfig = {
@@ -122,7 +128,7 @@ function makeRenderer(
     publish: {},
     transforms: {},
     topics: options.topicSettings ?? {
-      "/video": { visible: true },
+      ...Object.fromEntries(videoTopics.map((name) => [name, { visible: true }])),
       "/raw": { visible: true },
     },
     layers: {},
@@ -346,5 +352,200 @@ describe("Images compressed video seek lookback", () => {
       targetDelta.message.timestamp,
     ]);
     expect(renderer.hud.getHUDItems().map((item) => item.id)).not.toContain("SEEK_KEYFRAME_SEARCH");
+  });
+});
+
+describe("Images compressed video seek lookback gate contention", () => {
+  // Five cameras — the Astribot S1 layout shape. Unlike the gate unit tests, real keyframe/delta
+  // frames flow through the gated range reads here, so queueing and stale-waiter dropping are
+  // exercised together with GOP recovery and display, not in isolation.
+  const VIDEO_TOPICS = ["/video0", "/video1", "/video2", "/video3", "/video4"];
+
+  type CapturedRead = {
+    topic: string;
+    timeRange: { start: Time; end: Time };
+    onNewRangeIterator: Parameters<SubscribeMessageRange>[0]["onNewRangeIterator"];
+    unsubscribe: jest.Mock;
+    resolved: boolean;
+  };
+
+  beforeEach(() => {
+    globalVideoSeekLookbackGate.resetForTests();
+    jest.spyOn(H264, "IsAnnexB").mockReturnValue(true);
+    jest.spyOn(H264, "GetFrameInfo").mockImplementation((data) => ({
+      isKeyFrame: data[0] === 0x65,
+      mayNeedRewrite: false,
+    }));
+  });
+
+  afterEach(() => {
+    globalVideoSeekLookbackGate.resetForTests();
+    jest.restoreAllMocks();
+  });
+
+  function makeContendedSetup() {
+    const reads: CapturedRead[] = [];
+    const subscribeMessageRange = jest.fn<
+      ReturnType<SubscribeMessageRange>,
+      Parameters<SubscribeMessageRange>
+    >((args) => {
+      const unsubscribe = jest.fn();
+      reads.push({
+        topic: args.topic,
+        timeRange: args.timeRange,
+        onNewRangeIterator: args.onNewRangeIterator,
+        unsubscribe,
+        resolved: false,
+      });
+      return unsubscribe;
+    });
+    const renderer = makeRenderer({ videoTopics: VIDEO_TOPICS, subscribeMessageRange });
+    renderer.currentTime = 0n;
+    const images = new TestImages(renderer);
+    const subscription = images
+      .getSubscriptions()
+      .find(
+        (entry) => entry.type === "schema" && entry.schemaNames.has("foxglove.CompressedVideo"),
+      )?.subscription;
+    if (subscription == undefined) {
+      throw new Error("Missing compressed video subscription");
+    }
+    return { reads, renderer, images, subscription };
+  }
+
+  async function resolveRead(read: CapturedRead, frames: MessageEvent<CompressedVideo>[]) {
+    read.resolved = true;
+    await read.onNewRangeIterator(
+      (async function* () {
+        yield frames;
+      })(),
+    );
+    await flushAsyncWork();
+  }
+
+  function displayedSeekBatches(images: TestImages, topic: string): Time[][] {
+    const renderable = images.renderables.get(topic) as TestImageRenderable | undefined;
+    return (renderable?.setCompressedVideoFrameBatches ?? []).map((batch) =>
+      batch.map(timestampFromImage),
+    );
+  }
+
+  it("recovers GOPs on five cameras while at most two range reads run concurrently", async () => {
+    const { reads, renderer, images, subscription } = makeContendedSetup();
+
+    for (const topic of VIDEO_TOPICS) {
+      subscription.handler(makeVideoMessage(0n, "key", topic));
+      subscription.handler(makeVideoMessage(10_000_000n, "delta", topic));
+    }
+    await flushAsyncWork();
+
+    (
+      images as unknown as { removeAllRenderables(args?: { reason?: "seek" }): void }
+    ).removeAllRenderables({ reason: "seek" });
+    renderer.currentTime = 20_000_000n;
+    images.handleSeek();
+
+    // All five cameras want a lookback read, but only two slots exist.
+    expect(reads).toHaveLength(2);
+    expect(reads.map((read) => read.topic)).toEqual(["/video0", "/video1"]);
+    expect(globalVideoSeekLookbackGate.getActiveCount()).toBe(2);
+    expect(globalVideoSeekLookbackGate.getPendingCount()).toBe(3);
+
+    // Each resolved read frees its slot for exactly one queued camera.
+    for (const expectedCount of [3, 4, 5, 5, 5]) {
+      const nextUnresolved = reads.find((read) => !read.resolved);
+      expect(nextUnresolved).toBeDefined();
+      const topic = nextUnresolved!.topic;
+      await resolveRead(nextUnresolved!, [
+        makeVideoMessage(0n, "key", topic),
+        makeVideoMessage(10_000_000n, "delta", topic),
+        makeVideoMessage(20_000_000n, "delta", topic),
+      ]);
+      expect(reads.length).toBe(expectedCount);
+      expect(globalVideoSeekLookbackGate.getActiveCount()).toBeLessThanOrEqual(2);
+    }
+
+    // Every camera issued exactly one read and displayed its recovered GOP up to the target.
+    expect(reads.map((read) => read.topic).sort()).toEqual([...VIDEO_TOPICS].sort());
+    for (const topic of VIDEO_TOPICS) {
+      expect(displayedSeekBatches(images, topic)).toContainEqual([
+        timeFromNanoseconds(0n),
+        timeFromNanoseconds(10_000_000n),
+        timeFromNanoseconds(20_000_000n),
+      ]);
+    }
+    expect(globalVideoSeekLookbackGate.getActiveCount()).toBe(0);
+    expect(globalVideoSeekLookbackGate.getPendingCount()).toBe(0);
+  });
+
+  it("drops queued waiters superseded by a newer seek and completes the new seek with frames", async () => {
+    const { reads, renderer, images, subscription } = makeContendedSetup();
+
+    for (const topic of VIDEO_TOPICS) {
+      subscription.handler(makeVideoMessage(0n, "key", topic));
+      subscription.handler(makeVideoMessage(10_000_000n, "delta", topic));
+    }
+    await flushAsyncWork();
+
+    (
+      images as unknown as { removeAllRenderables(args?: { reason?: "seek" }): void }
+    ).removeAllRenderables({ reason: "seek" });
+    renderer.currentTime = 20_000_000n;
+    images.handleSeek();
+
+    expect(reads).toHaveLength(2);
+    expect(globalVideoSeekLookbackGate.getPendingCount()).toBe(3);
+
+    // A newer seek supersedes everything: the two in-flight reads are cancelled and the three
+    // queued waiters must be dropped without ever issuing their stale reads.
+    renderer.currentTime = 40_000_000n;
+    images.handleSeek();
+    await flushAsyncWork();
+
+    // 2 cancelled reads from the first seek + 2 new reads now holding the slots. The three stale
+    // waiters produced no reads.
+    expect(reads).toHaveLength(4);
+    expect(reads[0]!.unsubscribe).toHaveBeenCalled();
+    expect(reads[1]!.unsubscribe).toHaveBeenCalled();
+    const newReads = reads.slice(2);
+    expect(newReads.map((read) => read.topic)).toEqual(["/video0", "/video1"]);
+    for (const read of newReads) {
+      expect(read.timeRange.end).toEqual(timeFromNanoseconds(40_000_000n));
+    }
+    expect(globalVideoSeekLookbackGate.getActiveCount()).toBe(2);
+    expect(globalVideoSeekLookbackGate.getPendingCount()).toBe(3);
+
+    // The new seek settles: every camera reads once for the new target and displays its GOP.
+    reads[0]!.resolved = true;
+    reads[1]!.resolved = true;
+    for (;;) {
+      const nextUnresolved = reads.find((read) => !read.resolved);
+      if (nextUnresolved == undefined) {
+        break;
+      }
+      const topic = nextUnresolved.topic;
+      await resolveRead(nextUnresolved, [
+        makeVideoMessage(0n, "key", topic),
+        makeVideoMessage(10_000_000n, "delta", topic),
+        makeVideoMessage(40_000_000n, "delta", topic),
+      ]);
+    }
+
+    expect(reads).toHaveLength(7);
+    expect(
+      reads
+        .slice(2)
+        .map((read) => read.topic)
+        .sort(),
+    ).toEqual([...VIDEO_TOPICS].sort());
+    for (const topic of VIDEO_TOPICS) {
+      expect(displayedSeekBatches(images, topic)).toContainEqual([
+        timeFromNanoseconds(0n),
+        timeFromNanoseconds(10_000_000n),
+        timeFromNanoseconds(40_000_000n),
+      ]);
+    }
+    expect(globalVideoSeekLookbackGate.getActiveCount()).toBe(0);
+    expect(globalVideoSeekLookbackGate.getPendingCount()).toBe(0);
   });
 });

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.test.ts
@@ -20,6 +20,7 @@ import {
 } from "./CompressedVideoController";
 import { type CompressedVideoFrameEvent, type ImageSetImageResult } from "./ImageRenderable";
 import { CompressedVideo } from "./ImageTypes";
+import { globalVideoSeekLookbackGate } from "./videoSeekLookbackGate";
 
 function timeFromNanoseconds(timestamp: bigint): Time {
   return {
@@ -122,6 +123,8 @@ async function flushAsyncWork(): Promise<void> {
 
 describe("CompressedVideoController", () => {
   beforeEach(() => {
+    // Isolate multi-camera seek lookback gate state across tests (REI-125).
+    globalVideoSeekLookbackGate.resetForTests();
     jest.spyOn(H264, "IsAnnexB").mockReturnValue(true);
     jest.spyOn(H264, "IsKeyframe").mockImplementation((data) => data[0] === 0x65);
     jest.spyOn(H264, "GetFrameInfo").mockImplementation((data) => ({
@@ -132,6 +135,7 @@ describe("CompressedVideoController", () => {
 
   afterEach(() => {
     jest.useRealTimers();
+    globalVideoSeekLookbackGate.resetForTests();
   });
 
   afterEach(() => {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.test.ts
@@ -123,7 +123,7 @@ async function flushAsyncWork(): Promise<void> {
 
 describe("CompressedVideoController", () => {
   beforeEach(() => {
-    // Isolate multi-camera seek lookback gate state across tests (REI-125).
+    // Isolate multi-camera seek lookback gate state across tests.
     globalVideoSeekLookbackGate.resetForTests();
     jest.spyOn(H264, "IsAnnexB").mockReturnValue(true);
     jest.spyOn(H264, "IsKeyframe").mockImplementation((data) => data[0] === 0x65);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts
@@ -24,6 +24,7 @@ import type {
 import { CompressedVideo } from "./ImageTypes";
 import { normalizeCompressedVideo } from "./imageNormalizers";
 import { VideoGopCache, parseVideoFrameInfo } from "./videoGopCache";
+import { globalVideoSeekLookbackGate } from "./videoSeekLookbackGate";
 import { IRenderer } from "../../IRenderer";
 import { PartialMessageEvent } from "../../SceneExtension";
 
@@ -788,18 +789,53 @@ export class CompressedVideoController {
     startTime: Time,
     endTime: Time,
   ): Promise<MessageEvent[] | undefined> {
-    let frames = await this.#readRange(generation, startTime, endTime);
+    let frames = await this.#readRangeGated(generation, startTime, endTime);
     for (const retryDelayMs of LOOKBACK_RANGE_RETRY_DELAYS_MS) {
       if (frames != undefined || !this.#isCurrentLookback(generation)) {
         return frames;
       }
+      // Backoff happens outside the concurrency slot so a retrying camera does not block others.
       await delay(retryDelayMs);
       if (!this.#isCurrentLookback(generation)) {
         return undefined;
       }
-      frames = await this.#readRange(generation, startTime, endTime);
+      frames = await this.#readRangeGated(generation, startTime, endTime);
     }
     return frames;
+  }
+
+  /**
+   * Single range-read attempt holding a lookback concurrency slot (REI-125).
+   *
+   * This is the only section the gate covers. Keeping decode, the window ladder and retry backoff
+   * outside means a stalled camera can occupy a slot for at most one read timeout, and cameras
+   * 3-5 no longer wait on earlier cameras' decode work.
+   */
+  async #readRangeGated(
+    generation: number,
+    startTime: Time,
+    endTime: Time,
+  ): Promise<MessageEvent[] | undefined> {
+    // Prefer tryAcquire so the common under-limit path stays synchronous (tests and single-camera
+    // seeks don't pay a microtask).
+    if (!globalVideoSeekLookbackGate.tryAcquire()) {
+      const acquired = await globalVideoSeekLookbackGate.acquire(() =>
+        this.#isCurrentLookback(generation),
+      );
+      if (!acquired) {
+        // Superseded by a newer seek while queued; no slot held.
+        return undefined;
+      }
+      if (!this.#isCurrentLookback(generation)) {
+        globalVideoSeekLookbackGate.release();
+        return undefined;
+      }
+    }
+    try {
+      return await this.#readRange(generation, startTime, endTime);
+    } finally {
+      globalVideoSeekLookbackGate.release();
+    }
   }
 
   async #readRange(

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts
@@ -805,7 +805,7 @@ export class CompressedVideoController {
   }
 
   /**
-   * Single range-read attempt holding a lookback concurrency slot (REI-125).
+   * Single range-read attempt holding a lookback concurrency slot.
    *
    * This is the only section the gate covers. Keeping decode, the window ladder and retry backoff
    * outside means a stalled camera can occupy a slot for at most one read timeout, and cameras

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoSeekLookbackGate.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoSeekLookbackGate.test.ts
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { VideoSeekLookbackGate } from "./videoSeekLookbackGate";
+
+describe("VideoSeekLookbackGate", () => {
+  it("tryAcquire is synchronous and does not queue", () => {
+    const gate = new VideoSeekLookbackGate(1);
+    expect(gate.tryAcquire()).toBe(true);
+    expect(gate.tryAcquire()).toBe(false);
+    expect(gate.getActiveCount()).toBe(1);
+    expect(gate.getPendingCount()).toBe(0);
+    gate.release();
+    expect(gate.tryAcquire()).toBe(true);
+    gate.release();
+  });
+
+  it("allows up to maxConcurrent acquires without waiting", async () => {
+    const gate = new VideoSeekLookbackGate(2);
+    await gate.acquire();
+    await gate.acquire();
+    expect(gate.getActiveCount()).toBe(2);
+    expect(gate.getPendingCount()).toBe(0);
+    gate.release();
+    gate.release();
+    expect(gate.getActiveCount()).toBe(0);
+  });
+
+  it("queues a third acquire until a slot is released", async () => {
+    const gate = new VideoSeekLookbackGate(2);
+    await gate.acquire();
+    await gate.acquire();
+
+    let thirdResolved = false;
+    const third = gate.acquire().then(() => {
+      thirdResolved = true;
+    });
+
+    // Let the microtask queue flush; third must still be pending.
+    await Promise.resolve();
+    expect(thirdResolved).toBe(false);
+    expect(gate.getPendingCount()).toBe(1);
+    expect(gate.getActiveCount()).toBe(2);
+
+    gate.release();
+    await third;
+    expect(thirdResolved).toBe(true);
+    expect(gate.getActiveCount()).toBe(2);
+    expect(gate.getPendingCount()).toBe(0);
+
+    gate.release();
+    gate.release();
+    expect(gate.getActiveCount()).toBe(0);
+  });
+
+  it("runExclusive serializes work beyond the concurrency limit", async () => {
+    const gate = new VideoSeekLookbackGate(1);
+    const order: number[] = [];
+    let releaseFirst!: () => void;
+    const firstHold = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const first = gate.runExclusive(async () => {
+      order.push(1);
+      await firstHold;
+      order.push(2);
+      return "a";
+    });
+
+    const second = gate.runExclusive(async () => {
+      order.push(3);
+      return "b";
+    });
+
+    await Promise.resolve();
+    expect(order).toEqual([1]);
+    expect(gate.getPendingCount()).toBe(1);
+
+    releaseFirst();
+    await expect(first).resolves.toBe("a");
+    await expect(second).resolves.toBe("b");
+    expect(order).toEqual([1, 2, 3]);
+    expect(gate.getActiveCount()).toBe(0);
+  });
+
+  it("rejects maxConcurrent < 1", () => {
+    expect(() => new VideoSeekLookbackGate(0)).toThrow(/maxConcurrent/);
+  });
+
+  it("acquire resolves true when a slot is taken", async () => {
+    const gate = new VideoSeekLookbackGate(1);
+    await expect(gate.acquire()).resolves.toBe(true);
+    gate.release();
+  });
+
+  it("drops a superseded waiter and resolves it false without consuming a slot", async () => {
+    const gate = new VideoSeekLookbackGate(1);
+    expect(gate.tryAcquire()).toBe(true);
+
+    // This waiter's work is already superseded, so it should never receive the slot.
+    const superseded = gate.acquire(() => false);
+    const live = gate.acquire();
+
+    await Promise.resolve();
+    expect(gate.getPendingCount()).toBe(2);
+
+    // The stale waiter is dropped when the slot frees; the live one gets it instead.
+    gate.release();
+    await expect(superseded).resolves.toBe(false);
+    await expect(live).resolves.toBe(true);
+    expect(gate.getActiveCount()).toBe(1);
+    expect(gate.getPendingCount()).toBe(0);
+
+    gate.release();
+    expect(gate.getActiveCount()).toBe(0);
+  });
+
+  it("does not head-of-line block: a live waiter behind stale ones runs immediately", async () => {
+    const gate = new VideoSeekLookbackGate(1);
+    expect(gate.tryAcquire()).toBe(true);
+
+    const order: string[] = [];
+    const dead = [0, 1, 2].map(async (i) => {
+      const acquired = await gate.acquire(() => false);
+      order.push(`dead${i}:${acquired}`);
+      return acquired;
+    });
+    const livePromise = gate
+      .acquire(() => true)
+      .then((acquired) => {
+        order.push(`live:${acquired}`);
+        return acquired;
+      });
+
+    await Promise.resolve();
+    expect(gate.getPendingCount()).toBe(4);
+
+    // A single release drains all three stale waiters and hands the slot to the live one.
+    gate.release();
+    await Promise.all(dead);
+    await expect(livePromise).resolves.toBe(true);
+    expect(order).toEqual(["dead0:false", "dead1:false", "dead2:false", "live:true"]);
+    expect(gate.getActiveCount()).toBe(1);
+
+    gate.release();
+    expect(gate.getActiveCount()).toBe(0);
+  });
+
+  it("releases the slot entirely when every waiter is stale", async () => {
+    const gate = new VideoSeekLookbackGate(1);
+    expect(gate.tryAcquire()).toBe(true);
+
+    const stale = gate.acquire(() => false);
+    await Promise.resolve();
+
+    gate.release();
+    await expect(stale).resolves.toBe(false);
+    expect(gate.getActiveCount()).toBe(0);
+    expect(gate.getPendingCount()).toBe(0);
+    expect(gate.tryAcquire()).toBe(true);
+    gate.release();
+  });
+});

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoSeekLookbackGate.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoSeekLookbackGate.ts
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+/**
+ * Global concurrency limit for H.264/H.265 seek keyframe lookback **range reads**.
+ *
+ * Multi-camera layouts (e.g. 5 Image panels) each start a lookback on seek. Without a gate,
+ * concurrent range reads contend for the browser's per-origin HTTP connection pool and for
+ * remote shard readers, causing seek jank. Limiting concurrent reads keeps early cameras
+ * responsive while others queue.
+ *
+ * Scope note (REI-125 review): the gate deliberately covers only the network range read, **not**
+ * WebCodecs decode/display. Decode runs on a separate worker/hardware path and is not a contended
+ * resource, so holding a slot across it only serialized cameras 3-5 for no benefit (measured
+ * ~2.6 s of aggregate queue wait with no wall-clock win). Retry backoff sleeps are likewise
+ * outside the slot.
+ *
+ * REI-125: Astribot S1 public share-manifest has 5 concurrent video panels.
+ */
+export const DEFAULT_VIDEO_SEEK_LOOKBACK_CONCURRENCY = 2;
+
+/** Outcome handed to a queued waiter: it either got the slot or was dropped as superseded. */
+type WaiterOutcome = "acquired" | "dropped";
+
+type Waiter = {
+  resolve: (outcome: WaiterOutcome) => void;
+  reject: (error: Error) => void;
+  /**
+   * Optional liveness predicate. Evaluated when a slot frees: a waiter whose work has been
+   * superseded (e.g. a newer seek) is dropped and the slot passes to the next live waiter,
+   * so stale entries cannot head-of-line block the queue.
+   */
+  isStillNeeded?: () => boolean;
+};
+
+export class VideoSeekLookbackGate {
+  readonly #maxConcurrent: number;
+  #active = 0;
+  readonly #waiters: Waiter[] = [];
+
+  public constructor(maxConcurrent: number = DEFAULT_VIDEO_SEEK_LOOKBACK_CONCURRENCY) {
+    if (maxConcurrent < 1) {
+      throw new Error("VideoSeekLookbackGate maxConcurrent must be >= 1");
+    }
+    this.#maxConcurrent = maxConcurrent;
+  }
+
+  public getActiveCount(): number {
+    return this.#active;
+  }
+
+  public getPendingCount(): number {
+    return this.#waiters.length;
+  }
+
+  public getMaxConcurrent(): number {
+    return this.#maxConcurrent;
+  }
+
+  /**
+   * Try to take a slot without waiting. Returns true if acquired (caller must `release()`).
+   * Prefer this on the hot path so seek lookback can start synchronously when under the limit.
+   */
+  public tryAcquire(): boolean {
+    if (this.#active < this.#maxConcurrent) {
+      this.#active += 1;
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Acquire a lookback slot, waiting if necessary. Prefer `tryAcquire()` first to avoid an
+   * unnecessary microtask when a slot is free.
+   *
+   * Resolves `true` when a slot was taken (the caller **must** `release()`), or `false` when the
+   * caller was dropped from the queue because `isStillNeeded` returned false while it waited. A
+   * `false` result means no slot is held and nothing needs releasing.
+   */
+  public async acquire(isStillNeeded?: () => boolean): Promise<boolean> {
+    if (this.tryAcquire()) {
+      return true;
+    }
+
+    const outcome = await new Promise<WaiterOutcome>((resolve, reject) => {
+      this.#waiters.push({ resolve, reject, isStillNeeded });
+    });
+    return outcome === "acquired";
+  }
+
+  public release(): void {
+    if (this.#active <= 0) {
+      return;
+    }
+
+    // Hand the slot to the first waiter that still needs it, discarding superseded waiters along
+    // the way. Without this drain a cancelled seek's waiter would hold its place in line and
+    // delay live work behind it.
+    for (;;) {
+      const next = this.#waiters.shift();
+      if (!next) {
+        this.#active -= 1;
+        return;
+      }
+      if (next.isStillNeeded != undefined && !next.isStillNeeded()) {
+        next.resolve("dropped");
+        continue;
+      }
+      // Transfer the slot directly to the next waiter without decrementing.
+      next.resolve("acquired");
+      return;
+    }
+  }
+
+  /** Run `fn` while holding a slot. */
+  public async runExclusive<T>(fn: () => Promise<T>): Promise<T> {
+    await this.acquire();
+    try {
+      return await fn();
+    } finally {
+      this.release();
+    }
+  }
+
+  /** Test helper: drain waiters (reject) and reset counts. */
+  public resetForTests(): void {
+    const waiters = this.#waiters.splice(0, this.#waiters.length);
+    this.#active = 0;
+    for (const waiter of waiters) {
+      waiter.reject(new Error("VideoSeekLookbackGate reset"));
+    }
+  }
+}
+
+/** Process-wide gate shared by all CompressedVideoController instances. */
+export const globalVideoSeekLookbackGate = new VideoSeekLookbackGate();

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoSeekLookbackGate.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoSeekLookbackGate.ts
@@ -13,13 +13,13 @@
  * remote shard readers, causing seek jank. Limiting concurrent reads keeps early cameras
  * responsive while others queue.
  *
- * Scope note (REI-125 review): the gate deliberately covers only the network range read, **not**
+ * Scope note: the gate deliberately covers only the network range read, **not**
  * WebCodecs decode/display. Decode runs on a separate worker/hardware path and is not a contended
  * resource, so holding a slot across it only serialized cameras 3-5 for no benefit (measured
  * ~2.6 s of aggregate queue wait with no wall-clock win). Retry backoff sleeps are likewise
  * outside the slot.
  *
- * REI-125: Astribot S1 public share-manifest has 5 concurrent video panels.
+ * Motivating workload: the Astribot S1 share-manifest layout has 5 concurrent video panels.
  */
 export const DEFAULT_VIDEO_SEEK_LOOKBACK_CONCURRENCY = 2;
 


### PR DESCRIPTION
## Summary

On seek, every visible video panel starts a keyframe lookback — a remote range read. With five cameras those reads contend for the browser's per-origin connection pool. This PR adds a process-wide counting semaphore limiting **only the remote range-read attempt** to 2 concurrent operations. Retry backoff, window iteration, decode, and display all stay outside the gated section, so a stalled camera can hold a slot for at most one read timeout (~5 s) and cameras never wait on each other's decode work.

Waiters superseded by a newer seek are dropped when a slot frees (each waiter carries a liveness predicate), so stale seeks cannot head-of-line block live ones.

## Claimed scope

Deterministic properties only, all test-enforced:

- At most 2 concurrent remote range reads process-wide.
- Slot release is exception-safe (`try/finally`); no leaked slots.
- Superseded waiters are dropped without ever issuing their reads; the queue never head-of-line blocks.
- With five contending cameras and real keyframe/delta frames, every camera performs exactly one read, recovers its GOP, and displays the correct frames; a superseding seek drops the stale queue and still settles on all five cameras.

No latency claim is made here; the gate's benefit is bounding connection-pool contention.

## Verification

- Gate unit tests: queueing, stale-waiter drop, head-of-line drain, all-stale release.
- Five-camera contended integration tests with real frames through the gated path (both scenarios above). Both fail if the concurrency cap is lifted.
- Single-camera frame tests confirm the uncontended fast path is unchanged.
