### PR TITLE
perf(studio): add opt-in playhead block loading

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.test.ts
@@ -10,7 +10,11 @@ import PlayerProblemManager from "@foxglove/studio-base/players/PlayerProblemMan
 import { MessageBlock } from "@foxglove/studio-base/players/types";
 import { mockTopicSelection } from "@foxglove/studio-base/test/mocks/mockTopicSelection";
 
-import { BlockLoader, MEMORY_INFO_PRELOADED_MSGS } from "./BlockLoader";
+import {
+  BLOCK_LOAD_MAX_SPAN_DURATION_NS,
+  BlockLoader,
+  MEMORY_INFO_PRELOADED_MSGS,
+} from "./BlockLoader";
 import {
   GetBackfillMessagesArgs,
   IDeserializedIterableSource,
@@ -671,5 +675,272 @@ describe("BlockLoader", () => {
     // arrays should be unchanged.
     expect(firstBlockLoad?.[0]?.messagesByTopic["a"]).toBe(lastBlocks?.[0]?.messagesByTopic["a"]);
     expect(firstBlockLoad?.[1]?.messagesByTopic["a"]).toBe(lastBlocks?.[1]?.messagesByTopic["a"]);
+  });
+
+  it("loads blocks near focus time before earlier blocks (REI-125)", async () => {
+    const source = new TestSource();
+    const loadStarts: Array<{ start: number; end: number }> = [];
+
+    const loader = new BlockLoader({
+      maxBlocks: 4,
+      cacheSizeBytes: 100,
+      minBlockDurationNs: 1e9, // 1s blocks over [0,4)
+      source,
+      start: { sec: 0, nsec: 0 },
+      end: { sec: 3, nsec: 999_999_999 },
+      problemManager: new PlayerProblemManager(),
+      playheadFocusEnabled: true,
+    });
+
+    // One message per second → one message per block
+    const msgEvents: MessageEvent[] = [0, 1, 2, 3].map((sec) => ({
+      topic: "a",
+      receiveTime: { sec, nsec: 0 },
+      message: undefined,
+      sizeInBytes: 1,
+      schemaName: "foo",
+    }));
+
+    source.messageIterator = async function* messageIterator(
+      args: MessageIteratorArgs,
+    ): AsyncIterableIterator<Readonly<IteratorResult>> {
+      loadStarts.push({
+        start: args.start?.sec ?? -1,
+        end: args.end?.sec ?? -1,
+      });
+      for (const msgEvent of msgEvents) {
+        const t = msgEvent.receiveTime.sec;
+        const startSec = args.start?.sec ?? 0;
+        const endSec = args.end?.sec ?? Number.MAX_SAFE_INTEGER;
+        if (t >= startSec && t <= endSec) {
+          yield { type: "message-event", msgEvent };
+        }
+      }
+    };
+
+    // Focus near the end (block ~3) so the first span should start there, not at 0.
+    loader.setFocusTime({ sec: 3, nsec: 0 });
+    loader.setTopics(mockTopicSelection("a"));
+
+    await loader.startLoading({
+      progress: async (progress) => {
+        const ranges = progress.fullyLoadedFractionRanges ?? [];
+        const fullyLoaded = ranges.some((r) => r.start === 0 && r.end === 1);
+        if (fullyLoaded) {
+          await loader.stopLoading();
+        }
+      },
+    });
+
+    expect(loadStarts.length).toBeGreaterThanOrEqual(1);
+    // First range request should begin at/near the focus (sec >= 2), not at the bag start.
+    expect(loadStarts[0]!.start).toBeGreaterThanOrEqual(2);
+    // Later a range covering earlier history should also run.
+    expect(loadStarts.some((r) => r.start === 0)).toBe(true);
+  });
+
+  it("caps each load span duration so focus does not pull focus→EOF (REI-125)", async () => {
+    const source = new TestSource();
+    const loadRanges: Array<{ startSec: number; endSec: number }> = [];
+    // 30 one-second blocks; span cap is 10s so first focused request must not cover all 30.
+    const blockCount = 30;
+    const loader = new BlockLoader({
+      maxBlocks: blockCount,
+      cacheSizeBytes: 1_000_000,
+      minBlockDurationNs: 1e9,
+      source,
+      start: { sec: 0, nsec: 0 },
+      end: { sec: blockCount - 1, nsec: 999_999_999 },
+      problemManager: new PlayerProblemManager(),
+      playheadFocusEnabled: true,
+    });
+
+    const msgEvents: MessageEvent[] = Array.from({ length: blockCount }, (_, sec) => ({
+      topic: "a",
+      receiveTime: { sec, nsec: 0 },
+      message: undefined,
+      sizeInBytes: 1,
+      schemaName: "foo",
+    }));
+
+    source.messageIterator = async function* messageIterator(
+      args: MessageIteratorArgs,
+    ): AsyncIterableIterator<Readonly<IteratorResult>> {
+      const startSec = args.start?.sec ?? 0;
+      const endSec = args.end?.sec ?? Number.MAX_SAFE_INTEGER;
+      loadRanges.push({ startSec, endSec });
+      for (const msgEvent of msgEvents) {
+        const t = msgEvent.receiveTime.sec;
+        if (t >= startSec && t <= endSec) {
+          yield { type: "message-event", msgEvent };
+        }
+      }
+    };
+
+    // Focus mid-bag so without a cap the first span would expand to EOF.
+    loader.setFocusTime({ sec: 15, nsec: 0 });
+    loader.setTopics(mockTopicSelection("a"));
+
+    await loader.startLoading({
+      progress: async (progress) => {
+        const ranges = progress.fullyLoadedFractionRanges ?? [];
+        if (ranges.some((r) => r.start === 0 && r.end === 1)) {
+          await loader.stopLoading();
+        }
+      },
+    });
+
+    expect(loadRanges.length).toBeGreaterThan(1);
+    const first = loadRanges[0]!;
+    // First request starts at/near focus.
+    expect(first.startSec).toBeGreaterThanOrEqual(14);
+    // And is capped (~10s of blocks), not the full remaining timeline to ~29s.
+    const firstDurationSec = first.endSec - first.startSec;
+    const maxSpanSec = BLOCK_LOAD_MAX_SPAN_DURATION_NS / 1e9;
+    expect(firstDurationSec).toBeLessThanOrEqual(maxSpanSec + 1);
+    expect(first.endSec).toBeLessThan(blockCount - 1);
+  });
+
+  it("aborts in-flight load and restarts near a new focus on seek (REI-125)", async () => {
+    const source = new TestSource();
+    const loadStarts: number[] = [];
+    let resolveSlow: (() => void) | undefined;
+    const slowGate = new Promise<void>((resolve) => {
+      resolveSlow = resolve;
+    });
+    let iteratorCalls = 0;
+
+    const loader = new BlockLoader({
+      maxBlocks: 20,
+      cacheSizeBytes: 1_000_000,
+      minBlockDurationNs: 1e9,
+      source,
+      start: { sec: 0, nsec: 0 },
+      end: { sec: 19, nsec: 999_999_999 },
+      problemManager: new PlayerProblemManager(),
+      playheadFocusEnabled: true,
+    });
+
+    source.messageIterator = async function* messageIterator(
+      args: MessageIteratorArgs,
+    ): AsyncIterableIterator<Readonly<IteratorResult>> {
+      iteratorCalls += 1;
+      const startSec = args.start?.sec ?? 0;
+      loadStarts.push(startSec);
+
+      // First open stalls until we seek, simulating a slow range read from bag start.
+      if (iteratorCalls === 1) {
+        await slowGate;
+        if (args.abortSignal?.aborted === true) {
+          return;
+        }
+      }
+
+      for (let sec = 0; sec < 20; sec++) {
+        if (args.abortSignal?.aborted === true) {
+          return;
+        }
+        const t = sec;
+        const endSec = args.end?.sec ?? Number.MAX_SAFE_INTEGER;
+        if (t >= startSec && t <= endSec) {
+          yield {
+            type: "message-event",
+            msgEvent: {
+              topic: "a",
+              receiveTime: { sec: t, nsec: 0 },
+              message: undefined,
+              sizeInBytes: 1,
+              schemaName: "foo",
+            },
+          };
+        }
+      }
+    };
+
+    loader.setTopics(mockTopicSelection("a"));
+
+    const loading = loader.startLoading({
+      progress: async (progress) => {
+        const ranges = progress.fullyLoadedFractionRanges ?? [];
+        if (ranges.some((r) => r.start === 0 && r.end === 1)) {
+          await loader.stopLoading();
+        }
+      },
+    });
+
+    // Wait until the first iterator has started at bag start.
+    for (let i = 0; i < 50 && loadStarts.length === 0; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(loadStarts[0]).toBe(0);
+
+    // Seek focus to mid-bag with abort — should cancel the start-of-bag span.
+    loader.setFocusTime({ sec: 12, nsec: 0 }, { abortInFlight: true });
+    resolveSlow?.();
+
+    await loading;
+
+    // A later request should start near the seek focus (not only complete from 0).
+    expect(loadStarts.some((s) => s >= 10)).toBe(true);
+  });
+
+  it("ignores focus and loads one contiguous span by default (REI-125)", async () => {
+    const source = new TestSource();
+    const loadRanges: Array<{ startSec: number; endSec: number }> = [];
+    const blockCount = 30;
+
+    // No playheadFocusEnabled: block consumers use ascending cursors, so focus must stay off.
+    const loader = new BlockLoader({
+      maxBlocks: blockCount,
+      cacheSizeBytes: 1_000_000,
+      minBlockDurationNs: 1e9,
+      source,
+      start: { sec: 0, nsec: 0 },
+      end: { sec: blockCount - 1, nsec: 999_999_999 },
+      problemManager: new PlayerProblemManager(),
+    });
+
+    const msgEvents: MessageEvent[] = Array.from({ length: blockCount }, (_, sec) => ({
+      topic: "a",
+      receiveTime: { sec, nsec: 0 },
+      message: undefined,
+      sizeInBytes: 1,
+      schemaName: "foo",
+    }));
+
+    source.messageIterator = async function* messageIterator(
+      args: MessageIteratorArgs,
+    ): AsyncIterableIterator<Readonly<IteratorResult>> {
+      loadRanges.push({
+        startSec: args.start?.sec ?? -1,
+        endSec: args.end?.sec ?? -1,
+      });
+      for (const msgEvent of msgEvents) {
+        const t = msgEvent.receiveTime.sec;
+        const startSec = args.start?.sec ?? 0;
+        const endSec = args.end?.sec ?? Number.MAX_SAFE_INTEGER;
+        if (t >= startSec && t <= endSec) {
+          yield { type: "message-event", msgEvent };
+        }
+      }
+    };
+
+    // Focus calls are no-ops while the feature is off; an abort here must not restart loading.
+    loader.setFocusTime({ sec: 25, nsec: 0 }, { abortInFlight: true });
+    loader.setTopics(mockTopicSelection("a"));
+
+    await loader.startLoading({
+      progress: async (progress) => {
+        const ranges = progress.fullyLoadedFractionRanges ?? [];
+        if (ranges.some((r) => r.start === 0 && r.end === 1)) {
+          await loader.stopLoading();
+        }
+      },
+    });
+
+    // Exactly one contiguous span from the bag start — no focus jump, no 10s span fragmentation.
+    expect(loadRanges).toHaveLength(1);
+    expect(loadRanges[0]!.startSec).toBe(0);
+    expect(loadRanges[0]!.endSec).toBe(blockCount - 1);
   });
 });

--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
@@ -30,6 +30,33 @@ const log = Log.getLogger(__filename);
 
 export const MEMORY_INFO_PRELOADED_MSGS = "Preloaded messages";
 
+/**
+ * Max continuous time loaded in a single BlockLoader span. Caps forward expansion so
+ * playhead-priority loading is not defeated by a single request from focus→EOF (REI-125).
+ * After each span completes, the next nearest incomplete neighborhood is chosen.
+ *
+ * Only applied when playhead focus is enabled — without focus the cap just fragments one
+ * contiguous preload into many smaller range requests that contend with video reads.
+ */
+export const BLOCK_LOAD_MAX_SPAN_DURATION_NS = 10_000_000_000; // 10 seconds
+
+/**
+ * Playhead-priority block loading is **off by default** (REI-125 review).
+ *
+ * Loading blocks outward from the playhead only pays off if block consumers can ingest blocks out
+ * of order, and today none can:
+ *   - `Plot/builders/BlockTopicCursor` stops at the first gap and returns nothing until block 0
+ *     arrives — which, under outward-from-focus fill, is the *last* block loaded.
+ *   - `StateTransitionsCoordinator` keeps a single ascending cursor per series.
+ *
+ * Enabling focus also fragments preload into many short spans (measured 1 → 8 range requests on
+ * the Astribot S1 layout), contending with the video seek range reads on the same origin.
+ *
+ * Re-enable via the `playheadFocusEnabled` constructor option once consumers merge blocks by
+ * timestamp rather than by ascending cursor. See docs/rei-125-perf-report.md.
+ */
+export const BLOCK_LOADER_PLAYHEAD_FOCUS_DEFAULT = false;
+
 type BlockLoaderArgs = {
   cacheSizeBytes: number;
   source: IDeserializedIterableSource;
@@ -38,6 +65,8 @@ type BlockLoaderArgs = {
   maxBlocks: number;
   minBlockDurationNs: number;
   problemManager: PlayerProblemManager;
+  /** See {@link BLOCK_LOADER_PLAYHEAD_FOCUS_DEFAULT}. Defaults to off. */
+  playheadFocusEnabled?: boolean;
 };
 
 type CacheBlock = MessageBlock & {
@@ -66,6 +95,10 @@ export class BlockLoader {
   #activeChangeCondvar: Condvar = new Condvar();
   #abortController: AbortController;
   #progressCallback?: (progress: Progress) => void;
+  /** Playhead focus used to prioritize which incomplete blocks load first (REI-125). */
+  #focusTime?: Time;
+  #focusBlockId: number = 0;
+  readonly #playheadFocusEnabled: boolean;
 
   public constructor(args: BlockLoaderArgs) {
     this.#source = args.source;
@@ -73,6 +106,7 @@ export class BlockLoader {
     this.#end = args.end;
     this.#maxCacheSize = args.cacheSizeBytes;
     this.#problemManager = args.problemManager;
+    this.#playheadFocusEnabled = args.playheadFocusEnabled ?? BLOCK_LOADER_PLAYHEAD_FOCUS_DEFAULT;
     this.#abortController = new AbortController();
 
     const totalNs = Number(toNanoSec(subtractTimes(this.#end, this.#start))) + 1; // +1 since times are inclusive.
@@ -88,6 +122,42 @@ export class BlockLoader {
 
     log.debug(`Block count: ${blockCount}`);
     this.#blocks = Array.from({ length: blockCount });
+  }
+
+  /**
+   * Hint the playhead time so incomplete blocks near the current view load first.
+   *
+   * When `abortInFlight` is true (seeks), an in-progress span is cancelled so the next
+   * load picks a span near the new playhead. Continuous playback should omit abort to
+   * avoid thrashing preload as the playhead crosses block boundaries.
+   */
+  public setFocusTime(time: Time | undefined, options?: { abortInFlight?: boolean }): void {
+    if (!this.#playheadFocusEnabled) {
+      // Focus is opt-in; leaving #focusTime undefined keeps the sequential left-to-right scan
+      // that every block consumer currently requires. See BLOCK_LOADER_PLAYHEAD_FOCUS_DEFAULT.
+      return;
+    }
+    if (time == undefined) {
+      if (this.#focusTime == undefined) {
+        return;
+      }
+      this.#focusTime = undefined;
+      this.#focusBlockId = 0;
+      return;
+    }
+
+    const nextBlockId = this.#timeToBlockId(time);
+    const focusBlockChanged = nextBlockId !== this.#focusBlockId || this.#focusTime == undefined;
+    this.#focusTime = time;
+    this.#focusBlockId = nextBlockId;
+
+    if (!focusBlockChanged || options?.abortInFlight !== true) {
+      return;
+    }
+
+    // Abort the in-flight span; #load returns "aborted" and startLoading loops without wait.
+    this.#abortController.abort();
+    this.#activeChangeCondvar.notifyAll();
   }
 
   public setTopics(topics: TopicSelection): void {
@@ -181,11 +251,16 @@ export class BlockLoader {
 
         const topics = this.#topics;
 
-        await this.#load({ progress: args.progress });
+        const loadResult = await this.#load({ progress: args.progress });
 
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         if (this.#stopped) {
           break;
+        }
+
+        // Aborted (seek focus) or topics changed: immediately pick the next span.
+        if (loadResult === "aborted" || loadResult === "topics-changed") {
+          continue;
         }
 
         // Wait for topics to possibly change.
@@ -198,47 +273,54 @@ export class BlockLoader {
     }
   }
 
-  async #load(args: { progress: LoadArgs["progress"] }): Promise<void> {
+  async #load(args: {
+    progress: LoadArgs["progress"];
+  }): Promise<"done" | "aborted" | "topics-changed"> {
     this.#progressCallback = args.progress;
     const topics = new Map(this.#topics);
 
     // Ignore changing the blocks if the topic list is empty
     if (topics.size === 0) {
       args.progress(this.#calculateProgress(topics, this.#cacheSize()));
-      return;
+      return "done";
     }
 
     if (this.#blocks.length === 0) {
-      return;
+      return "done";
     }
 
-    log.debug("loading blocks", { topics });
+    log.debug("loading blocks", { topics, focusBlockId: this.#focusBlockId });
 
     const { progress } = args;
     let totalBlockSizeBytes = this.#cacheSize();
 
-    for (let blockId = 0; blockId < this.#blocks.length; ++blockId) {
-      // Topics we will fetch for this range
-      let topicsToFetch: Immutable<TopicSelection>;
-
-      // Keep looking for a block that needs loading
-      {
-        const existingBlock = this.#blocks[blockId];
-
-        // The current block has everything, so we can move to the next block
-        if (existingBlock?.needTopics.size === 0) {
-          continue;
-        }
-
-        // The current block needs some topics so those will be come the topics we need to fetch
-        topicsToFetch = existingBlock?.needTopics ?? topics;
+    // Load incomplete spans until none remain. Prefer spans near the playhead so seek/deep-link
+    // views get preloaded StateTransitions/Plot history before distant blocks (REI-125).
+    for (;;) {
+      const blockId = this.#nextIncompleteBlockId(topics);
+      if (blockId == undefined) {
+        break;
       }
 
-      // blockId is the first block that needs loading
-      // Now we look for the last block. We do this by finding blocks that need the same topics to fetch.
-      // This creates a continuous span of the same topics to fetch
+      // Topics we will fetch for this range
+      const existingBlock = this.#blocks[blockId];
+      const topicsToFetch: Immutable<TopicSelection> = existingBlock?.needTopics ?? topics;
+
+      // Expand a continuous span forward only. When playhead focus is enabled the span is capped
+      // in duration so a focus near mid-bag does not pull the entire remaining timeline in one
+      // request; with focus off we keep the original single contiguous span, because splitting it
+      // only multiplies range requests that contend with video seek reads (REI-125 review).
+      const startBlockId = blockId;
+      const maxEndBlockId = this.#playheadFocusEnabled
+        ? Math.min(
+            this.#blocks.length - 1,
+            startBlockId +
+              Math.max(1, Math.ceil(BLOCK_LOAD_MAX_SPAN_DURATION_NS / this.#blockDurationNanos)) -
+              1,
+          )
+        : this.#blocks.length - 1;
       let endBlockId = blockId;
-      for (let endIdx = blockId + 1; endIdx < this.#blocks.length; ++endIdx) {
+      for (let endIdx = blockId + 1; endIdx <= maxEndBlockId; ++endIdx) {
         // if needtopics is undefined cause there's no block, then needTopics is all topics
         const needTopics = this.#blocks[endIdx]?.needTopics ?? topics;
 
@@ -251,7 +333,7 @@ export class BlockLoader {
       }
 
       // Compute the cursor start/end time from the range of blocks we need to load
-      const cursorStartTime = this.#blockIdToStartTime(blockId);
+      const cursorStartTime = this.#blockIdToStartTime(startBlockId);
       const cursorEndTime = clampTime(this.#blockIdToEndTime(endBlockId), this.#start, this.#end);
 
       const iteratorArgs: Immutable<MessageIteratorArgs> = {
@@ -273,9 +355,9 @@ export class BlockLoader {
           this.#abortController.signal,
         );
 
-      log.debug("Loading range", { blockId, endBlockId });
+      log.debug("Loading range", { startBlockId, endBlockId, focusBlockId: this.#focusBlockId });
       // Loop through the blocks corresponding to the range of our cursor
-      for (let currentBlockId = blockId; currentBlockId <= endBlockId; ++currentBlockId) {
+      for (let currentBlockId = startBlockId; currentBlockId <= endBlockId; ++currentBlockId) {
         // Until time is the end time of the current block, we want all the messages from the cursor
         // until (inclusive) of the end of of the block
         const untilTime = clampTime(this.#blockIdToEndTime(currentBlockId), this.#start, this.#end);
@@ -284,14 +366,15 @@ export class BlockLoader {
         // No results means cursor aborted or eof
         if (!results) {
           await cursor.end();
-          return;
+          return this.#abortController.signal.aborted ? "aborted" : "done";
         }
 
         // While we were waiting for cursor data the topics we need to be loading may have changed.
         // Check whether the topics are changed and abort this loading instance because the results
         // may no longer be valid for the data we should be loading.
         if (!_.isEqual(topics, this.#topics)) {
-          return;
+          await cursor.end();
+          return "topics-changed";
         }
 
         const messagesByTopic: Record<string, MessageEvent[]> = {};
@@ -357,7 +440,8 @@ export class BlockLoader {
             // We need to emit progress here so the player will emit a new state
             // containing the problem.
             progress(this.#calculateProgress(topics, totalBlockSizeBytes));
-            return;
+            await cursor.end();
+            return "done";
           }
         }
 
@@ -393,8 +477,59 @@ export class BlockLoader {
       }
 
       await cursor.end();
-      blockId = endBlockId;
     }
+
+    return "done";
+  }
+
+  /**
+   * Next incomplete block closest to the focus playhead (ties prefer the focus/right side).
+   * Falls back to left-to-right scan when no focus is set.
+   */
+  #nextIncompleteBlockId(_topics: TopicSelection): number | undefined {
+    const needsLoad = (blockId: number): boolean => {
+      const block = this.#blocks[blockId];
+      // Missing block or non-empty needTopics ⇒ still needs work (matches prior loop condition).
+      if (!block) {
+        return true;
+      }
+      return block.needTopics.size !== 0;
+    };
+
+    if (this.#focusTime == undefined) {
+      for (let blockId = 0; blockId < this.#blocks.length; ++blockId) {
+        if (needsLoad(blockId)) {
+          return blockId;
+        }
+      }
+      return undefined;
+    }
+
+    const focus = this.#focusBlockId;
+    const n = this.#blocks.length;
+    for (let distance = 0; distance < n; ++distance) {
+      const right = focus + distance;
+      if (right < n && needsLoad(right)) {
+        return right;
+      }
+      if (distance === 0) {
+        continue;
+      }
+      const left = focus - distance;
+      if (left >= 0 && needsLoad(left)) {
+        return left;
+      }
+    }
+    return undefined;
+  }
+
+  #timeToBlockId(time: Time): number {
+    const totalNs = Number(toNanoSec(subtractTimes(time, this.#start)));
+    if (!Number.isFinite(totalNs) || totalNs <= 0) {
+      return 0;
+    }
+    const id = Math.floor(totalNs / this.#blockDurationNanos);
+    return Math.max(0, Math.min(this.#blocks.length - 1, id));
   }
 
   #calculateProgress(topics: TopicSelection, currentCacheSize: number): Progress {

--- a/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
+++ b/packages/studio-base/src/players/IterablePlayer/IterablePlayer.ts
@@ -391,6 +391,10 @@ export class IterablePlayer implements Player {
     this.#lastRangeMillis = undefined;
     this.#lastStamp = undefined;
 
+    // Prioritize block preloading near the seek target (REI-125). No-op unless the block loader
+    // was constructed with `playheadFocusEnabled` — see BLOCK_LOADER_PLAYHEAD_FOCUS_DEFAULT.
+    this.#blockLoader?.setFocusTime(targetTime, { abortInFlight: true });
+
     this.#setState("seek-backfill");
   }
 
@@ -762,6 +766,9 @@ export class IterablePlayer implements Player {
       }
 
       this.#blockLoader?.setTopics(this.#preloadTopics);
+      if (this.#currentTime) {
+        this.#blockLoader?.setFocusTime(this.#currentTime);
+      }
 
       // Block loadings is constantly running and tries to keep the preloaded messages in memory
       this.#blockLoadingProcess = this.#startBlockLoading().catch((err: unknown) => {
@@ -898,6 +905,7 @@ export class IterablePlayer implements Player {
 
       this.#messages = messages;
       this.#currentTime = targetTime;
+      this.#blockLoader?.setFocusTime(targetTime, { abortInFlight: true });
       this.#lastSeekEmitTime = Date.now();
       this.#presence = PlayerPresence.PRESENT;
 
@@ -1149,6 +1157,7 @@ export class IterablePlayer implements Player {
     await this.#queueEmitState.currentPromise;
 
     this.#currentTime = end;
+    this.#blockLoader?.setFocusTime(end);
     this.#messages = msgEvents;
     this.#queueEmitState();
 


### PR DESCRIPTION
## What changed

- add an opt-in playhead focus hint to BlockLoader
- support aborting an in-flight span after an explicit seek
- cap focused spans to ten seconds
- choose the nearest incomplete block when focus is enabled
- keep the feature disabled by default

## Current limitation

Existing Plot and StateTransitions consumers expect ascending contiguous blocks. Enabling focused out-of-order loading before those consumers change can delay useful history and multiply range requests. This draft isolates the experiment for review and should remain disabled until an independent benchmark demonstrates a benefit.

## Validation

- 30 focused BlockLoader and IterablePlayer tests pass
- Prettier check passes

This PR intentionally excludes all other REI-125 optimizations and temporary probes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787404126&installation_model_id=425002&pr_number=1423&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1423&signature=ee861e4194b0ceead9e955af4b1fa1505f823ffcc5b0f8b435fc5af47fb1f196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->