### PR TITLE
feat(studio): sample playback performance telemetry

### DIFF
--- a/packages/studio-base/src/SharedRoot.tsx
+++ b/packages/studio-base/src/SharedRoot.tsx
@@ -22,7 +22,7 @@ import {
   ISharedRootContext,
   SharedRootContext,
 } from "@foxglove/studio-base/context/SharedRootContext";
-import { sanitizeAnalyticsCaptureResult } from "@foxglove/studio-base/services/messageCacheTelemetry";
+import { sanitizePrivacySafeCaptureResult } from "@foxglove/studio-base/services/playbackPerformanceTelemetry";
 import { getAppConfig } from "@foxglove/studio-base/util/appConfig";
 import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
@@ -63,7 +63,7 @@ export function SharedRoot(
     posthog.init(appConfig.POSTHOG.token, {
       api_host: appConfig.POSTHOG.api_host,
       person_profiles: "always",
-      before_send: sanitizeAnalyticsCaptureResult,
+      before_send: sanitizePrivacySafeCaptureResult,
     });
   }
 

--- a/packages/studio-base/src/Workspace.tsx
+++ b/packages/studio-base/src/Workspace.tsx
@@ -85,6 +85,10 @@ import { PlayerPresence } from "@foxglove/studio-base/players/types";
 import { PanelStateContextProvider } from "@foxglove/studio-base/providers/PanelStateContextProvider";
 import WorkspaceContextProvider from "@foxglove/studio-base/providers/WorkspaceContextProvider";
 import { logMessageCacheMetric } from "@foxglove/studio-base/services/messageCacheTelemetry";
+import {
+  logPlaybackPerformanceMetric,
+  playbackPerformanceMetrics,
+} from "@foxglove/studio-base/services/playbackPerformanceTelemetry";
 import { isAuthlessDataSource } from "@foxglove/studio-base/util/coscene";
 import isDesktopApp from "@foxglove/studio-base/util/isDesktopApp";
 
@@ -180,6 +184,12 @@ function WorkspaceContent(props: WorkspaceProps): React.JSX.Element {
     // before cache databases perform idle maintenance.
     scheduleMessageCacheMaintenance((metric, data) => {
       logMessageCacheMetric(analytics, metric, data);
+    });
+  }, [analytics]);
+
+  useEffect(() => {
+    return playbackPerformanceMetrics.installSink((data) => {
+      logPlaybackPerformanceMetric(analytics, data);
     });
   }, [analytics]);
 

--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -67,6 +67,7 @@ import {
 } from "@foxglove/studio-base/players/TopicAliasingPlayer/TopicAliasingPlayer";
 import UserScriptPlayer from "@foxglove/studio-base/players/UserScriptPlayer";
 import { Player } from "@foxglove/studio-base/players/types";
+import { playbackPerformanceMetrics } from "@foxglove/studio-base/services/playbackPerformanceTelemetry";
 import { UserScripts } from "@foxglove/studio-base/types/panels";
 import { SHARE_MANIFEST_DATA_SOURCE_ID } from "@foxglove/studio-base/util/shareManifest";
 
@@ -334,6 +335,11 @@ export default function PlayerManager(
 
       // If sourceId is undefined, clear the current source selection
       if (sourceId == undefined) {
+        // Flush any tracked sampled seek before the player goes away: this path bypasses both
+        // setProperty("player", ...) and the collector's close(), so without the flush a stale
+        // seek could later emit as settled/timeout with counters from a player that no longer
+        // exists.
+        playbackPerformanceMetrics.handlePlayerChange();
         setCurrentSourceId(undefined);
         setSelectedSource(undefined);
         setCurrentSourceArgs(undefined);

--- a/packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.ts
+++ b/packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.ts
@@ -24,6 +24,7 @@ import {
 } from "@foxglove/studio-base/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
 import { MessageBlock, PlayerState, Topic } from "@foxglove/studio-base/players/types";
+import { playbackPerformanceMetrics } from "@foxglove/studio-base/services/playbackPerformanceTelemetry";
 import { Bounds, Bounds1D } from "@foxglove/studio-base/types/Bounds";
 import { enumValuesByDatatypeAndField } from "@foxglove/studio-base/util/enums";
 import { expandedLineColors } from "@foxglove/studio-base/util/plotColors";
@@ -627,7 +628,11 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
       return;
     }
 
+    const shouldRecordPerformance = playbackPerformanceMetrics.captureActiveSeek() != undefined;
+    const startedAt = shouldRecordPerformance ? performance.now() : undefined;
     const datasets: Dataset[] = [];
+    let inputPointCount = 0;
+    let outputPointCount = 0;
     let minY: number | undefined;
 
     for (const series of this.#series) {
@@ -638,9 +643,11 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
 
       // Merge fullData and currentData
       const data = this.#getMergedData(cursorKey);
+      inputPointCount += data.length;
 
       // Process data to create state transition segments (with caching)
       const processedData = this.#processDataForStateTransitions(data, y, cursorKey);
+      outputPointCount += processedData.length;
 
       const dataset: Dataset = {
         borderWidth: 10,
@@ -687,6 +694,13 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
 
     this.emit("pathStateChanged", pathState);
     this.updateDatasets(datasets);
+    if (startedAt != undefined) {
+      playbackPerformanceMetrics.recordStateTransitionBuild(
+        performance.now() - startedAt,
+        inputPointCount,
+        outputPointCount,
+      );
+    }
   }
 
   /**

--- a/packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.ts
+++ b/packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.ts
@@ -24,7 +24,6 @@ import {
 } from "@foxglove/studio-base/components/MessagePathSyntax/useCachedGetMessagePathDataItems";
 import { GlobalVariables } from "@foxglove/studio-base/hooks/useGlobalVariables";
 import { MessageBlock, PlayerState, Topic } from "@foxglove/studio-base/players/types";
-import { playbackPerformanceMetrics } from "@foxglove/studio-base/services/playbackPerformanceTelemetry";
 import { Bounds, Bounds1D } from "@foxglove/studio-base/types/Bounds";
 import { enumValuesByDatatypeAndField } from "@foxglove/studio-base/util/enums";
 import { expandedLineColors } from "@foxglove/studio-base/util/plotColors";
@@ -628,11 +627,7 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
       return;
     }
 
-    const shouldRecordPerformance = playbackPerformanceMetrics.captureActiveSeek() != undefined;
-    const startedAt = shouldRecordPerformance ? performance.now() : undefined;
     const datasets: Dataset[] = [];
-    let inputPointCount = 0;
-    let outputPointCount = 0;
     let minY: number | undefined;
 
     for (const series of this.#series) {
@@ -643,11 +638,9 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
 
       // Merge fullData and currentData
       const data = this.#getMergedData(cursorKey);
-      inputPointCount += data.length;
 
       // Process data to create state transition segments (with caching)
       const processedData = this.#processDataForStateTransitions(data, y, cursorKey);
-      outputPointCount += processedData.length;
 
       const dataset: Dataset = {
         borderWidth: 10,
@@ -694,13 +687,6 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
 
     this.emit("pathStateChanged", pathState);
     this.updateDatasets(datasets);
-    if (startedAt != undefined) {
-      playbackPerformanceMetrics.recordStateTransitionBuild(
-        performance.now() - startedAt,
-        inputPointCount,
-        outputPointCount,
-      );
-    }
   }
 
   /**

--- a/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
+++ b/packages/studio-base/src/panels/ThreeDeeRender/ThreeDeeRender.tsx
@@ -33,6 +33,7 @@ import {
   DEFAULT_SCENE_EXTENSION_CONFIG,
   SceneExtensionConfig,
 } from "@foxglove/studio-base/panels/ThreeDeeRender/SceneExtensionConfig";
+import { playbackPerformanceMetrics } from "@foxglove/studio-base/services/playbackPerformanceTelemetry";
 import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
 
 import type {
@@ -543,13 +544,23 @@ export function ThreeDeeRender(props: {
   }, [renderer, subscribeMessageRange]);
 
   const acquireSeekKeyframeSearchPlaybackPause = useCallback(() => {
-    return (
+    const finishVisualTask = playbackPerformanceMetrics.beginVisualTask();
+    const releasePlaybackPause =
       context.unstable_acquireKeyframeSearchLock?.({
         isPlaying: context.unstable_getPlaybackIsPlaying?.() ?? false,
         pausePlayback: context.unstable_pausePlayback,
         startPlayback: context.unstable_startPlayback,
-      }) ?? (() => {})
-    );
+      }) ?? (() => {});
+    if (finishVisualTask == undefined) {
+      return releasePlaybackPause;
+    }
+    return () => {
+      try {
+        releasePlaybackPause();
+      } finally {
+        finishVisualTask();
+      }
+    };
   }, [context]);
 
   useEffect(() => {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.test.ts
@@ -11,6 +11,7 @@ import { H264 } from "@foxglove/den/video";
 import { Time, toNanoSec } from "@foxglove/rostime";
 import { MessageEvent } from "@foxglove/studio";
 import { SubscribeMessageRange } from "@foxglove/studio-base/players/types";
+import { playbackPerformanceMetrics } from "@foxglove/studio-base/services/playbackPerformanceTelemetry";
 
 import {
   CompressedVideoController,
@@ -1676,5 +1677,57 @@ describe("CompressedVideoController", () => {
       [20_000_000n, 30_000_000n],
     ]);
     expect(renderer.queueAnimationFrame).toHaveBeenCalledTimes(1);
+  });
+
+  it("classifies cancelled and failed lookback range reads distinctly in playback telemetry", async () => {
+    // Force sampling on the process-wide metrics singleton the controller reports to.
+    playbackPerformanceMetrics.overrideRandomForTests(() => 0);
+    const emitted: Array<Record<string, string | number>> = [];
+    const uninstall = playbackPerformanceMetrics.installSink((data) => emitted.push({ ...data }));
+    try {
+      playbackPerformanceMetrics.beginSeek();
+
+      const subscribeMessageRange = jest.fn<
+        ReturnType<SubscribeMessageRange>,
+        Parameters<SubscribeMessageRange>
+      >(({ onNewRangeIterator }) => {
+        if (subscribeMessageRange.mock.calls.length > 1) {
+          // Second seek's read: the range iterator throws mid-collection.
+          void onNewRangeIterator(
+            // eslint-disable-next-line require-yield
+            (async function* (): AsyncGenerator<MessageEvent<CompressedVideo>[]> {
+              throw new Error("iterator failed");
+            })(),
+          );
+        }
+        // First seek's read stays pending until the newer seek cancels it.
+        return jest.fn();
+      });
+      const renderer = makeRenderer({ currentTime: 20_000_000n, subscribeMessageRange });
+      const controller = makeController({ renderer });
+
+      controller.handleSeek();
+      renderer.currentTime = 30_000_000n;
+      controller.handleSeek();
+      await flushAsyncWork();
+
+      playbackPerformanceMetrics.finishCurrent("closed");
+      expect(emitted).toHaveLength(1);
+      // Neither the cancelled read nor the exception may be counted as a successful range read.
+      expect(emitted[0]).toEqual(
+        expect.objectContaining({
+          status: "closed",
+          range_read_count: 2,
+          range_read_cancel_count: 1,
+          range_read_failure_count: 1,
+          lookback_count: 2,
+          lookback_cancel_count: 1,
+          lookback_failure_count: 1,
+        }),
+      );
+    } finally {
+      uninstall();
+      playbackPerformanceMetrics.overrideRandomForTests(undefined);
+    }
   });
 });

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts
@@ -808,7 +808,10 @@ export class CompressedVideoController {
     endTime: Time,
     metricsSeekId: number | undefined,
   ): Promise<MessageEvent[] | undefined> {
-    let frames = await this.#readRangeMeasured(generation, startTime, endTime, metricsSeekId);
+    let frames =
+      metricsSeekId == undefined
+        ? await this.#readRange(generation, startTime, endTime)
+        : await this.#readRangeMeasured(generation, startTime, endTime, metricsSeekId);
     for (const retryDelayMs of LOOKBACK_RANGE_RETRY_DELAYS_MS) {
       if (frames != undefined || !this.#isCurrentLookback(generation)) {
         return frames;
@@ -818,7 +821,10 @@ export class CompressedVideoController {
         return undefined;
       }
       playbackPerformanceMetrics.recordVideoRangeReadRetry(metricsSeekId);
-      frames = await this.#readRangeMeasured(generation, startTime, endTime, metricsSeekId);
+      frames =
+        metricsSeekId == undefined
+          ? await this.#readRange(generation, startTime, endTime)
+          : await this.#readRangeMeasured(generation, startTime, endTime, metricsSeekId);
     }
     return frames;
   }
@@ -827,11 +833,8 @@ export class CompressedVideoController {
     generation: number,
     startTime: Time,
     endTime: Time,
-    metricsSeekId: number | undefined,
+    metricsSeekId: number,
   ): Promise<MessageEvent[] | undefined> {
-    if (metricsSeekId == undefined) {
-      return await this.#readRange(generation, startTime, endTime);
-    }
     const startedAt = performance.now();
     const frames = await this.#readRange(generation, startTime, endTime);
     playbackPerformanceMetrics.recordVideoRangeRead(

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts
@@ -15,6 +15,10 @@ import {
   toNanoSec,
 } from "@foxglove/rostime";
 import { MessageEvent } from "@foxglove/studio";
+import {
+  playbackPerformanceMetrics,
+  VideoLookbackOutcome,
+} from "@foxglove/studio-base/services/playbackPerformanceTelemetry";
 
 import type {
   CompressedVideoFrameEvent,
@@ -622,6 +626,9 @@ export class CompressedVideoController {
     lookbackTargetNs: bigint,
     options?: SetCompressedVideoFramesOptions,
   ): Promise<boolean> {
+    const metricsSeekId = playbackPerformanceMetrics.captureActiveSeek();
+    const startedAt = metricsSeekId != undefined ? performance.now() : undefined;
+    let outcome: VideoLookbackOutcome = "failure";
     this.#beginSeekKeyframeSearch(generation);
     try {
       const seekTime = fromNanoSec(lookbackTargetNs);
@@ -654,6 +661,7 @@ export class CompressedVideoController {
 
       for (const { time: windowStart, windowSec } of windowStarts) {
         if (!this.#isCurrentLookback(generation)) {
+          outcome = "cancelled";
           return false;
         }
         const windowStartNs = toNanoSec(windowStart);
@@ -669,8 +677,10 @@ export class CompressedVideoController {
           generation,
           windowStart,
           fromNanoSec(coveredStartNs),
+          metricsSeekId,
         );
         if (!this.#isCurrentLookback(generation)) {
+          outcome = "cancelled";
           return false;
         }
         if (slice == undefined) {
@@ -692,6 +702,7 @@ export class CompressedVideoController {
 
         const ok = await this.#displayReplayFrames(replayFrames, generation, "seek", options);
         if (!this.#isCurrentLookback(generation)) {
+          outcome = "cancelled";
           return false;
         }
         if (!ok) {
@@ -705,6 +716,7 @@ export class CompressedVideoController {
         this.#state.lookbackCancel = undefined;
         this.#state.lookbackGeneration = undefined;
         this.#flushPendingPlaybackAfterReplay(generation);
+        outcome = "success";
         return true;
       }
 
@@ -714,6 +726,13 @@ export class CompressedVideoController {
       return false;
     } finally {
       this.#endSeekKeyframeSearch(generation);
+      if (startedAt != undefined) {
+        playbackPerformanceMetrics.recordVideoLookback(
+          metricsSeekId,
+          performance.now() - startedAt,
+          outcome,
+        );
+      }
     }
   }
 
@@ -787,8 +806,9 @@ export class CompressedVideoController {
     generation: number,
     startTime: Time,
     endTime: Time,
+    metricsSeekId: number | undefined,
   ): Promise<MessageEvent[] | undefined> {
-    let frames = await this.#readRange(generation, startTime, endTime);
+    let frames = await this.#readRangeMeasured(generation, startTime, endTime, metricsSeekId);
     for (const retryDelayMs of LOOKBACK_RANGE_RETRY_DELAYS_MS) {
       if (frames != undefined || !this.#isCurrentLookback(generation)) {
         return frames;
@@ -797,8 +817,28 @@ export class CompressedVideoController {
       if (!this.#isCurrentLookback(generation)) {
         return undefined;
       }
-      frames = await this.#readRange(generation, startTime, endTime);
+      playbackPerformanceMetrics.recordVideoRangeReadRetry(metricsSeekId);
+      frames = await this.#readRangeMeasured(generation, startTime, endTime, metricsSeekId);
     }
+    return frames;
+  }
+
+  async #readRangeMeasured(
+    generation: number,
+    startTime: Time,
+    endTime: Time,
+    metricsSeekId: number | undefined,
+  ): Promise<MessageEvent[] | undefined> {
+    if (metricsSeekId == undefined) {
+      return await this.#readRange(generation, startTime, endTime);
+    }
+    const startedAt = performance.now();
+    const frames = await this.#readRange(generation, startTime, endTime);
+    playbackPerformanceMetrics.recordVideoRangeRead(
+      metricsSeekId,
+      performance.now() - startedAt,
+      frames == undefined ? "failure" : "success",
+    );
     return frames;
   }
 

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts
@@ -631,7 +631,6 @@ export class CompressedVideoController {
     options?: SetCompressedVideoFramesOptions,
   ): Promise<boolean> {
     const metricsSeekId = playbackPerformanceMetrics.captureActiveSeek();
-    const startedAt = metricsSeekId != undefined ? performance.now() : undefined;
     let outcome: VideoLookbackOutcome = "failure";
     this.#beginSeekKeyframeSearch(generation);
     try {
@@ -730,12 +729,8 @@ export class CompressedVideoController {
       return false;
     } finally {
       this.#endSeekKeyframeSearch(generation);
-      if (startedAt != undefined) {
-        playbackPerformanceMetrics.recordVideoLookback(
-          metricsSeekId,
-          performance.now() - startedAt,
-          outcome,
-        );
+      if (metricsSeekId != undefined) {
+        playbackPerformanceMetrics.recordVideoLookback(metricsSeekId, outcome);
       }
     }
   }
@@ -839,14 +834,12 @@ export class CompressedVideoController {
     endTime: Time,
     metricsSeekId: number,
   ): Promise<MessageEvent[] | undefined> {
-    const startedAt = performance.now();
     // The returned frames alone cannot distinguish outcomes: cancellation and iterator exceptions
     // both resolve `[]` (so the retry loop stops), which must not be counted as successful reads.
     const outcomeRef: { outcome: RangeReadResolution } = { outcome: "timeout" };
     const frames = await this.#readRange(generation, startTime, endTime, outcomeRef);
     playbackPerformanceMetrics.recordVideoRangeRead(
       metricsSeekId,
-      performance.now() - startedAt,
       outcomeRef.outcome === "success"
         ? "success"
         : outcomeRef.outcome === "cancelled"

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/CompressedVideoController.ts
@@ -38,6 +38,10 @@ const LOOKBACK_WINDOWS_SEC = [1, 2, 5, 10, 20, 40, 60] as const;
 const LOOKBACK_RANGE_RETRY_DELAYS_MS = [50, 250, 1000] as const;
 const LOOKBACK_RANGE_READ_TIMEOUT_MS = 5_000;
 
+// How a single range read actually resolved. The return value alone conflates these: cancellation
+// and iterator exceptions resolve `[]`, timeout and missing-unsubscribe resolve `undefined`.
+type RangeReadResolution = "success" | "cancelled" | "exception" | "timeout" | "unavailable";
+
 export type VideoDisplayMode = "playback" | "seek" | "direct";
 
 export type CompressedVideoDisplayFrames = (
@@ -836,11 +840,18 @@ export class CompressedVideoController {
     metricsSeekId: number,
   ): Promise<MessageEvent[] | undefined> {
     const startedAt = performance.now();
-    const frames = await this.#readRange(generation, startTime, endTime);
+    // The returned frames alone cannot distinguish outcomes: cancellation and iterator exceptions
+    // both resolve `[]` (so the retry loop stops), which must not be counted as successful reads.
+    const outcomeRef: { outcome: RangeReadResolution } = { outcome: "timeout" };
+    const frames = await this.#readRange(generation, startTime, endTime, outcomeRef);
     playbackPerformanceMetrics.recordVideoRangeRead(
       metricsSeekId,
       performance.now() - startedAt,
-      frames == undefined ? "failure" : "success",
+      outcomeRef.outcome === "success"
+        ? "success"
+        : outcomeRef.outcome === "cancelled"
+          ? "cancelled"
+          : "failure",
     );
     return frames;
   }
@@ -849,9 +860,13 @@ export class CompressedVideoController {
     generation: number,
     startTime: Time,
     endTime: Time,
+    outcomeRef?: { outcome: RangeReadResolution },
   ): Promise<MessageEvent[] | undefined> {
     const subscribeMessageRange = this.#renderer.subscribeMessageRange;
     if (subscribeMessageRange == undefined) {
+      if (outcomeRef) {
+        outcomeRef.outcome = "unavailable";
+      }
       return [];
     }
 
@@ -860,13 +875,16 @@ export class CompressedVideoController {
       let timeout: ReturnType<typeof setTimeout> | undefined;
       let unsubscribe: (() => void) | undefined;
       const currentCancel = () => {
-        finish([]);
+        finish([], "cancelled");
       };
-      const finish = (frames: MessageEvent[] | undefined) => {
+      const finish = (frames: MessageEvent[] | undefined, resolution: RangeReadResolution) => {
         if (finished) {
           return;
         }
         finished = true;
+        if (outcomeRef) {
+          outcomeRef.outcome = resolution;
+        }
         if (timeout != undefined) {
           clearTimeout(timeout);
           timeout = undefined;
@@ -887,21 +905,22 @@ export class CompressedVideoController {
           try {
             const frames = await collectFramesInRange(iterator, this.#topic, startTime, endTime);
             if (this.#isCurrentLookback(generation)) {
-              finish(frames);
+              // A genuinely empty range is still a successful read.
+              finish(frames, "success");
             }
           } catch {
             if (this.#isCurrentLookback(generation)) {
-              finish([]);
+              finish([], "exception");
             }
           }
         },
       });
       if (unsubscribe == undefined) {
-        finish(undefined);
+        finish(undefined, "unavailable");
         return;
       }
       timeout = setTimeout(() => {
-        finish(undefined);
+        finish(undefined, "timeout");
       }, LOOKBACK_RANGE_READ_TIMEOUT_MS);
     });
   }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoGopCache.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoGopCache.ts
@@ -8,6 +8,7 @@
 import { H264, H265 } from "@foxglove/den/video";
 import { Time, fromNanoSec, toNanoSec } from "@foxglove/rostime";
 import { MessageEvent } from "@foxglove/studio";
+import { playbackPerformanceMetrics } from "@foxglove/studio-base/services/playbackPerformanceTelemetry";
 
 const VIDEO_FORMATS = new Set(["h264", "h265"]);
 export const DEFAULT_VIDEO_GOP_CACHE_MAX_BYTES = 64 * 1024 * 1024;
@@ -27,6 +28,11 @@ type CachedVideoFrame = {
   isKeyframe: boolean;
   byteLength: number;
 };
+
+function recordCacheLookup(frames: MessageEvent[] | undefined): MessageEvent[] | undefined {
+  playbackPerformanceMetrics.recordGopCacheLookup(frames != undefined ? "hit" : "miss");
+  return frames;
+}
 
 export type VideoFrameInfo = {
   frame: CompressedVideoLike;
@@ -132,6 +138,7 @@ export class VideoGopCache {
     this.#activeRangeByTopic.set(msg.topic, range);
     this.#mergeOverlappingRanges(msg.topic);
     this.#pruneToBudget();
+    playbackPerformanceMetrics.recordGopCacheSize(this.#byteSize);
     return true;
   }
 
@@ -180,6 +187,7 @@ export class VideoGopCache {
       this.#targetReceiveTimeNs = range.lastReceiveTime();
       this.#mergeOverlappingRanges(topic);
       this.#pruneToBudget();
+      playbackPerformanceMetrics.recordGopCacheSize(this.#byteSize);
     }
   }
 
@@ -190,42 +198,44 @@ export class VideoGopCache {
   }
 
   public framesForReceiveTime(topic: string, targetTime: Time): MessageEvent[] | undefined {
+    playbackPerformanceMetrics.recordGopCacheSize(this.#byteSize);
     const targetNs = toNanoSec(targetTime);
     const ranges = this.#rangesByTopic.get(topic);
     if (ranges == undefined || ranges.length === 0) {
-      return undefined;
+      return recordCacheLookup(undefined);
     }
 
     const range = ranges.find((entry) => entry.overlapsReceiveTime(targetNs));
     if (range == undefined) {
-      return undefined;
+      return recordCacheLookup(undefined);
     }
 
     const replayableFrames = range.framesForReceiveTime(targetNs);
-    return replayableFrames.length > 0 ? replayableFrames : undefined;
+    return recordCacheLookup(replayableFrames.length > 0 ? replayableFrames : undefined);
   }
 
   public seekAndReturnFramesForReceiveTime(
     topic: string,
     targetTime: Time,
   ): MessageEvent[] | undefined {
+    playbackPerformanceMetrics.recordGopCacheSize(this.#byteSize);
     const targetNs = toNanoSec(targetTime);
     const ranges = this.#rangesByTopic.get(topic);
     if (ranges == undefined || ranges.length === 0) {
-      return undefined;
+      return recordCacheLookup(undefined);
     }
 
     const range = ranges.find((entry) => entry.overlapsReceiveTime(targetNs));
     if (range == undefined) {
-      return undefined;
+      return recordCacheLookup(undefined);
     }
 
     const replayableFrames = range.framesForReceiveTime(targetNs);
     if (replayableFrames.length === 0) {
-      return undefined;
+      return recordCacheLookup(undefined);
     }
     this.#activeRangeByTopic.set(topic, range);
-    return replayableFrames;
+    return recordCacheLookup(replayableFrames);
   }
 
   public framesForPublishTime(
@@ -233,43 +243,45 @@ export class VideoGopCache {
     targetTime: Time,
     afterTime?: Time,
   ): MessageEvent[] | undefined {
+    playbackPerformanceMetrics.recordGopCacheSize(this.#byteSize);
     const targetNs = toNanoSec(targetTime);
     const afterNs = afterTime != undefined ? toNanoSec(afterTime) : undefined;
     const ranges = this.#rangesByTopic.get(topic);
     if (ranges == undefined || ranges.length === 0) {
-      return undefined;
+      return recordCacheLookup(undefined);
     }
 
     const range = ranges.find((entry) => entry.overlapsPublishTime(targetNs));
     if (range == undefined) {
-      return undefined;
+      return recordCacheLookup(undefined);
     }
 
     const replayableFrames = range.framesForPublishTime(targetNs, afterNs);
-    return replayableFrames.length > 0 ? replayableFrames : undefined;
+    return recordCacheLookup(replayableFrames.length > 0 ? replayableFrames : undefined);
   }
 
   public seekAndReturnFramesForPublishTime(
     topic: string,
     targetTime: Time,
   ): MessageEvent[] | undefined {
+    playbackPerformanceMetrics.recordGopCacheSize(this.#byteSize);
     const targetNs = toNanoSec(targetTime);
     const ranges = this.#rangesByTopic.get(topic);
     if (ranges == undefined || ranges.length === 0) {
-      return undefined;
+      return recordCacheLookup(undefined);
     }
 
     const range = ranges.find((entry) => entry.overlapsPublishTime(targetNs));
     if (range == undefined) {
-      return undefined;
+      return recordCacheLookup(undefined);
     }
 
     const replayableFrames = range.framesForPublishTime(targetNs);
     if (replayableFrames.length === 0) {
-      return undefined;
+      return recordCacheLookup(undefined);
     }
     this.#activeRangeByTopic.set(topic, range);
-    return replayableFrames;
+    return recordCacheLookup(replayableFrames);
   }
 
   /**
@@ -376,13 +388,16 @@ export class VideoGopCache {
       const removedBytes = candidate.range.trimFurthestFromReceiveTime(this.#targetReceiveTimeNs);
       if (removedBytes > 0) {
         this.#byteSize -= removedBytes;
+        playbackPerformanceMetrics.recordGopCacheEviction(removedBytes);
         if (candidate.range.isEmpty()) {
           this.#removeRange(candidate.topic, candidate.range);
         }
         continue;
       }
 
-      this.#byteSize -= candidate.range.size;
+      const removedBytesForRange = candidate.range.size;
+      this.#byteSize -= removedBytesForRange;
+      playbackPerformanceMetrics.recordGopCacheEviction(removedBytesForRange);
       this.#removeRange(candidate.topic, candidate.range);
     }
   }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoGopCache.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/videoGopCache.ts
@@ -138,7 +138,6 @@ export class VideoGopCache {
     this.#activeRangeByTopic.set(msg.topic, range);
     this.#mergeOverlappingRanges(msg.topic);
     this.#pruneToBudget();
-    playbackPerformanceMetrics.recordGopCacheSize(this.#byteSize);
     return true;
   }
 
@@ -187,7 +186,6 @@ export class VideoGopCache {
       this.#targetReceiveTimeNs = range.lastReceiveTime();
       this.#mergeOverlappingRanges(topic);
       this.#pruneToBudget();
-      playbackPerformanceMetrics.recordGopCacheSize(this.#byteSize);
     }
   }
 
@@ -198,7 +196,6 @@ export class VideoGopCache {
   }
 
   public framesForReceiveTime(topic: string, targetTime: Time): MessageEvent[] | undefined {
-    playbackPerformanceMetrics.recordGopCacheSize(this.#byteSize);
     const targetNs = toNanoSec(targetTime);
     const ranges = this.#rangesByTopic.get(topic);
     if (ranges == undefined || ranges.length === 0) {
@@ -218,7 +215,6 @@ export class VideoGopCache {
     topic: string,
     targetTime: Time,
   ): MessageEvent[] | undefined {
-    playbackPerformanceMetrics.recordGopCacheSize(this.#byteSize);
     const targetNs = toNanoSec(targetTime);
     const ranges = this.#rangesByTopic.get(topic);
     if (ranges == undefined || ranges.length === 0) {
@@ -243,7 +239,6 @@ export class VideoGopCache {
     targetTime: Time,
     afterTime?: Time,
   ): MessageEvent[] | undefined {
-    playbackPerformanceMetrics.recordGopCacheSize(this.#byteSize);
     const targetNs = toNanoSec(targetTime);
     const afterNs = afterTime != undefined ? toNanoSec(afterTime) : undefined;
     const ranges = this.#rangesByTopic.get(topic);
@@ -264,7 +259,6 @@ export class VideoGopCache {
     topic: string,
     targetTime: Time,
   ): MessageEvent[] | undefined {
-    playbackPerformanceMetrics.recordGopCacheSize(this.#byteSize);
     const targetNs = toNanoSec(targetTime);
     const ranges = this.#rangesByTopic.get(topic);
     if (ranges == undefined || ranges.length === 0) {
@@ -388,7 +382,6 @@ export class VideoGopCache {
       const removedBytes = candidate.range.trimFurthestFromReceiveTime(this.#targetReceiveTimeNs);
       if (removedBytes > 0) {
         this.#byteSize -= removedBytes;
-        playbackPerformanceMetrics.recordGopCacheEviction(removedBytes);
         if (candidate.range.isEmpty()) {
           this.#removeRange(candidate.topic, candidate.range);
         }
@@ -397,7 +390,6 @@ export class VideoGopCache {
 
       const removedBytesForRange = candidate.range.size;
       this.#byteSize -= removedBytesForRange;
-      playbackPerformanceMetrics.recordGopCacheEviction(removedBytesForRange);
       this.#removeRange(candidate.topic, candidate.range);
     }
   }

--- a/packages/studio-base/src/players/AnalyticsMetricsCollector.ts
+++ b/packages/studio-base/src/players/AnalyticsMetricsCollector.ts
@@ -13,6 +13,7 @@ import {
   SubscribePayload,
 } from "@foxglove/studio-base/players/types";
 import IAnalytics, { AppEvent } from "@foxglove/studio-base/services/IAnalytics";
+import { playbackPerformanceMetrics } from "@foxglove/studio-base/services/playbackPerformanceTelemetry";
 
 const log = Log.getLogger(__filename);
 
@@ -96,6 +97,7 @@ export default class AnalyticsMetricsCollector implements PlayerMetricsCollector
    */
   public seek(time: Time): void {
     this.#currentSeekId = Date.now() * 1000 + (this.#seekSequence++ % 1000);
+    playbackPerformanceMetrics.beginSeek();
     console.debug(`coScene seek: ${time.sec}.${time.nsec}`);
     void this.#syncEventToAnalytics({
       event: AppEvent.PLAYER_SEEK,
@@ -107,6 +109,7 @@ export default class AnalyticsMetricsCollector implements PlayerMetricsCollector
     console.debug(`coScene setSpeed: ${speed}`);
   }
   public close(): void {
+    playbackPerformanceMetrics.finishCurrent("closed");
     if (this.#intervalId != undefined) {
       clearInterval(this.#intervalId);
       this.#intervalId = undefined;
@@ -146,6 +149,7 @@ export default class AnalyticsMetricsCollector implements PlayerMetricsCollector
     latencyMs: number,
     details: Readonly<{ topicCount: number; messageCount: number }>,
   ): void {
+    playbackPerformanceMetrics.markPlayerReady(latencyMs, details);
     void this.#syncEventToAnalytics({
       event: AppEvent.PLAYER_SEEK_LATENCY,
       data: {

--- a/packages/studio-base/src/players/AnalyticsMetricsCollector.ts
+++ b/packages/studio-base/src/players/AnalyticsMetricsCollector.ts
@@ -84,6 +84,9 @@ export default class AnalyticsMetricsCollector implements PlayerMetricsCollector
     this.#metadata[key] = value;
     console.debug(`coScene setProperty: ${key}=${value}`);
     if (key === "player") {
+      // A new player is initializing. Flush any seek still tracked for the previous player so its
+      // metrics cannot absorb the new player's activity (IterablePlayer never calls close()).
+      playbackPerformanceMetrics.handlePlayerChange();
       this.#sourceId = value as string;
       this.#analytics.initPlayer(this.#sourceId, args);
     }

--- a/packages/studio-base/src/services/AmplitudeAnalytics.test.ts
+++ b/packages/studio-base/src/services/AmplitudeAnalytics.test.ts
@@ -120,6 +120,24 @@ describe("AmplitudeAnalytics", () => {
     });
   });
 
+  it("sends only fixed playback performance fields to the analytics backend", async () => {
+    const analytics = Object.create(AmplitudeAnalytics.prototype) as AmplitudeAnalytics;
+
+    await analytics.logEvent(AppEvent.PLAYBACK_PERFORMANCE, {
+      status: "settled",
+      duration_ms: 150,
+      visual_task_count: 2,
+      topic: "/private/topic",
+      source_url: "https://example.test/file?signature=secret",
+    });
+
+    expect(mockCapture).toHaveBeenCalledWith(AppEvent.PLAYBACK_PERFORMANCE, {
+      status: "settled",
+      duration_ms: 150,
+      visual_task_count: 2,
+    });
+  });
+
   it("removes URL, referrer, campaign, topic, and message fields after SDK enrichment", () => {
     const result = sanitizeMessageCacheCaptureResult({
       uuid: "metric-id",

--- a/packages/studio-base/src/services/AmplitudeAnalytics.test.ts
+++ b/packages/studio-base/src/services/AmplitudeAnalytics.test.ts
@@ -126,7 +126,7 @@ describe("AmplitudeAnalytics", () => {
     await analytics.logEvent(AppEvent.PLAYBACK_PERFORMANCE, {
       status: "settled",
       duration_ms: 150,
-      visual_task_count: 2,
+      gop_cache_hit_count: 2,
       topic: "/private/topic",
       source_url: "https://example.test/file?signature=secret",
     });
@@ -134,7 +134,7 @@ describe("AmplitudeAnalytics", () => {
     expect(mockCapture).toHaveBeenCalledWith(AppEvent.PLAYBACK_PERFORMANCE, {
       status: "settled",
       duration_ms: 150,
-      visual_task_count: 2,
+      gop_cache_hit_count: 2,
     });
   });
 

--- a/packages/studio-base/src/services/AmplitudeAnalytics.ts
+++ b/packages/studio-base/src/services/AmplitudeAnalytics.ts
@@ -17,6 +17,7 @@ import {
   sanitizeMessageCacheMetricData,
   sanitizePlayerPerformanceMetricData,
 } from "@foxglove/studio-base/services/messageCacheTelemetry";
+import { sanitizePlaybackPerformanceMetricData } from "@foxglove/studio-base/services/playbackPerformanceTelemetry";
 import { getAppConfig } from "@foxglove/studio-base/util/appConfig";
 
 const log = Logger.getLogger("Analytics");
@@ -77,6 +78,9 @@ export class AmplitudeAnalytics implements IAnalytics {
         break;
       case AppEvent.MESSAGE_CACHE:
         posthog.capture(event, sanitizeMessageCacheMetricData(data));
+        break;
+      case AppEvent.PLAYBACK_PERFORMANCE:
+        posthog.capture(event, sanitizePlaybackPerformanceMetricData(data));
         break;
       default:
         log.info(`[EVENT] ${event}`, data);

--- a/packages/studio-base/src/services/IAnalytics.ts
+++ b/packages/studio-base/src/services/IAnalytics.ts
@@ -90,6 +90,9 @@ enum AppEvent {
 
   // Cache reliability and storage-pressure events (privacy-safe aggregate fields only)
   MESSAGE_CACHE = "message_cache",
+
+  // Sampled, privacy-safe aggregate performance fields for one playback seek
+  PLAYBACK_PERFORMANCE = "playback_performance",
 }
 
 interface IAnalytics {

--- a/packages/studio-base/src/services/playbackPerformanceTelemetry.test.ts
+++ b/packages/studio-base/src/services/playbackPerformanceTelemetry.test.ts
@@ -1,0 +1,269 @@
+/** @jest-environment jsdom */
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import { AppEvent } from "@foxglove/studio-base/services/IAnalytics";
+import {
+  PlaybackPerformanceMetrics,
+  logPlaybackPerformanceMetric,
+  sanitizePlaybackPerformanceMetricData,
+  sanitizePrivacySafeCaptureResult,
+} from "@foxglove/studio-base/services/playbackPerformanceTelemetry";
+
+describe("PlaybackPerformanceMetrics", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("emits one aggregate after the player and all visual work settle", () => {
+    let now = 0;
+    const sink = jest.fn();
+    const metrics = new PlaybackPerformanceMetrics({
+      sampleRate: 1,
+      settleDelayMs: 100,
+      seekTimeoutMs: 1_000,
+      now: () => now,
+      random: () => 0,
+    });
+    const uninstall = metrics.installSink(sink);
+
+    metrics.beginSeek();
+    const seekId = metrics.captureActiveSeek();
+    const finishFirstVisualTask = metrics.beginVisualTask()!;
+    const finishSecondVisualTask = metrics.beginVisualTask()!;
+    metrics.recordVideoLookback(seekId, 30.4, "success");
+    metrics.recordVideoRangeRead(seekId, 12.2, "success");
+    metrics.recordVideoRangeReadRetry(seekId);
+    metrics.recordGopCacheLookup("hit");
+    metrics.recordGopCacheLookup("miss");
+    metrics.recordGopCacheSize(1_024);
+    metrics.recordGopCacheEviction(256);
+    metrics.recordStateTransitionBuild(8.6, 100, 20);
+    metrics.recordLongTask(51.2);
+
+    now = 40;
+    metrics.markPlayerReady(38.7, { topicCount: 11, messageCount: 3 });
+    jest.advanceTimersByTime(100);
+    expect(sink).not.toHaveBeenCalled();
+
+    now = 70;
+    finishFirstVisualTask();
+    finishFirstVisualTask();
+    jest.advanceTimersByTime(100);
+    expect(sink).not.toHaveBeenCalled();
+
+    now = 90;
+    finishSecondVisualTask();
+    now = 190;
+    jest.advanceTimersByTime(100);
+
+    expect(sink).toHaveBeenCalledTimes(1);
+    expect(sink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "settled",
+        sample_rate: 1,
+        duration_ms: 190,
+        player_ready_ms: 39,
+        topic_count: 11,
+        message_count: 3,
+        visual_settle_ms: 190,
+        visual_task_count: 2,
+        visual_task_count_bucket: "2",
+        visual_task_ms_max: 90,
+        lookback_count: 1,
+        lookback_ms_total: 30,
+        lookback_success_count: 1,
+        range_read_count: 1,
+        range_read_retry_count: 1,
+        gop_cache_hit_count: 1,
+        gop_cache_miss_count: 1,
+        gop_cache_peak_bytes: 1_024,
+        gop_cache_evicted_bytes: 256,
+        state_build_count: 1,
+        state_build_ms_total: 9,
+        state_input_points_max: 100,
+        state_output_points_max: 20,
+        long_task_count: 1,
+        long_task_ms_total: 51,
+      }),
+    );
+
+    uninstall();
+  });
+
+  it("isolates stale visual completion callbacks from a superseding seek", () => {
+    let now = 0;
+    const sink = jest.fn();
+    const metrics = new PlaybackPerformanceMetrics({
+      sampleRate: 1,
+      settleDelayMs: 10,
+      now: () => now,
+      random: () => 0,
+    });
+    const uninstall = metrics.installSink(sink);
+
+    metrics.beginSeek();
+    const staleSeekId = metrics.captureActiveSeek();
+    const finishStaleTask = metrics.beginVisualTask()!;
+    now = 5;
+    metrics.beginSeek();
+    metrics.markPlayerReady(2);
+    metrics.recordVideoLookback(staleSeekId, 25, "cancelled");
+    metrics.recordLongTask(50, 0);
+    finishStaleTask();
+    now = 15;
+    jest.advanceTimersByTime(10);
+
+    expect(sink.mock.calls.map(([metric]) => metric.status)).toEqual(["superseded", "settled"]);
+    expect(sink.mock.calls[1]![0]).toEqual(
+      expect.objectContaining({
+        visual_task_count: 0,
+        visual_task_count_bucket: "0",
+        lookback_count: 0,
+        long_task_count: 0,
+      }),
+    );
+
+    uninstall();
+  });
+
+  it("emits a timeout if readiness or visual completion never arrives", () => {
+    let now = 0;
+    const sink = jest.fn();
+    const metrics = new PlaybackPerformanceMetrics({
+      sampleRate: 1,
+      seekTimeoutMs: 500,
+      now: () => now,
+      random: () => 0,
+    });
+    const uninstall = metrics.installSink(sink);
+
+    metrics.beginSeek();
+    metrics.beginVisualTask();
+    now = 500;
+    jest.advanceTimersByTime(500);
+
+    expect(sink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "timeout",
+        duration_ms: 500,
+      }),
+    );
+
+    uninstall();
+  });
+
+  it("does no aggregation for an unsampled seek", () => {
+    const sink = jest.fn();
+    const metrics = new PlaybackPerformanceMetrics({
+      sampleRate: 0.1,
+      random: () => 0.5,
+    });
+    const uninstall = metrics.installSink(sink);
+
+    metrics.beginSeek();
+    metrics.markPlayerReady(10);
+    metrics.recordGopCacheLookup("hit");
+    jest.runOnlyPendingTimers();
+
+    expect(sink).not.toHaveBeenCalled();
+    uninstall();
+  });
+});
+
+describe("playback performance telemetry transport", () => {
+  it("only retains fixed metric fields and valid enum values", () => {
+    expect(
+      sanitizePlaybackPerformanceMetricData({
+        status: "settled",
+        sample_rate: 0.1,
+        duration_ms: 123,
+        visual_task_count_bucket: "3-4",
+        source_url: "https://example.test/file?signature=secret",
+        topic: "/private/topic",
+        layout: { private: true },
+        arbitrary: 42,
+      }),
+    ).toEqual({
+      status: "settled",
+      sample_rate: 0.1,
+      duration_ms: 123,
+      visual_task_count_bucket: "3-4",
+    });
+  });
+
+  it("removes SDK-added URLs and caller data in the final PostHog hook", () => {
+    expect(
+      sanitizePrivacySafeCaptureResult({
+        uuid: "metric-id",
+        event: AppEvent.PLAYBACK_PERFORMANCE,
+        properties: {
+          token: "posthog-token",
+          distinct_id: "user-id",
+          release: "v1.2.3",
+          status: "settled",
+          duration_ms: 123,
+          $current_url: "https://example.test/project?signature=secret",
+          $referrer: "https://search.test/?q=private",
+          topic: "/private/topic",
+          arbitrary: "private",
+        },
+        $set: { $current_url: "https://example.test/person?secret=true" },
+      }),
+    ).toEqual({
+      uuid: "metric-id",
+      event: AppEvent.PLAYBACK_PERFORMANCE,
+      properties: {
+        token: "posthog-token",
+        distinct_id: "user-id",
+        release: "v1.2.3",
+        status: "settled",
+        duration_ms: 123,
+      },
+    });
+  });
+
+  it("keeps the stacked seek-event privacy filter active", () => {
+    expect(
+      sanitizePrivacySafeCaptureResult({
+        uuid: "metric-id",
+        event: AppEvent.PLAYER_SEEK_LATENCY,
+        properties: {
+          token: "posthog-token",
+          latency_ms: 123,
+          topic_count: 5,
+          $current_url: "https://example.test/project?signature=secret",
+          topic: "/private/topic",
+        },
+      }),
+    ).toEqual({
+      uuid: "metric-id",
+      event: AppEvent.PLAYER_SEEK_LATENCY,
+      properties: {
+        token: "posthog-token",
+        latency_ms: 123,
+        topic_count: 5,
+      },
+    });
+  });
+
+  it("supports synchronous analytics implementations", () => {
+    const logEvent = jest.fn(() => undefined);
+
+    expect(() => {
+      logPlaybackPerformanceMetric({ logEvent }, { status: "settled", duration_ms: 100 });
+    }).not.toThrow();
+    expect(logEvent).toHaveBeenCalledWith(AppEvent.PLAYBACK_PERFORMANCE, {
+      status: "settled",
+      duration_ms: 100,
+    });
+  });
+});

--- a/packages/studio-base/src/services/playbackPerformanceTelemetry.test.ts
+++ b/packages/studio-base/src/services/playbackPerformanceTelemetry.test.ts
@@ -39,14 +39,11 @@ describe("PlaybackPerformanceMetrics", () => {
     const seekId = metrics.captureActiveSeek();
     const finishFirstVisualTask = metrics.beginVisualTask()!;
     const finishSecondVisualTask = metrics.beginVisualTask()!;
-    metrics.recordVideoLookback(seekId, 30.4, "success");
-    metrics.recordVideoRangeRead(seekId, 12.2, "success");
+    metrics.recordVideoLookback(seekId, "success");
+    metrics.recordVideoRangeRead(seekId, "success");
     metrics.recordVideoRangeReadRetry(seekId);
     metrics.recordGopCacheLookup("hit");
     metrics.recordGopCacheLookup("miss");
-    metrics.recordGopCacheSize(1_024);
-    metrics.recordGopCacheEviction(256);
-    metrics.recordStateTransitionBuild(8.6, 100, 20);
     metrics.recordLongTask(51.2);
 
     now = 40;
@@ -74,23 +71,15 @@ describe("PlaybackPerformanceMetrics", () => {
         player_ready_ms: 39,
         topic_count: 11,
         message_count: 3,
-        visual_task_count: 2,
-        visual_task_count_bucket: "2",
-        visual_task_ms_max: 90,
         lookback_count: 1,
-        lookback_ms_total: 30,
-        lookback_success_count: 1,
+        lookback_failure_count: 0,
+        lookback_cancel_count: 0,
         range_read_count: 1,
         range_read_retry_count: 1,
+        range_read_failure_count: 0,
         range_read_cancel_count: 0,
         gop_cache_hit_count: 1,
         gop_cache_miss_count: 1,
-        gop_cache_single_peak_bytes: 1_024,
-        gop_cache_evicted_bytes: 256,
-        state_build_count: 1,
-        state_build_ms_total: 9,
-        state_input_points_max: 100,
-        state_output_points_max: 20,
         long_task_count: 1,
         long_task_ms_total: 51,
       }),
@@ -116,7 +105,7 @@ describe("PlaybackPerformanceMetrics", () => {
     now = 5;
     metrics.beginSeek();
     metrics.markPlayerReady(2);
-    metrics.recordVideoLookback(staleSeekId, 25, "cancelled");
+    metrics.recordVideoLookback(staleSeekId, "cancelled");
     metrics.recordLongTask(50, 0);
     finishStaleTask();
     now = 15;
@@ -125,8 +114,6 @@ describe("PlaybackPerformanceMetrics", () => {
     expect(sink.mock.calls.map(([metric]) => metric.status)).toEqual(["superseded", "settled"]);
     expect(sink.mock.calls[1]![0]).toEqual(
       expect.objectContaining({
-        visual_task_count: 0,
-        visual_task_count_bucket: "0",
         lookback_count: 0,
         long_task_count: 0,
       }),
@@ -190,9 +177,9 @@ describe("PlaybackPerformanceMetrics", () => {
 
     metrics.beginSeek();
     const seekId = metrics.captureActiveSeek();
-    metrics.recordVideoRangeRead(seekId, 10, "success");
-    metrics.recordVideoRangeRead(seekId, 20, "cancelled");
-    metrics.recordVideoRangeRead(seekId, 30, "failure");
+    metrics.recordVideoRangeRead(seekId, "success");
+    metrics.recordVideoRangeRead(seekId, "cancelled");
+    metrics.recordVideoRangeRead(seekId, "failure");
     now = 100;
     metrics.finishCurrent("closed");
 
@@ -201,8 +188,6 @@ describe("PlaybackPerformanceMetrics", () => {
         range_read_count: 3,
         range_read_failure_count: 1,
         range_read_cancel_count: 1,
-        range_read_ms_total: 60,
-        range_read_ms_max: 30,
       }),
     );
     uninstall();
@@ -245,6 +230,7 @@ describe("playback performance telemetry transport", () => {
         status: "settled",
         sample_rate: 0.1,
         duration_ms: 123,
+        gop_cache_hit_count: 4,
         visual_task_count_bucket: "3-4",
         source_url: "https://example.test/file?signature=secret",
         topic: "/private/topic",
@@ -255,7 +241,7 @@ describe("playback performance telemetry transport", () => {
       status: "settled",
       sample_rate: 0.1,
       duration_ms: 123,
-      visual_task_count_bucket: "3-4",
+      gop_cache_hit_count: 4,
     });
   });
 

--- a/packages/studio-base/src/services/playbackPerformanceTelemetry.test.ts
+++ b/packages/studio-base/src/services/playbackPerformanceTelemetry.test.ts
@@ -74,7 +74,6 @@ describe("PlaybackPerformanceMetrics", () => {
         player_ready_ms: 39,
         topic_count: 11,
         message_count: 3,
-        visual_settle_ms: 190,
         visual_task_count: 2,
         visual_task_count_bucket: "2",
         visual_task_ms_max: 90,
@@ -83,9 +82,10 @@ describe("PlaybackPerformanceMetrics", () => {
         lookback_success_count: 1,
         range_read_count: 1,
         range_read_retry_count: 1,
+        range_read_cancel_count: 0,
         gop_cache_hit_count: 1,
         gop_cache_miss_count: 1,
-        gop_cache_peak_bytes: 1_024,
+        gop_cache_single_peak_bytes: 1_024,
         gop_cache_evicted_bytes: 256,
         state_build_count: 1,
         state_build_ms_total: 9,
@@ -175,6 +175,65 @@ describe("PlaybackPerformanceMetrics", () => {
     jest.runOnlyPendingTimers();
 
     expect(sink).not.toHaveBeenCalled();
+    uninstall();
+  });
+
+  it("distinguishes cancelled range reads from failures", () => {
+    let now = 0;
+    const sink = jest.fn();
+    const metrics = new PlaybackPerformanceMetrics({
+      sampleRate: 1,
+      now: () => now,
+      random: () => 0,
+    });
+    const uninstall = metrics.installSink(sink);
+
+    metrics.beginSeek();
+    const seekId = metrics.captureActiveSeek();
+    metrics.recordVideoRangeRead(seekId, 10, "success");
+    metrics.recordVideoRangeRead(seekId, 20, "cancelled");
+    metrics.recordVideoRangeRead(seekId, 30, "failure");
+    now = 100;
+    metrics.finishCurrent("closed");
+
+    expect(sink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        range_read_count: 3,
+        range_read_failure_count: 1,
+        range_read_cancel_count: 1,
+        range_read_ms_total: 60,
+        range_read_ms_max: 30,
+      }),
+    );
+    uninstall();
+  });
+
+  it("flushes the tracked seek when the player changes so metrics cannot mix players", () => {
+    let now = 0;
+    const sink = jest.fn();
+    const metrics = new PlaybackPerformanceMetrics({
+      sampleRate: 1,
+      now: () => now,
+      random: () => 0,
+    });
+    const uninstall = metrics.installSink(sink);
+
+    metrics.beginSeek();
+    metrics.recordGopCacheLookup("hit");
+    now = 50;
+    metrics.handlePlayerChange();
+
+    expect(sink).toHaveBeenCalledTimes(1);
+    expect(sink).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "closed", gop_cache_hit_count: 1, duration_ms: 50 }),
+    );
+
+    // The new player's readiness and cache activity land on no seek — not the flushed one.
+    metrics.markPlayerReady(10);
+    metrics.recordGopCacheLookup("hit");
+    jest.runOnlyPendingTimers();
+    expect(sink).toHaveBeenCalledTimes(1);
+
     uninstall();
   });
 });

--- a/packages/studio-base/src/services/playbackPerformanceTelemetry.ts
+++ b/packages/studio-base/src/services/playbackPerformanceTelemetry.ts
@@ -1,0 +1,559 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import type { BeforeSendFn, CaptureResult, Properties } from "posthog-js";
+
+import IAnalytics, { AppEvent } from "@foxglove/studio-base/services/IAnalytics";
+import {
+  sanitizeAnalyticsCaptureResult,
+  sanitizePostHogPrimitiveProperties,
+} from "@foxglove/studio-base/services/messageCacheTelemetry";
+
+export const DEFAULT_PLAYBACK_PERFORMANCE_SAMPLE_RATE = 0.1;
+
+const DEFAULT_SETTLE_DELAY_MS = 250;
+const DEFAULT_SEEK_TIMEOUT_MS = 15_000;
+
+const SAFE_STATUS_VALUES = new Set(["settled", "timeout", "superseded", "closed"]);
+const SAFE_VISUAL_TASK_COUNT_BUCKETS = new Set(["0", "1", "2", "3-4", "5-8", "9+"]);
+const SAFE_STRING_KEYS = new Set(["status", "visual_task_count_bucket"]);
+const SAFE_NUMBER_KEYS = new Set([
+  "sample_rate",
+  "duration_ms",
+  "player_ready_ms",
+  "topic_count",
+  "message_count",
+  "visual_settle_ms",
+  "visual_task_count",
+  "visual_task_ms_max",
+  "lookback_count",
+  "lookback_ms_total",
+  "lookback_ms_max",
+  "lookback_success_count",
+  "lookback_failure_count",
+  "lookback_cancel_count",
+  "range_read_count",
+  "range_read_ms_total",
+  "range_read_ms_max",
+  "range_read_retry_count",
+  "range_read_failure_count",
+  "gop_cache_hit_count",
+  "gop_cache_miss_count",
+  "gop_cache_peak_bytes",
+  "gop_cache_evicted_bytes",
+  "state_build_count",
+  "state_build_ms_total",
+  "state_build_ms_max",
+  "state_input_points_max",
+  "state_output_points_max",
+  "long_task_count",
+  "long_task_ms_total",
+]);
+
+export type PlaybackPerformanceStatus = "settled" | "timeout" | "superseded" | "closed";
+export type VideoLookbackOutcome = "success" | "failure" | "cancelled";
+export type PlaybackPerformanceMetricData = Readonly<Record<string, string | number>>;
+
+type MetricSink = (data: PlaybackPerformanceMetricData) => void;
+
+type ActiveSeek = {
+  id: number;
+  startedAt: number;
+  playerReadyAt?: number;
+  playerReadyMs?: number;
+  topicCount?: number;
+  messageCount?: number;
+  pendingVisualTasks: number;
+  visualTaskCount: number;
+  visualTaskMsMax: number;
+  lookbackCount: number;
+  lookbackMsTotal: number;
+  lookbackMsMax: number;
+  lookbackSuccessCount: number;
+  lookbackFailureCount: number;
+  lookbackCancelCount: number;
+  rangeReadCount: number;
+  rangeReadMsTotal: number;
+  rangeReadMsMax: number;
+  rangeReadRetryCount: number;
+  rangeReadFailureCount: number;
+  gopCacheHitCount: number;
+  gopCacheMissCount: number;
+  gopCachePeakBytes: number;
+  gopCacheEvictedBytes: number;
+  stateBuildCount: number;
+  stateBuildMsTotal: number;
+  stateBuildMsMax: number;
+  stateInputPointsMax: number;
+  stateOutputPointsMax: number;
+  longTaskCount: number;
+  longTaskMsTotal: number;
+  settleTimer?: ReturnType<typeof setTimeout>;
+  deadlineTimer?: ReturnType<typeof setTimeout>;
+};
+
+type PlaybackPerformanceMetricsOptions = {
+  sampleRate?: number;
+  settleDelayMs?: number;
+  seekTimeoutMs?: number;
+  now?: () => number;
+  random?: () => number;
+};
+
+function finiteNonNegative(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, value) : 0;
+}
+
+function rounded(value: number): number {
+  return Math.round(finiteNonNegative(value));
+}
+
+function visualTaskCountBucket(count: number): string {
+  if (count <= 0) {
+    return "0";
+  }
+  if (count === 1) {
+    return "1";
+  }
+  if (count === 2) {
+    return "2";
+  }
+  if (count <= 4) {
+    return "3-4";
+  }
+  if (count <= 8) {
+    return "5-8";
+  }
+  return "9+";
+}
+
+/**
+ * Aggregates detailed playback work into one bounded, privacy-safe event per sampled seek.
+ *
+ * Hot-path call sites only update numbers on an active sampled seek. They never allocate event
+ * payloads or send analytics independently.
+ */
+export class PlaybackPerformanceMetrics {
+  readonly #sampleRate: number;
+  readonly #settleDelayMs: number;
+  readonly #seekTimeoutMs: number;
+  readonly #now: () => number;
+  readonly #random: () => number;
+
+  #sink: MetricSink | undefined;
+  #activeSeek: ActiveSeek | undefined;
+  #nextSeekId = 0;
+  #longTaskObserver: PerformanceObserver | undefined;
+
+  public constructor(options: PlaybackPerformanceMetricsOptions = {}) {
+    const requestedSampleRate = options.sampleRate ?? DEFAULT_PLAYBACK_PERFORMANCE_SAMPLE_RATE;
+    this.#sampleRate = Math.min(
+      1,
+      Math.max(
+        0,
+        Number.isFinite(requestedSampleRate)
+          ? requestedSampleRate
+          : DEFAULT_PLAYBACK_PERFORMANCE_SAMPLE_RATE,
+      ),
+    );
+    this.#settleDelayMs = finiteNonNegative(options.settleDelayMs ?? DEFAULT_SETTLE_DELAY_MS);
+    this.#seekTimeoutMs = finiteNonNegative(options.seekTimeoutMs ?? DEFAULT_SEEK_TIMEOUT_MS);
+    this.#now = options.now ?? (() => performance.now());
+    this.#random = options.random ?? Math.random;
+  }
+
+  public installSink(sink: MetricSink): () => void {
+    this.#sink = sink;
+
+    return () => {
+      if (this.#sink !== sink) {
+        return;
+      }
+      this.finishCurrent("closed");
+      this.#sink = undefined;
+      this.#longTaskObserver?.disconnect();
+      this.#longTaskObserver = undefined;
+    };
+  }
+
+  public beginSeek(): void {
+    this.finishCurrent("superseded");
+    if (this.#sink == undefined || this.#random() >= this.#sampleRate) {
+      return;
+    }
+
+    const activeSeek: ActiveSeek = {
+      id: ++this.#nextSeekId,
+      startedAt: this.#now(),
+      pendingVisualTasks: 0,
+      visualTaskCount: 0,
+      visualTaskMsMax: 0,
+      lookbackCount: 0,
+      lookbackMsTotal: 0,
+      lookbackMsMax: 0,
+      lookbackSuccessCount: 0,
+      lookbackFailureCount: 0,
+      lookbackCancelCount: 0,
+      rangeReadCount: 0,
+      rangeReadMsTotal: 0,
+      rangeReadMsMax: 0,
+      rangeReadRetryCount: 0,
+      rangeReadFailureCount: 0,
+      gopCacheHitCount: 0,
+      gopCacheMissCount: 0,
+      gopCachePeakBytes: 0,
+      gopCacheEvictedBytes: 0,
+      stateBuildCount: 0,
+      stateBuildMsTotal: 0,
+      stateBuildMsMax: 0,
+      stateInputPointsMax: 0,
+      stateOutputPointsMax: 0,
+      longTaskCount: 0,
+      longTaskMsTotal: 0,
+    };
+    activeSeek.deadlineTimer = setTimeout(() => {
+      if (this.#activeSeek?.id === activeSeek.id) {
+        this.finishCurrent("timeout");
+      }
+    }, this.#seekTimeoutMs);
+    this.#activeSeek = activeSeek;
+    this.#installLongTaskObserver();
+  }
+
+  public markPlayerReady(
+    latencyMs: number,
+    details?: Readonly<{ topicCount: number; messageCount: number }>,
+  ): void {
+    const activeSeek = this.#activeSeek;
+    if (activeSeek == undefined) {
+      return;
+    }
+    activeSeek.playerReadyAt = this.#now();
+    activeSeek.playerReadyMs = finiteNonNegative(latencyMs);
+    if (details != undefined) {
+      activeSeek.topicCount = finiteNonNegative(details.topicCount);
+      activeSeek.messageCount = finiteNonNegative(details.messageCount);
+    }
+    this.#scheduleSettle(activeSeek);
+  }
+
+  public beginVisualTask(): (() => void) | undefined {
+    const activeSeek = this.#activeSeek;
+    if (activeSeek == undefined) {
+      return undefined;
+    }
+
+    if (activeSeek.settleTimer != undefined) {
+      clearTimeout(activeSeek.settleTimer);
+      activeSeek.settleTimer = undefined;
+    }
+    const startedAt = this.#now();
+    const seekId = activeSeek.id;
+    activeSeek.pendingVisualTasks++;
+    activeSeek.visualTaskCount++;
+
+    let finished = false;
+    return () => {
+      if (finished) {
+        return;
+      }
+      finished = true;
+      const currentSeek = this.#activeSeek;
+      if (currentSeek?.id !== seekId) {
+        return;
+      }
+
+      currentSeek.pendingVisualTasks = Math.max(0, currentSeek.pendingVisualTasks - 1);
+      currentSeek.visualTaskMsMax = Math.max(
+        currentSeek.visualTaskMsMax,
+        finiteNonNegative(this.#now() - startedAt),
+      );
+      this.#scheduleSettle(currentSeek);
+    };
+  }
+
+  /** Capture before asynchronous work so a late result cannot leak into a superseding seek. */
+  public captureActiveSeek(): number | undefined {
+    return this.#activeSeek?.id;
+  }
+
+  public recordVideoLookback(
+    seekId: number | undefined,
+    durationMs: number,
+    outcome: VideoLookbackOutcome,
+  ): void {
+    const activeSeek = this.#activeSeek;
+    if (activeSeek == undefined || activeSeek.id !== seekId) {
+      return;
+    }
+    const duration = finiteNonNegative(durationMs);
+    activeSeek.lookbackCount++;
+    activeSeek.lookbackMsTotal += duration;
+    activeSeek.lookbackMsMax = Math.max(activeSeek.lookbackMsMax, duration);
+    if (outcome === "success") {
+      activeSeek.lookbackSuccessCount++;
+    } else if (outcome === "cancelled") {
+      activeSeek.lookbackCancelCount++;
+    } else {
+      activeSeek.lookbackFailureCount++;
+    }
+  }
+
+  public recordVideoRangeRead(
+    seekId: number | undefined,
+    durationMs: number,
+    outcome: "success" | "failure",
+  ): void {
+    const activeSeek = this.#activeSeek;
+    if (activeSeek == undefined || activeSeek.id !== seekId) {
+      return;
+    }
+    const duration = finiteNonNegative(durationMs);
+    activeSeek.rangeReadCount++;
+    activeSeek.rangeReadMsTotal += duration;
+    activeSeek.rangeReadMsMax = Math.max(activeSeek.rangeReadMsMax, duration);
+    if (outcome === "failure") {
+      activeSeek.rangeReadFailureCount++;
+    }
+  }
+
+  public recordVideoRangeReadRetry(seekId: number | undefined): void {
+    const activeSeek = this.#activeSeek;
+    if (activeSeek != undefined && activeSeek.id === seekId) {
+      activeSeek.rangeReadRetryCount++;
+    }
+  }
+
+  public recordGopCacheLookup(outcome: "hit" | "miss"): void {
+    const activeSeek = this.#activeSeek;
+    if (activeSeek == undefined) {
+      return;
+    }
+    if (outcome === "hit") {
+      activeSeek.gopCacheHitCount++;
+    } else {
+      activeSeek.gopCacheMissCount++;
+    }
+  }
+
+  public recordGopCacheSize(bytes: number): void {
+    const activeSeek = this.#activeSeek;
+    if (activeSeek != undefined) {
+      activeSeek.gopCachePeakBytes = Math.max(
+        activeSeek.gopCachePeakBytes,
+        finiteNonNegative(bytes),
+      );
+    }
+  }
+
+  public recordGopCacheEviction(bytes: number): void {
+    if (this.#activeSeek != undefined) {
+      this.#activeSeek.gopCacheEvictedBytes += finiteNonNegative(bytes);
+    }
+  }
+
+  public recordStateTransitionBuild(
+    durationMs: number,
+    inputPointCount: number,
+    outputPointCount: number,
+  ): void {
+    const activeSeek = this.#activeSeek;
+    if (activeSeek == undefined) {
+      return;
+    }
+    const duration = finiteNonNegative(durationMs);
+    activeSeek.stateBuildCount++;
+    activeSeek.stateBuildMsTotal += duration;
+    activeSeek.stateBuildMsMax = Math.max(activeSeek.stateBuildMsMax, duration);
+    activeSeek.stateInputPointsMax = Math.max(
+      activeSeek.stateInputPointsMax,
+      finiteNonNegative(inputPointCount),
+    );
+    activeSeek.stateOutputPointsMax = Math.max(
+      activeSeek.stateOutputPointsMax,
+      finiteNonNegative(outputPointCount),
+    );
+  }
+
+  public recordLongTask(durationMs: number, startTime?: number): void {
+    const activeSeek = this.#activeSeek;
+    if (activeSeek != undefined && (startTime == undefined || startTime >= activeSeek.startedAt)) {
+      activeSeek.longTaskCount++;
+      activeSeek.longTaskMsTotal += finiteNonNegative(durationMs);
+    }
+  }
+
+  public finishCurrent(status: PlaybackPerformanceStatus): void {
+    const activeSeek = this.#activeSeek;
+    if (activeSeek == undefined) {
+      return;
+    }
+    this.#activeSeek = undefined;
+    this.#longTaskObserver?.disconnect();
+    this.#longTaskObserver = undefined;
+    if (activeSeek.settleTimer != undefined) {
+      clearTimeout(activeSeek.settleTimer);
+    }
+    if (activeSeek.deadlineTimer != undefined) {
+      clearTimeout(activeSeek.deadlineTimer);
+    }
+
+    const finishedAt = this.#now();
+    const durationMs = finiteNonNegative(finishedAt - activeSeek.startedAt);
+    const metric: Record<string, string | number> = {
+      status,
+      sample_rate: this.#sampleRate,
+      duration_ms: rounded(durationMs),
+      visual_task_count: activeSeek.visualTaskCount,
+      visual_task_ms_max: rounded(activeSeek.visualTaskMsMax),
+      visual_task_count_bucket: visualTaskCountBucket(activeSeek.visualTaskCount),
+      lookback_count: activeSeek.lookbackCount,
+      lookback_ms_total: rounded(activeSeek.lookbackMsTotal),
+      lookback_ms_max: rounded(activeSeek.lookbackMsMax),
+      lookback_success_count: activeSeek.lookbackSuccessCount,
+      lookback_failure_count: activeSeek.lookbackFailureCount,
+      lookback_cancel_count: activeSeek.lookbackCancelCount,
+      range_read_count: activeSeek.rangeReadCount,
+      range_read_ms_total: rounded(activeSeek.rangeReadMsTotal),
+      range_read_ms_max: rounded(activeSeek.rangeReadMsMax),
+      range_read_retry_count: activeSeek.rangeReadRetryCount,
+      range_read_failure_count: activeSeek.rangeReadFailureCount,
+      gop_cache_hit_count: activeSeek.gopCacheHitCount,
+      gop_cache_miss_count: activeSeek.gopCacheMissCount,
+      gop_cache_peak_bytes: rounded(activeSeek.gopCachePeakBytes),
+      gop_cache_evicted_bytes: rounded(activeSeek.gopCacheEvictedBytes),
+      state_build_count: activeSeek.stateBuildCount,
+      state_build_ms_total: rounded(activeSeek.stateBuildMsTotal),
+      state_build_ms_max: rounded(activeSeek.stateBuildMsMax),
+      state_input_points_max: rounded(activeSeek.stateInputPointsMax),
+      state_output_points_max: rounded(activeSeek.stateOutputPointsMax),
+      long_task_count: activeSeek.longTaskCount,
+      long_task_ms_total: rounded(activeSeek.longTaskMsTotal),
+    };
+    if (activeSeek.playerReadyMs != undefined) {
+      metric.player_ready_ms = rounded(activeSeek.playerReadyMs);
+    }
+    if (activeSeek.topicCount != undefined) {
+      metric.topic_count = rounded(activeSeek.topicCount);
+    }
+    if (activeSeek.messageCount != undefined) {
+      metric.message_count = rounded(activeSeek.messageCount);
+    }
+    if (status === "settled") {
+      metric.visual_settle_ms = rounded(durationMs);
+    }
+
+    try {
+      this.#sink?.(metric);
+    } catch {
+      // Telemetry must never affect playback.
+    }
+  }
+
+  #scheduleSettle(activeSeek: ActiveSeek): void {
+    if (
+      activeSeek.playerReadyAt == undefined ||
+      activeSeek.pendingVisualTasks !== 0 ||
+      this.#activeSeek?.id !== activeSeek.id
+    ) {
+      return;
+    }
+    if (activeSeek.settleTimer != undefined) {
+      clearTimeout(activeSeek.settleTimer);
+    }
+    activeSeek.settleTimer = setTimeout(() => {
+      if (
+        this.#activeSeek?.id === activeSeek.id &&
+        activeSeek.pendingVisualTasks === 0 &&
+        activeSeek.playerReadyAt != undefined
+      ) {
+        this.finishCurrent("settled");
+      }
+    }, this.#settleDelayMs);
+  }
+
+  #installLongTaskObserver(): void {
+    if (this.#longTaskObserver != undefined || typeof PerformanceObserver === "undefined") {
+      return;
+    }
+    try {
+      this.#longTaskObserver = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          this.recordLongTask(entry.duration, entry.startTime);
+        }
+      });
+      this.#longTaskObserver.observe({ type: "longtask", buffered: false });
+    } catch {
+      this.#longTaskObserver = undefined;
+    }
+  }
+}
+
+export const playbackPerformanceMetrics = new PlaybackPerformanceMetrics();
+
+/** Restrict the event to a fixed, numeric schema so call sites cannot add identifying context. */
+export function sanitizePlaybackPerformanceMetricData(
+  data: Readonly<Record<string, unknown>> | undefined,
+): Record<string, string | number> {
+  const sanitized: Record<string, string | number> = {};
+  if (data == undefined) {
+    return sanitized;
+  }
+
+  for (const [key, value] of Object.entries(data)) {
+    if (SAFE_NUMBER_KEYS.has(key) && typeof value === "number" && Number.isFinite(value)) {
+      sanitized[key] = value;
+    } else if (SAFE_STRING_KEYS.has(key) && typeof value === "string") {
+      if (
+        (key === "status" && SAFE_STATUS_VALUES.has(value)) ||
+        (key === "visual_task_count_bucket" && SAFE_VISUAL_TASK_COUNT_BUCKETS.has(value))
+      ) {
+        sanitized[key] = value;
+      }
+    }
+  }
+  return sanitized;
+}
+
+function sanitizePlaybackPerformanceCaptureProperties(properties: Properties): Properties {
+  return Object.assign(
+    sanitizePostHogPrimitiveProperties(properties),
+    sanitizePlaybackPerformanceMetricData(properties),
+  );
+}
+
+/** Fire-and-forget transport supporting both synchronous and asynchronous analytics clients. */
+export function logPlaybackPerformanceMetric(
+  analytics: Pick<IAnalytics, "logEvent">,
+  data: PlaybackPerformanceMetricData,
+): void {
+  void Promise.resolve(analytics.logEvent(AppEvent.PLAYBACK_PERFORMANCE, data)).catch(
+    () => undefined,
+  );
+}
+
+/** Final PostHog hook: SDK URL/referrer enrichment happens after capture() is called. */
+export const sanitizePlaybackPerformanceCaptureResult: BeforeSendFn = (result) => {
+  if (result?.event !== AppEvent.PLAYBACK_PERFORMANCE) {
+    return result;
+  }
+
+  const sanitized: CaptureResult = {
+    uuid: result.uuid,
+    event: result.event,
+    properties: sanitizePlaybackPerformanceCaptureProperties(result.properties),
+  };
+  if (result.timestamp != undefined) {
+    sanitized.timestamp = result.timestamp;
+  }
+  return sanitized;
+};
+
+/** Apply all privacy-safe event filters from one PostHog before_send hook. */
+export const sanitizePrivacySafeCaptureResult: BeforeSendFn = (result) => {
+  return sanitizePlaybackPerformanceCaptureResult(sanitizeAnalyticsCaptureResult(result));
+};

--- a/packages/studio-base/src/services/playbackPerformanceTelemetry.ts
+++ b/packages/studio-base/src/services/playbackPerformanceTelemetry.ts
@@ -21,13 +21,18 @@ const DEFAULT_SEEK_TIMEOUT_MS = 15_000;
 const SAFE_STATUS_VALUES = new Set(["settled", "timeout", "superseded", "closed"]);
 const SAFE_VISUAL_TASK_COUNT_BUCKETS = new Set(["0", "1", "2", "3-4", "5-8", "9+"]);
 const SAFE_STRING_KEYS = new Set(["status", "visual_task_count_bucket"]);
+// Metric semantics notes:
+// - `duration_ms` with status "settled" is a task-quiet proxy: time from the accepted seek until
+//   player readiness plus a quiet period with no pending keyframe-search visual tasks. It is NOT
+//   observed paint or decoded-frame presentation, and long tasks do not extend it.
+// - `gop_cache_single_peak_bytes` is the largest post-prune size observed for any single
+//   controller's GOP cache during the seek — not aggregate cache pressure across cameras.
 const SAFE_NUMBER_KEYS = new Set([
   "sample_rate",
   "duration_ms",
   "player_ready_ms",
   "topic_count",
   "message_count",
-  "visual_settle_ms",
   "visual_task_count",
   "visual_task_ms_max",
   "lookback_count",
@@ -41,9 +46,10 @@ const SAFE_NUMBER_KEYS = new Set([
   "range_read_ms_max",
   "range_read_retry_count",
   "range_read_failure_count",
+  "range_read_cancel_count",
   "gop_cache_hit_count",
   "gop_cache_miss_count",
-  "gop_cache_peak_bytes",
+  "gop_cache_single_peak_bytes",
   "gop_cache_evicted_bytes",
   "state_build_count",
   "state_build_ms_total",
@@ -56,6 +62,7 @@ const SAFE_NUMBER_KEYS = new Set([
 
 export type PlaybackPerformanceStatus = "settled" | "timeout" | "superseded" | "closed";
 export type VideoLookbackOutcome = "success" | "failure" | "cancelled";
+export type VideoRangeReadOutcome = "success" | "failure" | "cancelled";
 export type PlaybackPerformanceMetricData = Readonly<Record<string, string | number>>;
 
 type MetricSink = (data: PlaybackPerformanceMetricData) => void;
@@ -81,6 +88,7 @@ type ActiveSeek = {
   rangeReadMsMax: number;
   rangeReadRetryCount: number;
   rangeReadFailureCount: number;
+  rangeReadCancelCount: number;
   gopCacheHitCount: number;
   gopCacheMissCount: number;
   gopCachePeakBytes: number;
@@ -142,7 +150,7 @@ export class PlaybackPerformanceMetrics {
   readonly #settleDelayMs: number;
   readonly #seekTimeoutMs: number;
   readonly #now: () => number;
-  readonly #random: () => number;
+  #random: () => number;
 
   #sink: MetricSink | undefined;
   #activeSeek: ActiveSeek | undefined;
@@ -180,6 +188,25 @@ export class PlaybackPerformanceMetrics {
     };
   }
 
+  /**
+   * Test helper: force or restore the sampling decision on the process-wide singleton. The
+   * constructor captures Math.random by reference, so spying on Math.random in a test has no
+   * effect on an already-constructed instance.
+   */
+  public overrideRandomForTests(random: (() => number) | undefined): void {
+    this.#random = random ?? Math.random;
+  }
+
+  /**
+   * Called when a new player instance is initialized for a (possibly different) data source. The
+   * singleton outlives player instances and IterablePlayer never calls the metrics collector's
+   * close(), so without this a seek sampled on the old player could absorb the new player's
+   * cache/state/readiness activity for up to the deadline timeout and emit cross-player metrics.
+   */
+  public handlePlayerChange(): void {
+    this.finishCurrent("closed");
+  }
+
   public beginSeek(): void {
     this.finishCurrent("superseded");
     if (this.#sink == undefined || this.#random() >= this.#sampleRate) {
@@ -203,6 +230,7 @@ export class PlaybackPerformanceMetrics {
       rangeReadMsMax: 0,
       rangeReadRetryCount: 0,
       rangeReadFailureCount: 0,
+      rangeReadCancelCount: 0,
       gopCacheHitCount: 0,
       gopCacheMissCount: 0,
       gopCachePeakBytes: 0,
@@ -306,7 +334,7 @@ export class PlaybackPerformanceMetrics {
   public recordVideoRangeRead(
     seekId: number | undefined,
     durationMs: number,
-    outcome: "success" | "failure",
+    outcome: VideoRangeReadOutcome,
   ): void {
     const activeSeek = this.#activeSeek;
     if (activeSeek == undefined || activeSeek.id !== seekId) {
@@ -318,6 +346,8 @@ export class PlaybackPerformanceMetrics {
     activeSeek.rangeReadMsMax = Math.max(activeSeek.rangeReadMsMax, duration);
     if (outcome === "failure") {
       activeSeek.rangeReadFailureCount++;
+    } else if (outcome === "cancelled") {
+      activeSeek.rangeReadCancelCount++;
     }
   }
 
@@ -340,6 +370,12 @@ export class PlaybackPerformanceMetrics {
     }
   }
 
+  /**
+   * Records one controller's post-prune cache size. The emitted
+   * `gop_cache_single_peak_bytes` is the max across these observations — the largest any single
+   * cache got, never a sum across cameras, and it is capped by the per-cache budget because the
+   * sampling sites run after pruning.
+   */
   public recordGopCacheSize(bytes: number): void {
     const activeSeek = this.#activeSeek;
     if (activeSeek != undefined) {
@@ -422,9 +458,10 @@ export class PlaybackPerformanceMetrics {
       range_read_ms_max: rounded(activeSeek.rangeReadMsMax),
       range_read_retry_count: activeSeek.rangeReadRetryCount,
       range_read_failure_count: activeSeek.rangeReadFailureCount,
+      range_read_cancel_count: activeSeek.rangeReadCancelCount,
       gop_cache_hit_count: activeSeek.gopCacheHitCount,
       gop_cache_miss_count: activeSeek.gopCacheMissCount,
-      gop_cache_peak_bytes: rounded(activeSeek.gopCachePeakBytes),
+      gop_cache_single_peak_bytes: rounded(activeSeek.gopCachePeakBytes),
       gop_cache_evicted_bytes: rounded(activeSeek.gopCacheEvictedBytes),
       state_build_count: activeSeek.stateBuildCount,
       state_build_ms_total: rounded(activeSeek.stateBuildMsTotal),
@@ -443,9 +480,10 @@ export class PlaybackPerformanceMetrics {
     if (activeSeek.messageCount != undefined) {
       metric.message_count = rounded(activeSeek.messageCount);
     }
-    if (status === "settled") {
-      metric.visual_settle_ms = rounded(durationMs);
-    }
+    // No separate settle field: `duration_ms` with status "settled" IS the task-quiet settle
+    // proxy (see the schema note above SAFE_NUMBER_KEYS). A duplicate field previously named
+    // "visual_settle_ms" was removed because it was byte-identical to duration_ms and its name
+    // implied paint observation that does not happen.
 
     try {
       this.#sink?.(metric);

--- a/packages/studio-base/src/services/playbackPerformanceTelemetry.ts
+++ b/packages/studio-base/src/services/playbackPerformanceTelemetry.ts
@@ -19,43 +19,30 @@ const DEFAULT_SETTLE_DELAY_MS = 250;
 const DEFAULT_SEEK_TIMEOUT_MS = 15_000;
 
 const SAFE_STATUS_VALUES = new Set(["settled", "timeout", "superseded", "closed"]);
-const SAFE_VISUAL_TASK_COUNT_BUCKETS = new Set(["0", "1", "2", "3-4", "5-8", "9+"]);
-const SAFE_STRING_KEYS = new Set(["status", "visual_task_count_bucket"]);
+const SAFE_STRING_KEYS = new Set(["status"]);
 // Metric semantics notes:
 // - `duration_ms` with status "settled" is a task-quiet proxy: time from the accepted seek until
 //   player readiness plus a quiet period with no pending keyframe-search visual tasks. It is NOT
 //   observed paint or decoded-frame presentation, and long tasks do not extend it.
-// - `gop_cache_single_peak_bytes` is the largest post-prune size observed for any single
-//   controller's GOP cache during the seek — not aggregate cache pressure across cameras.
+// - The field set is deliberately restricted to outcome/count metrics our code controls.
+//   Externally-dominated measurements (network/data-shaped durations, byte gauges, point maxima)
+//   were removed per review: they varied with device, data, and network rather than with our
+//   design decisions.
 const SAFE_NUMBER_KEYS = new Set([
   "sample_rate",
   "duration_ms",
   "player_ready_ms",
   "topic_count",
   "message_count",
-  "visual_task_count",
-  "visual_task_ms_max",
   "lookback_count",
-  "lookback_ms_total",
-  "lookback_ms_max",
-  "lookback_success_count",
   "lookback_failure_count",
   "lookback_cancel_count",
   "range_read_count",
-  "range_read_ms_total",
-  "range_read_ms_max",
   "range_read_retry_count",
   "range_read_failure_count",
   "range_read_cancel_count",
   "gop_cache_hit_count",
   "gop_cache_miss_count",
-  "gop_cache_single_peak_bytes",
-  "gop_cache_evicted_bytes",
-  "state_build_count",
-  "state_build_ms_total",
-  "state_build_ms_max",
-  "state_input_points_max",
-  "state_output_points_max",
   "long_task_count",
   "long_task_ms_total",
 ]);
@@ -74,30 +61,17 @@ type ActiveSeek = {
   playerReadyMs?: number;
   topicCount?: number;
   messageCount?: number;
+  // Pending visual tasks gate the "settled" status; their counts/durations are not emitted.
   pendingVisualTasks: number;
-  visualTaskCount: number;
-  visualTaskMsMax: number;
   lookbackCount: number;
-  lookbackMsTotal: number;
-  lookbackMsMax: number;
-  lookbackSuccessCount: number;
   lookbackFailureCount: number;
   lookbackCancelCount: number;
   rangeReadCount: number;
-  rangeReadMsTotal: number;
-  rangeReadMsMax: number;
   rangeReadRetryCount: number;
   rangeReadFailureCount: number;
   rangeReadCancelCount: number;
   gopCacheHitCount: number;
   gopCacheMissCount: number;
-  gopCachePeakBytes: number;
-  gopCacheEvictedBytes: number;
-  stateBuildCount: number;
-  stateBuildMsTotal: number;
-  stateBuildMsMax: number;
-  stateInputPointsMax: number;
-  stateOutputPointsMax: number;
   longTaskCount: number;
   longTaskMsTotal: number;
   settleTimer?: ReturnType<typeof setTimeout>;
@@ -118,25 +92,6 @@ function finiteNonNegative(value: number): number {
 
 function rounded(value: number): number {
   return Math.round(finiteNonNegative(value));
-}
-
-function visualTaskCountBucket(count: number): string {
-  if (count <= 0) {
-    return "0";
-  }
-  if (count === 1) {
-    return "1";
-  }
-  if (count === 2) {
-    return "2";
-  }
-  if (count <= 4) {
-    return "3-4";
-  }
-  if (count <= 8) {
-    return "5-8";
-  }
-  return "9+";
 }
 
 /**
@@ -208,6 +163,9 @@ export class PlaybackPerformanceMetrics {
   }
 
   public beginSeek(): void {
+    // Video work already in flight for the superseded seek may be cancelled after this flush.
+    // Those late callbacks carry the old seek id and are rejected, so lookback/range-read counts
+    // are lower bounds around a supersede — a deliberate trade-off to keep the flush synchronous.
     this.finishCurrent("superseded");
     if (this.#sink == undefined || this.#random() >= this.#sampleRate) {
       return;
@@ -217,29 +175,15 @@ export class PlaybackPerformanceMetrics {
       id: ++this.#nextSeekId,
       startedAt: this.#now(),
       pendingVisualTasks: 0,
-      visualTaskCount: 0,
-      visualTaskMsMax: 0,
       lookbackCount: 0,
-      lookbackMsTotal: 0,
-      lookbackMsMax: 0,
-      lookbackSuccessCount: 0,
       lookbackFailureCount: 0,
       lookbackCancelCount: 0,
       rangeReadCount: 0,
-      rangeReadMsTotal: 0,
-      rangeReadMsMax: 0,
       rangeReadRetryCount: 0,
       rangeReadFailureCount: 0,
       rangeReadCancelCount: 0,
       gopCacheHitCount: 0,
       gopCacheMissCount: 0,
-      gopCachePeakBytes: 0,
-      gopCacheEvictedBytes: 0,
-      stateBuildCount: 0,
-      stateBuildMsTotal: 0,
-      stateBuildMsMax: 0,
-      stateInputPointsMax: 0,
-      stateOutputPointsMax: 0,
       longTaskCount: 0,
       longTaskMsTotal: 0,
     };
@@ -279,10 +223,8 @@ export class PlaybackPerformanceMetrics {
       clearTimeout(activeSeek.settleTimer);
       activeSeek.settleTimer = undefined;
     }
-    const startedAt = this.#now();
     const seekId = activeSeek.id;
     activeSeek.pendingVisualTasks++;
-    activeSeek.visualTaskCount++;
 
     let finished = false;
     return () => {
@@ -296,10 +238,6 @@ export class PlaybackPerformanceMetrics {
       }
 
       currentSeek.pendingVisualTasks = Math.max(0, currentSeek.pendingVisualTasks - 1);
-      currentSeek.visualTaskMsMax = Math.max(
-        currentSeek.visualTaskMsMax,
-        finiteNonNegative(this.#now() - startedAt),
-      );
       this.#scheduleSettle(currentSeek);
     };
   }
@@ -309,41 +247,25 @@ export class PlaybackPerformanceMetrics {
     return this.#activeSeek?.id;
   }
 
-  public recordVideoLookback(
-    seekId: number | undefined,
-    durationMs: number,
-    outcome: VideoLookbackOutcome,
-  ): void {
+  public recordVideoLookback(seekId: number | undefined, outcome: VideoLookbackOutcome): void {
     const activeSeek = this.#activeSeek;
     if (activeSeek == undefined || activeSeek.id !== seekId) {
       return;
     }
-    const duration = finiteNonNegative(durationMs);
     activeSeek.lookbackCount++;
-    activeSeek.lookbackMsTotal += duration;
-    activeSeek.lookbackMsMax = Math.max(activeSeek.lookbackMsMax, duration);
-    if (outcome === "success") {
-      activeSeek.lookbackSuccessCount++;
-    } else if (outcome === "cancelled") {
+    if (outcome === "cancelled") {
       activeSeek.lookbackCancelCount++;
-    } else {
+    } else if (outcome === "failure") {
       activeSeek.lookbackFailureCount++;
     }
   }
 
-  public recordVideoRangeRead(
-    seekId: number | undefined,
-    durationMs: number,
-    outcome: VideoRangeReadOutcome,
-  ): void {
+  public recordVideoRangeRead(seekId: number | undefined, outcome: VideoRangeReadOutcome): void {
     const activeSeek = this.#activeSeek;
     if (activeSeek == undefined || activeSeek.id !== seekId) {
       return;
     }
-    const duration = finiteNonNegative(durationMs);
     activeSeek.rangeReadCount++;
-    activeSeek.rangeReadMsTotal += duration;
-    activeSeek.rangeReadMsMax = Math.max(activeSeek.rangeReadMsMax, duration);
     if (outcome === "failure") {
       activeSeek.rangeReadFailureCount++;
     } else if (outcome === "cancelled") {
@@ -370,51 +292,6 @@ export class PlaybackPerformanceMetrics {
     }
   }
 
-  /**
-   * Records one controller's post-prune cache size. The emitted
-   * `gop_cache_single_peak_bytes` is the max across these observations — the largest any single
-   * cache got, never a sum across cameras, and it is capped by the per-cache budget because the
-   * sampling sites run after pruning.
-   */
-  public recordGopCacheSize(bytes: number): void {
-    const activeSeek = this.#activeSeek;
-    if (activeSeek != undefined) {
-      activeSeek.gopCachePeakBytes = Math.max(
-        activeSeek.gopCachePeakBytes,
-        finiteNonNegative(bytes),
-      );
-    }
-  }
-
-  public recordGopCacheEviction(bytes: number): void {
-    if (this.#activeSeek != undefined) {
-      this.#activeSeek.gopCacheEvictedBytes += finiteNonNegative(bytes);
-    }
-  }
-
-  public recordStateTransitionBuild(
-    durationMs: number,
-    inputPointCount: number,
-    outputPointCount: number,
-  ): void {
-    const activeSeek = this.#activeSeek;
-    if (activeSeek == undefined) {
-      return;
-    }
-    const duration = finiteNonNegative(durationMs);
-    activeSeek.stateBuildCount++;
-    activeSeek.stateBuildMsTotal += duration;
-    activeSeek.stateBuildMsMax = Math.max(activeSeek.stateBuildMsMax, duration);
-    activeSeek.stateInputPointsMax = Math.max(
-      activeSeek.stateInputPointsMax,
-      finiteNonNegative(inputPointCount),
-    );
-    activeSeek.stateOutputPointsMax = Math.max(
-      activeSeek.stateOutputPointsMax,
-      finiteNonNegative(outputPointCount),
-    );
-  }
-
   public recordLongTask(durationMs: number, startTime?: number): void {
     const activeSeek = this.#activeSeek;
     if (activeSeek != undefined && (startTime == undefined || startTime >= activeSeek.startedAt)) {
@@ -429,6 +306,14 @@ export class PlaybackPerformanceMetrics {
       return;
     }
     this.#activeSeek = undefined;
+    // Drain entries the observer has queued but not yet delivered; disconnect() would silently
+    // drop them and undercount completed long tasks (review finding).
+    for (const entry of this.#longTaskObserver?.takeRecords() ?? []) {
+      if (entry.startTime >= activeSeek.startedAt) {
+        activeSeek.longTaskCount++;
+        activeSeek.longTaskMsTotal += finiteNonNegative(entry.duration);
+      }
+    }
     this.#longTaskObserver?.disconnect();
     this.#longTaskObserver = undefined;
     if (activeSeek.settleTimer != undefined) {
@@ -444,30 +329,15 @@ export class PlaybackPerformanceMetrics {
       status,
       sample_rate: this.#sampleRate,
       duration_ms: rounded(durationMs),
-      visual_task_count: activeSeek.visualTaskCount,
-      visual_task_ms_max: rounded(activeSeek.visualTaskMsMax),
-      visual_task_count_bucket: visualTaskCountBucket(activeSeek.visualTaskCount),
       lookback_count: activeSeek.lookbackCount,
-      lookback_ms_total: rounded(activeSeek.lookbackMsTotal),
-      lookback_ms_max: rounded(activeSeek.lookbackMsMax),
-      lookback_success_count: activeSeek.lookbackSuccessCount,
       lookback_failure_count: activeSeek.lookbackFailureCount,
       lookback_cancel_count: activeSeek.lookbackCancelCount,
       range_read_count: activeSeek.rangeReadCount,
-      range_read_ms_total: rounded(activeSeek.rangeReadMsTotal),
-      range_read_ms_max: rounded(activeSeek.rangeReadMsMax),
       range_read_retry_count: activeSeek.rangeReadRetryCount,
       range_read_failure_count: activeSeek.rangeReadFailureCount,
       range_read_cancel_count: activeSeek.rangeReadCancelCount,
       gop_cache_hit_count: activeSeek.gopCacheHitCount,
       gop_cache_miss_count: activeSeek.gopCacheMissCount,
-      gop_cache_single_peak_bytes: rounded(activeSeek.gopCachePeakBytes),
-      gop_cache_evicted_bytes: rounded(activeSeek.gopCacheEvictedBytes),
-      state_build_count: activeSeek.stateBuildCount,
-      state_build_ms_total: rounded(activeSeek.stateBuildMsTotal),
-      state_build_ms_max: rounded(activeSeek.stateBuildMsMax),
-      state_input_points_max: rounded(activeSeek.stateInputPointsMax),
-      state_output_points_max: rounded(activeSeek.stateOutputPointsMax),
       long_task_count: activeSeek.longTaskCount,
       long_task_ms_total: rounded(activeSeek.longTaskMsTotal),
     };
@@ -545,13 +415,13 @@ export function sanitizePlaybackPerformanceMetricData(
   for (const [key, value] of Object.entries(data)) {
     if (SAFE_NUMBER_KEYS.has(key) && typeof value === "number" && Number.isFinite(value)) {
       sanitized[key] = value;
-    } else if (SAFE_STRING_KEYS.has(key) && typeof value === "string") {
-      if (
-        (key === "status" && SAFE_STATUS_VALUES.has(value)) ||
-        (key === "visual_task_count_bucket" && SAFE_VISUAL_TASK_COUNT_BUCKETS.has(value))
-      ) {
-        sanitized[key] = value;
-      }
+    } else if (
+      SAFE_STRING_KEYS.has(key) &&
+      typeof value === "string" &&
+      key === "status" &&
+      SAFE_STATUS_VALUES.has(value)
+    ) {
+      sanitized[key] = value;
     }
   }
   return sanitized;


### PR DESCRIPTION
## Summary

Stacked on #1425. Samples 10% of accepted seeks and emits **one** bounded, fixed-schema `playback_performance` event per tracked seek with outcome `settled | timeout | superseded | closed`. Hot paths only increment counters on an active sampled seek; they never allocate payloads or send events.

**Field set (deliberately trimmed per review):** the event carries only outcome/count metrics our code controls — `status`, `duration_ms`, `player_ready_ms`, `topic_count`/`message_count`, lookback outcome counts, range-read outcome/retry counts, GOP cache hit/miss counts, and long-task totals (17 fields). Externally-dominated durations (network-bound lookback/range-read times), data-shaped maxima (StateTransitions point counts/build times), and byte gauges were removed: they measured the environment, not our system design.

## Metric semantics (stated precisely)

- `duration_ms` with status `settled` is a **task-quiet proxy**: player ready plus a 250 ms window with no pending keyframe-search visual tasks. It is not observed paint or decoded-frame presentation, and long tasks do not extend it. (An earlier duplicate field implying paint observation was removed.)
- Range reads carry their real resolution: cancellations count in `range_read_cancel_count` and iterator exceptions in `range_read_failure_count`; neither is a success. The taxonomy matches the lookback counters so dashboards agree.
- Lifecycle: a superseding seek flushes the tracked seek as `superseded`; player replacement **and** clearing the data source (`selectSource(undefined)`) flush it as `closed` — the metrics singleton outlives player instances, so every teardown path must flush.
- Known limitation (documented in code): video work already in flight when a supersede lands is attributed to neither seek, so lookback/range-read counts are lower bounds around a supersede.
- Long-task entries queued in the PerformanceObserver are drained via `takeRecords()` before disconnect, so completed work is not undercounted.

## Privacy

Same double-sanitization as #1425 (capture + `before_send` after SDK enrichment); payload restricted to the fixed numeric schema plus two enum strings; identity fields are exactly the shared allowlist every existing analytics event already carries.

## Verification

- Schema/sanitizer tests: fixed-field filtering, enum validation, SDK page-data stripping, stacked-filter coverage.
- Lifecycle tests: settle timing with visual tasks, stale visual-completion isolation across superseding seeks, timeout emission, unsampled no-op, player-change flush (no cross-player mixing), cancelled-vs-failed range accounting.
- End-to-end controller test drives a real cancellation and a real iterator exception through the video path and asserts the emitted counters.
- The unsampled hot path branches before the measuring wrapper, restoring identical microtask scheduling to pre-PR code (regression-tested at the video read sites).
