### PR TITLE
perf(studio): non-destructive StateTransitions viewport processing

### DIFF
--- a/packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.perfprobe.test.ts
+++ b/packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.perfprobe.test.ts
@@ -1,0 +1,278 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+// StateTransitions viewport perf probe. Skipped by default (CI-neutral); it asserts nothing
+// about timing and only prints measurements. To verify the numbers claimed in the PR that
+// introduced viewport slicing, run the identical file on this branch and on the baseline:
+//
+//   PERF_PROBE=1 TRANSITION_EVERY=2  yarn test <this file>   # transition-heavy
+//   PERF_PROBE=1 TRANSITION_EVERY=50 yarn test <this file>   # plateau-heavy
+//   # baseline: git switch main && git checkout <this branch> -- <this file>  (file is additive)
+//
+// `deliveredPoints` is deterministic (identical on every run); blockedMs is machine-dependent
+// but the cross-branch ratio is stable.
+//
+// Metrics:
+// - blockedMs: event-loop blocking accumulated during the phase (2 ms lag sampler) — the
+//   synchronous work a user would feel as jank.
+// - deliveredPoints: total datum count handed to renderer.updateDatasets — deterministic
+//   proxy for per-rebuild work shipped to the chart.
+// Fixture: 100 blocks x 2,000 msgs = 200,000 points at 10 Hz over 2,000 s, plateau-heavy
+// (state change every 50 samples), follow window 30 s.
+
+import type { Dataset, UpdateAction } from "./StateTransitionsChartRenderer";
+import { StateTransitionsCoordinator } from "./StateTransitionsCoordinator";
+import type { StateTransitionsRenderer } from "./StateTransitionsRenderer";
+
+jest.setTimeout(300_000);
+
+type Msg = {
+  topic: string;
+  schemaName: string;
+  receiveTime: { sec: number; nsec: number };
+  message: { data: number };
+  sizeInBytes: number;
+};
+
+const TOPIC = "/t";
+const HZ = 10;
+const BLOCK_COUNT = 100;
+const MSGS_PER_BLOCK = 2_000;
+const TOTAL_SECONDS = (BLOCK_COUNT * MSGS_PER_BLOCK) / HZ; // 2000 s
+// Samples per plateau: 50 = plateau-heavy (few transitions), 2 = transition-heavy (worst case).
+const TRANSITION_EVERY = Number(process.env.TRANSITION_EVERY ?? 50);
+
+function makeMsg(tSec: number, value: number): Msg {
+  return {
+    topic: TOPIC,
+    schemaName: "std_msgs/Float64",
+    receiveTime: { sec: Math.floor(tSec), nsec: Math.round((tSec % 1) * 1e9) },
+    message: { data: value },
+    sizeInBytes: 8,
+  };
+}
+
+function makeBlocks(): Array<{ messagesByTopic: Record<string, Msg[]>; sizeInBytes: number }> {
+  const blocks = [];
+  let sample = 0;
+  for (let b = 0; b < BLOCK_COUNT; b++) {
+    const msgs: Msg[] = [];
+    for (let i = 0; i < MSGS_PER_BLOCK; i++, sample++) {
+      msgs.push(makeMsg(sample / HZ, Math.floor(sample / TRANSITION_EVERY) % 4));
+    }
+    blocks.push({ messagesByTopic: { [TOPIC]: msgs }, sizeInBytes: msgs.length * 8 });
+  }
+  return blocks;
+}
+
+const DATATYPES = new Map([
+  [
+    "std_msgs/Float64",
+    {
+      name: "std_msgs/Float64",
+      definitions: [{ name: "data", type: "float64", isComplex: false, isArray: false }],
+    },
+  ],
+]);
+
+function makePlayerState(args: {
+  blocks: ReturnType<typeof makeBlocks>;
+  messages: Msg[];
+  currentTimeSec: number;
+}): unknown {
+  return {
+    presence: 3,
+    playerId: "perfprobe",
+    progress: {
+      messageCache: { blocks: args.blocks, startTime: { sec: 0, nsec: 0 } },
+    },
+    capabilities: [],
+    profile: undefined,
+    activeData: {
+      messages: args.messages,
+      totalBytesReceived: 0,
+      currentTime: { sec: Math.floor(args.currentTimeSec), nsec: 0 },
+      startTime: { sec: 0, nsec: 0 },
+      endTime: { sec: TOTAL_SECONDS + 100, nsec: 0 },
+      isPlaying: true,
+      speed: 1,
+      lastSeekTime: 1,
+      topics: [{ name: TOPIC, schemaName: "std_msgs/Float64" }],
+      topicStats: new Map(),
+      datatypes: DATATYPES,
+      publishedTopics: new Map(),
+      subscribedTopics: new Map(),
+      services: new Map(),
+    },
+  };
+}
+
+function makeMockRenderer() {
+  let deliveredPoints = 0;
+  let updateDatasetsCalls = 0;
+  const renderer = {
+    update: jest.fn(async (_action: UpdateAction) => {
+      return { x: { min: 0, max: 30 }, y: { min: -20, max: 0 } };
+    }),
+    updateDatasets: jest.fn(async (datasets: Dataset[]) => {
+      updateDatasetsCalls += 1;
+      for (const ds of datasets) {
+        deliveredPoints += ds.data.length;
+      }
+      // The real renderer posts datasets to a chart worker: a structured clone whose cost is
+      // proportional to delivered points. Model that transport cost so blockedMs reflects it.
+      structuredClone(datasets);
+      return { min: 0, max: 1, left: 0, right: 100 };
+    }),
+    getElementsAtPixel: jest.fn(async () => []),
+    getDatalabelAtEvent: jest.fn(async () => undefined),
+  };
+  return {
+    renderer: renderer as unknown as StateTransitionsRenderer,
+    stats: () => ({ deliveredPoints, updateDatasetsCalls }),
+  };
+}
+
+function startLagSampler() {
+  const intervalMs = 2;
+  let last = performance.now();
+  let blockedMs = 0;
+  const id = setInterval(() => {
+    const now = performance.now();
+    const lag = now - last - intervalMs;
+    if (lag > 1) {
+      blockedMs += lag;
+    }
+    last = now;
+  }, intervalMs);
+  return {
+    read: () => blockedMs,
+    resetBase: () => {
+      last = performance.now();
+    },
+    stop: () => {
+      clearInterval(id);
+      return blockedMs;
+    },
+  };
+}
+
+async function settle(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    setImmediate(resolve);
+  });
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, 150);
+  });
+  await new Promise<void>((resolve) => {
+    setImmediate(resolve);
+  });
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted.length === 0 ? 0 : sorted[Math.floor(sorted.length / 2)]!;
+}
+
+function p95(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted.length === 0 ? 0 : sorted[Math.min(sorted.length - 1, Math.ceil(sorted.length * 0.95) - 1)]!;
+}
+
+const probeIt = process.env.PERF_PROBE === "1" ? it : it.skip;
+
+probeIt("viewport perf probe (prints measurements; asserts nothing)", async () => {
+  const { renderer, stats } = makeMockRenderer();
+  const coordinator = new StateTransitionsCoordinator(renderer);
+
+  coordinator.handleConfig(
+    {
+      isSynced: true,
+      xAxisRange: 30,
+      paths: [{ value: `${TOPIC}.data`, timestampMethod: "receiveTime" }],
+    } as never,
+    {},
+  );
+
+  const blocks = makeBlocks();
+  const sampler = startLagSampler();
+
+  // ---- Phase 1: block ingestion (one emit carrying the full 200k-point cache) ----
+  const ingestStartBlocked = sampler.read();
+  const ingestStartWall = performance.now();
+  coordinator.handlePlayerState(makePlayerState({ blocks, messages: [], currentTimeSec: TOTAL_SECONDS }) as never);
+  await settle();
+  // Some implementations process blocks across several passes; give them a second settle.
+  await settle();
+  const ingest = {
+    wallMs: Math.round(performance.now() - ingestStartWall),
+    blockedMs: Math.round(sampler.read() - ingestStartBlocked),
+    ...stats(),
+  };
+
+  // ---- Phase 2: playback-emit storm (50 emits, 5 live msgs each, same block cache) ----
+  const emitBlocked: number[] = [];
+  const emitDelivered: number[] = [];
+  for (let i = 0; i < 50; i++) {
+    const currentTimeSec = TOTAL_SECONDS + i * 0.5;
+    const emitBaseSample = i * 5;
+    const messages = Array.from({ length: 5 }, (_, k) =>
+      makeMsg(currentTimeSec + k / HZ, Math.floor((emitBaseSample + k) / TRANSITION_EVERY) % 4),
+    );
+    const beforeBlocked = sampler.read();
+    const beforeDelivered = stats().deliveredPoints;
+    coordinator.handlePlayerState(
+      makePlayerState({ blocks, messages, currentTimeSec }) as never,
+    );
+    await settle();
+    emitBlocked.push(sampler.read() - beforeBlocked);
+    emitDelivered.push(stats().deliveredPoints - beforeDelivered);
+  }
+
+  // ---- Phase 3: synced-bounds storm (30 window moves over the loaded history) ----
+  const boundsBlocked: number[] = [];
+  const boundsDelivered: number[] = [];
+  for (let i = 0; i < 30; i++) {
+    const min = (i * 61) % (TOTAL_SECONDS - 30);
+    const beforeBlocked = sampler.read();
+    const beforeDelivered = stats().deliveredPoints;
+    coordinator.setGlobalBounds({ min, max: min + 30 });
+    await settle();
+    boundsBlocked.push(sampler.read() - beforeBlocked);
+    boundsDelivered.push(stats().deliveredPoints - beforeDelivered);
+  }
+
+  sampler.stop();
+  coordinator.destroy();
+
+  const resultJson = JSON.stringify({
+        fixture: {
+          totalPoints: BLOCK_COUNT * MSGS_PER_BLOCK,
+          blocks: BLOCK_COUNT,
+          hz: HZ,
+          transitionEvery: TRANSITION_EVERY,
+          followWindowSec: 30,
+        },
+        ingest,
+        emits: {
+          count: emitBlocked.length,
+          blockedMsMedian: Math.round(median(emitBlocked)),
+          blockedMsP95: Math.round(p95(emitBlocked)),
+          blockedMsTotal: Math.round(emitBlocked.reduce((a, b) => a + b, 0)),
+          deliveredPointsMedian: Math.round(median(emitDelivered)),
+        },
+        bounds: {
+          count: boundsBlocked.length,
+          blockedMsMedian: Math.round(median(boundsBlocked)),
+          blockedMsP95: Math.round(p95(boundsBlocked)),
+          blockedMsTotal: Math.round(boundsBlocked.reduce((a, b) => a + b, 0)),
+          deliveredPointsMedian: Math.round(median(boundsDelivered)),
+        },
+        totals: stats(),
+  });
+  process.stdout.write(`PERFPROBE_RESULT ${resultJson}\n`);
+});

--- a/packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.perfprobe.test.ts
+++ b/packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.perfprobe.test.ts
@@ -180,7 +180,9 @@ function median(values: number[]): number {
 
 function p95(values: number[]): number {
   const sorted = [...values].sort((a, b) => a - b);
-  return sorted.length === 0 ? 0 : sorted[Math.min(sorted.length - 1, Math.ceil(sorted.length * 0.95) - 1)]!;
+  return sorted.length === 0
+    ? 0
+    : sorted[Math.min(sorted.length - 1, Math.ceil(sorted.length * 0.95) - 1)]!;
 }
 
 const probeIt = process.env.PERF_PROBE === "1" ? it : it.skip;
@@ -204,7 +206,9 @@ probeIt("viewport perf probe (prints measurements; asserts nothing)", async () =
   // ---- Phase 1: block ingestion (one emit carrying the full 200k-point cache) ----
   const ingestStartBlocked = sampler.read();
   const ingestStartWall = performance.now();
-  coordinator.handlePlayerState(makePlayerState({ blocks, messages: [], currentTimeSec: TOTAL_SECONDS }) as never);
+  coordinator.handlePlayerState(
+    makePlayerState({ blocks, messages: [], currentTimeSec: TOTAL_SECONDS }) as never,
+  );
   await settle();
   // Some implementations process blocks across several passes; give them a second settle.
   await settle();
@@ -225,9 +229,7 @@ probeIt("viewport perf probe (prints measurements; asserts nothing)", async () =
     );
     const beforeBlocked = sampler.read();
     const beforeDelivered = stats().deliveredPoints;
-    coordinator.handlePlayerState(
-      makePlayerState({ blocks, messages, currentTimeSec }) as never,
-    );
+    coordinator.handlePlayerState(makePlayerState({ blocks, messages, currentTimeSec }) as never);
     await settle();
     emitBlocked.push(sampler.read() - beforeBlocked);
     emitDelivered.push(stats().deliveredPoints - beforeDelivered);
@@ -250,29 +252,29 @@ probeIt("viewport perf probe (prints measurements; asserts nothing)", async () =
   coordinator.destroy();
 
   const resultJson = JSON.stringify({
-        fixture: {
-          totalPoints: BLOCK_COUNT * MSGS_PER_BLOCK,
-          blocks: BLOCK_COUNT,
-          hz: HZ,
-          transitionEvery: TRANSITION_EVERY,
-          followWindowSec: 30,
-        },
-        ingest,
-        emits: {
-          count: emitBlocked.length,
-          blockedMsMedian: Math.round(median(emitBlocked)),
-          blockedMsP95: Math.round(p95(emitBlocked)),
-          blockedMsTotal: Math.round(emitBlocked.reduce((a, b) => a + b, 0)),
-          deliveredPointsMedian: Math.round(median(emitDelivered)),
-        },
-        bounds: {
-          count: boundsBlocked.length,
-          blockedMsMedian: Math.round(median(boundsBlocked)),
-          blockedMsP95: Math.round(p95(boundsBlocked)),
-          blockedMsTotal: Math.round(boundsBlocked.reduce((a, b) => a + b, 0)),
-          deliveredPointsMedian: Math.round(median(boundsDelivered)),
-        },
-        totals: stats(),
+    fixture: {
+      totalPoints: BLOCK_COUNT * MSGS_PER_BLOCK,
+      blocks: BLOCK_COUNT,
+      hz: HZ,
+      transitionEvery: TRANSITION_EVERY,
+      followWindowSec: 30,
+    },
+    ingest,
+    emits: {
+      count: emitBlocked.length,
+      blockedMsMedian: Math.round(median(emitBlocked)),
+      blockedMsP95: Math.round(p95(emitBlocked)),
+      blockedMsTotal: Math.round(emitBlocked.reduce((a, b) => a + b, 0)),
+      deliveredPointsMedian: Math.round(median(emitDelivered)),
+    },
+    bounds: {
+      count: boundsBlocked.length,
+      blockedMsMedian: Math.round(median(boundsBlocked)),
+      blockedMsP95: Math.round(p95(boundsBlocked)),
+      blockedMsTotal: Math.round(boundsBlocked.reduce((a, b) => a + b, 0)),
+      deliveredPointsMedian: Math.round(median(boundsDelivered)),
+    },
+    totals: stats(),
   });
   process.stdout.write(`PERFPROBE_RESULT ${resultJson}\n`);
 });

--- a/packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.ts
+++ b/packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.ts
@@ -42,6 +42,7 @@ import { Viewport } from "./downsampleStates";
 import positiveModulo from "./positiveModulo";
 import { PathState } from "./settings";
 import {
+  mergeSortedByX,
   processCacheFingerprint,
   sliceInterleavedStateDataForViewport,
   sliceMergedStateDataForViewport,
@@ -340,7 +341,8 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
       }
 
       let cursor = this.#blockCursors.get(cursorKey) ?? 0;
-      const existingData = this.#fullData.get(cursorKey) ?? [];
+      let existingData = this.#fullData.get(cursorKey) ?? [];
+      const appendedFrom = existingData.length;
 
       for (let blockIdx = cursor; blockIdx < blocks.length; blockIdx++) {
         const messagesForTopic = blocks[blockIdx]?.messagesByTopic[topicName];
@@ -365,10 +367,25 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
         cursor = blockIdx + 1;
       }
 
-      if (series.path.timestampMethod === "headerStamp") {
+      if (series.path.timestampMethod === "headerStamp" && existingData.length > appendedFrom) {
         // Blocks are receive-time ordered, but header stamps can move backwards. Normalize before
         // any binary viewport slicing; otherwise valid transitions can be omitted from the window.
-        existingData.sort((a, b) => a.x - b.x);
+        // Only this pass's appended samples are sorted, then merged with the already-sorted
+        // prefix: the block loader emits progress once per loaded block, so re-sorting the whole
+        // accumulated history here made loading quadratic in total samples. Passes that append
+        // nothing (every non-block player emit) skip sorting entirely.
+        const appended = existingData.slice(appendedFrom).sort((a, b) => a.x - b.x);
+        const prefixMaxX = appendedFrom > 0 ? existingData[appendedFrom - 1]!.x : -Infinity;
+        if (appended[0]!.x >= prefixMaxX) {
+          // Common case: the new stamps do not interleave with the prefix; write the sorted
+          // tail back in place.
+          for (let i = 0; i < appended.length; i++) {
+            existingData[appendedFrom + i] = appended[i]!;
+          }
+        } else {
+          existingData.length = appendedFrom;
+          existingData = mergeSortedByX(existingData, appended);
+        }
       }
 
       this.#blockCursors.set(cursorKey, cursor);

--- a/packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.ts
+++ b/packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.ts
@@ -41,7 +41,11 @@ import { StateTransitionsRenderer } from "./StateTransitionsRenderer";
 import { Viewport } from "./downsampleStates";
 import positiveModulo from "./positiveModulo";
 import { PathState } from "./settings";
-import { processCacheFingerprint, sliceMergedStateDataForViewport } from "./stateTransitionData";
+import {
+  processCacheFingerprint,
+  sliceInterleavedStateDataForViewport,
+  sliceMergedStateDataForViewport,
+} from "./stateTransitionData";
 import { StateTransitionConfig, StateTransitionPath, Datum } from "./types";
 
 type EventTypes = {
@@ -166,6 +170,7 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
       return;
     }
 
+    const prevConfig = this.#config;
     this.#config = config;
 
     // Detect showPoints change - need to invalidate processed data cache
@@ -215,7 +220,6 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
       // render representation: drop the processed cache and rebuild from the same data. No block
       // reprocessing and no player re-emit is required, and live-only history is lossless.
       this.#processedDataCache.clear();
-      this.#buildAndUpdateDatasets();
     }
 
     this.#series = newSeries;
@@ -228,6 +232,19 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
       x: { min: xMin, max: xMax },
       y: {},
     };
+
+    // Datasets are viewport-sliced, so any config change that moves the slice window (axis
+    // bounds, follow range) or changes the render representation (Show Points) must rebuild
+    // them from canonical data. A render dispatch alone would keep the old narrow slice on
+    // screen until the next player emit — invisible on live sources, stale on paused ones.
+    const axisBoundsChanged =
+      prevConfig != undefined &&
+      (prevConfig.xAxisMinValue !== config.xAxisMinValue ||
+        prevConfig.xAxisMaxValue !== config.xAxisMaxValue ||
+        prevConfig.xAxisRange !== config.xAxisRange);
+    if (!seriesChanged && (showPointsChanged || axisBoundsChanged)) {
+      this.#buildAndUpdateDatasets();
+    }
 
     // Emit pathStateChanged for all config.paths (including unparseable ones)
     // This ensures settings panel reflects all paths immediately
@@ -361,7 +378,7 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
       this.#firstBlockRefs.set(cursorKey, blocks[0]?.messagesByTopic[topicName]);
 
       // After updating fullData, trim currentData to remove duplicates
-      this.#trimCurrentData(cursorKey);
+      this.#trimCurrentData(cursorKey, series.path.timestampMethod);
     }
   }
 
@@ -388,12 +405,25 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
   /**
    * Trim currentData to remove entries that are already covered by fullData.
    * This ensures no duplicate data points when merging.
+   *
+   * Receive-time series are receive-ordered, so everything at or below fullData's last x is
+   * covered by blocks and can be range-trimmed. Header stamps are not monotonic in receive
+   * order: blocks containing stamps [0, 100, 50] do not cover a live sample stamped 75, so for
+   * header-stamped series only exact-stamp duplicates may be removed.
    */
-  #trimCurrentData(cursorKey: string): void {
+  #trimCurrentData(cursorKey: string, timestampMethod: string | undefined): void {
     const fullData = this.#fullData.get(cursorKey);
     const currentData = this.#currentData.get(cursorKey);
 
     if (!fullData || fullData.length === 0 || !currentData || currentData.length === 0) {
+      return;
+    }
+
+    if (timestampMethod === "headerStamp") {
+      const kept = currentData.filter((datum) => !this.#sortedDataContainsX(fullData, datum.x));
+      if (kept.length !== currentData.length) {
+        this.#currentData.set(cursorKey, kept);
+      }
       return;
     }
 
@@ -417,6 +447,12 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
     }
   }
 
+  /** Whether sorted data contains a datum at exactly x (binary search). */
+  #sortedDataContainsX(data: Datum[], x: number): boolean {
+    const pos = this.#findInsertPosition(data, x);
+    return data[pos]?.x === x;
+  }
+
   /**
    * Process streaming messages into currentData.
    * Streaming data is kept separate from block data and merged at render time.
@@ -425,6 +461,7 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
     for (const series of this.#series) {
       const topicName = series.parsed.topicName;
       const cursorKey = `${series.configIndex}:${topicName}`;
+      const isHeaderStamp = series.path.timestampMethod === "headerStamp";
 
       // Get the last timestamp from fullData to avoid duplicates
       const fullData = this.#fullData.get(cursorKey);
@@ -440,8 +477,15 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
           continue;
         }
 
-        // Skip if this datum is already covered by fullData
-        if (datum.x <= lastFullX) {
+        // Skip if this datum is already covered by fullData. Header stamps are not monotonic in
+        // receive order, so block coverage of stamp 100 does not imply coverage of a live sample
+        // stamped 75 — dedupe those by exact stamp membership instead of range (see
+        // #trimCurrentData).
+        if (isHeaderStamp) {
+          if (fullData != undefined && this.#sortedDataContainsX(fullData, datum.x)) {
+            continue;
+          }
+        } else if (datum.x <= lastFullX) {
           continue;
         }
 
@@ -646,8 +690,12 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
       this.#globalBounds?.max ??
       this.#configBounds.x.max ??
       viewMin + 1;
-    // Pad the window so pan/edge segments stay connected without processing the full bag.
-    const viewPad = Math.max(0, (viewMax - viewMin) * 0.25);
+    // Pad the window so pan/edge segments stay connected without processing the full bag. The
+    // pad must cover at least the renderer's own pan/zoom buffer (downsampleStates keeps half a
+    // view range on each side): #dispatchRender applies an interaction to the already-loaded
+    // dataset before the throttled rebuild lands, so a smaller upstream slice would expose
+    // blank regions during fast pans.
+    const viewPad = Math.max(0, (viewMax - viewMin) * 0.5);
     const sliceMin = viewMin - viewPad;
     const sliceMax = viewMax + viewPad;
 
@@ -658,8 +706,14 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
       const cursorKey = `${series.configIndex}:${series.parsed.topicName}`;
 
       // Window to the viewport *while* merging fullData and currentData. Materializing the merge
-      // first copied the whole preloaded history on every rebuild.
-      const data = sliceMergedStateDataForViewport(
+      // first copied the whole preloaded history on every rebuild. Header-stamped series need the
+      // interleave-safe variant: their live samples' stamps can fall between block stamps, which
+      // the concatenation-based slice would drop.
+      const sliceForViewport =
+        series.path.timestampMethod === "headerStamp"
+          ? sliceInterleavedStateDataForViewport
+          : sliceMergedStateDataForViewport;
+      const data = sliceForViewport(
         this.#fullData.get(cursorKey) ?? [],
         this.#currentData.get(cursorKey) ?? [],
         sliceMin,

--- a/packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.ts
+++ b/packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.ts
@@ -41,6 +41,7 @@ import { StateTransitionsRenderer } from "./StateTransitionsRenderer";
 import { Viewport } from "./downsampleStates";
 import positiveModulo from "./positiveModulo";
 import { PathState } from "./settings";
+import { processCacheFingerprint, sliceMergedStateDataForViewport } from "./stateTransitionData";
 import { StateTransitionConfig, StateTransitionPath, Datum } from "./types";
 
 type EventTypes = {
@@ -127,8 +128,9 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
   #fullData = new Map<string, Datum[]>(); // Preloaded block data (complete history)
   #currentData = new Map<string, Datum[]>(); // Streaming data (real-time)
 
-  // Cache for processed data to avoid reprocessing unchanged data
-  #processedDataCache = new Map<string, { data: Datum[]; inputLength: number; y: number }>();
+  // Cache for processed data to avoid reprocessing unchanged data. Cleared when Show Points
+  // toggles because the fingerprint does not encode the render representation.
+  #processedDataCache = new Map<string, { data: Datum[]; fingerprint: string }>();
 
   // Track which series have detected array input (invalid for StateTransitions)
   #seriesIsArray = new Map<string, boolean>();
@@ -209,10 +211,11 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
       this.#lastBlockRefs.clear();
       this.#latestBlocks = undefined; // Force reprocessing of blocks
     } else if (showPointsChanged) {
-      // showPoints affects how data is processed: when true, all points are emitted;
-      // when false, only state-change points are emitted. Invalidate the processed
-      // cache to ensure the UI reflects the new setting immediately.
+      // Canonical stores always retain raw samples, so toggling Show Points only changes the
+      // render representation: drop the processed cache and rebuild from the same data. No block
+      // reprocessing and no player re-emit is required, and live-only history is lossless.
       this.#processedDataCache.clear();
+      this.#buildAndUpdateDatasets();
     }
 
     this.#series = newSeries;
@@ -323,19 +326,19 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
       const existingData = this.#fullData.get(cursorKey) ?? [];
 
       for (let blockIdx = cursor; blockIdx < blocks.length; blockIdx++) {
-        const block = blocks[blockIdx];
-        if (!block) {
-          continue;
-        }
-
-        const messagesForTopic = block.messagesByTopic[topicName];
-        if (!messagesForTopic) {
-          continue;
+        const messagesForTopic = blocks[blockIdx]?.messagesByTopic[topicName];
+        if (messagesForTopic == undefined) {
+          // Gap: stop here instead of skipping ahead. Advancing the cursor past an unloaded block
+          // would permanently drop its history once it loads *behind* the cursor, leaving a silent
+          // hole in the plot. Matches Plot's BlockTopicCursor semantics.
+          break;
         }
 
         for (const msgEvent of messagesForTopic) {
           const datum = this.#messageEventToDatum(msgEvent, series, startTime);
           if (datum) {
+            // Canonical stores retain every raw sample. Plateau collapsing happens only in the
+            // render transform, so Show Points and troubleshooting always see the original data.
             existingData.push(datum);
           }
         }
@@ -345,8 +348,17 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
         cursor = blockIdx + 1;
       }
 
+      if (series.path.timestampMethod === "headerStamp") {
+        // Blocks are receive-time ordered, but header stamps can move backwards. Normalize before
+        // any binary viewport slicing; otherwise valid transitions can be omitted from the window.
+        existingData.sort((a, b) => a.x - b.x);
+      }
+
       this.#blockCursors.set(cursorKey, cursor);
       this.#fullData.set(cursorKey, existingData);
+      // Record blocks[0] every pass, not only on reset. Leaving it unset made the *second* pass
+      // always see "first block changed" and wipe + reprocess the whole series once.
+      this.#firstBlockRefs.set(cursorKey, blocks[0]?.messagesByTopic[topicName]);
 
       // After updating fullData, trim currentData to remove duplicates
       this.#trimCurrentData(cursorKey);
@@ -435,6 +447,15 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
 
         const currentData = this.#currentData.get(cursorKey) ?? [];
 
+        // Streaming path is usually already sorted by time; append raw samples to the end
+        // (common case). Fall back to ordered insert otherwise.
+        const last = currentData[currentData.length - 1];
+        if (last == undefined || datum.x > last.x) {
+          currentData.push(datum);
+          this.#currentData.set(cursorKey, currentData);
+          continue;
+        }
+
         // Check for duplicates in currentData using binary search position
         const insertPos = this.#findInsertPosition(currentData, datum.x);
 
@@ -446,7 +467,7 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
           continue;
         }
 
-        // Insert in sorted order
+        // Insert in sorted order (rare out-of-order stream).
         currentData.splice(insertPos, 0, datum);
         this.#currentData.set(cursorKey, currentData);
       }
@@ -470,32 +491,6 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
     }
 
     return low;
-  }
-
-  /**
-   * Merge fullData and currentData for a given series.
-   * fullData has priority - currentData only includes points after fullData's last point.
-   */
-  #getMergedData(cursorKey: string): Datum[] {
-    const fullData = this.#fullData.get(cursorKey) ?? [];
-    const currentData = this.#currentData.get(cursorKey) ?? [];
-
-    if (currentData.length === 0) {
-      return fullData;
-    }
-
-    if (fullData.length === 0) {
-      return currentData;
-    }
-
-    // Get the last timestamp from fullData
-    const lastFullX = fullData[fullData.length - 1]?.x ?? -Infinity;
-
-    // Filter currentData to only include points after fullData
-    const filteredCurrent = currentData.filter((datum) => datum.x > lastFullX);
-
-    // Concatenate: fullData first, then currentData
-    return [...fullData, ...filteredCurrent];
   }
 
   /**
@@ -630,17 +625,55 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
     const datasets: Dataset[] = [];
     let minY: number | undefined;
 
+    // Resolve x bounds first so we can window-process only the visible range.
+    if (this.#followRange != undefined && this.#currentSeconds != undefined) {
+      this.#configBounds.x = {
+        min: this.#currentSeconds - this.#followRange,
+        max: this.#currentSeconds,
+      };
+    } else {
+      this.#configBounds.x = {
+        min: this.#config.xAxisMinValue ?? 0,
+        max: this.#config.xAxisMaxValue ?? this.#datasetRange?.max,
+      };
+    }
+
+    // Prefer interaction / global bounds when set (zoom/pan/sync).
+    const viewMin =
+      this.#interactionBounds?.x.min ?? this.#globalBounds?.min ?? this.#configBounds.x.min ?? 0;
+    const viewMax =
+      this.#interactionBounds?.x.max ??
+      this.#globalBounds?.max ??
+      this.#configBounds.x.max ??
+      viewMin + 1;
+    // Pad the window so pan/edge segments stay connected without processing the full bag.
+    const viewPad = Math.max(0, (viewMax - viewMin) * 0.25);
+    const sliceMin = viewMin - viewPad;
+    const sliceMax = viewMax + viewPad;
+
     for (const series of this.#series) {
       const y = this.#getYForSeries(series.configIndex);
       minY = Math.min(minY ?? y, y - 5);
 
       const cursorKey = `${series.configIndex}:${series.parsed.topicName}`;
 
-      // Merge fullData and currentData
-      const data = this.#getMergedData(cursorKey);
+      // Window to the viewport *while* merging fullData and currentData. Materializing the merge
+      // first copied the whole preloaded history on every rebuild.
+      const data = sliceMergedStateDataForViewport(
+        this.#fullData.get(cursorKey) ?? [],
+        this.#currentData.get(cursorKey) ?? [],
+        sliceMin,
+        sliceMax,
+      );
 
       // Process data to create state transition segments (with caching)
-      const processedData = this.#processDataForStateTransitions(data, y, cursorKey);
+      const processedData = this.#processDataForStateTransitions(
+        data,
+        y,
+        cursorKey,
+        sliceMin,
+        sliceMax,
+      );
 
       const dataset: Dataset = {
         borderWidth: 10,
@@ -661,19 +694,6 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
     this.#configBounds.y = { min: minY, max: -3 };
     this.#updateAction.yBounds = this.#configBounds.y;
 
-    // Update x bounds with follow mode
-    if (this.#followRange != undefined && this.#currentSeconds != undefined) {
-      this.#configBounds.x = {
-        min: this.#currentSeconds - this.#followRange,
-        max: this.#currentSeconds,
-      };
-    } else {
-      this.#configBounds.x = {
-        min: this.#config.xAxisMinValue ?? 0,
-        max: this.#config.xAxisMaxValue ?? this.#datasetRange?.max,
-      };
-    }
-
     // Build pathState from all config.paths (including unparseable ones)
     // This ensures settings panel reflects all paths with updated isArray status
     const pathState: PathState[] = this.#config.paths.map((path, index) => {
@@ -693,14 +713,21 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
    * Process raw data into state transition format (only show state changes).
    * Uses caching to avoid reprocessing unchanged data.
    */
-  #processDataForStateTransitions(data: Datum[], y: number, cacheKey: string): Datum[] {
+  #processDataForStateTransitions(
+    data: Datum[],
+    y: number,
+    cacheKey: string,
+    viewMin: number,
+    viewMax: number,
+  ): Datum[] {
     if (data.length === 0) {
       return [];
     }
 
-    // Check cache - if data length and y are the same, reuse cached result
+    // Include head/tail so plateau endpoint mutation (same length) still busts the cache.
+    const fingerprint = processCacheFingerprint(data, y, viewMin, viewMax);
     const cached = this.#processedDataCache.get(cacheKey);
-    if (cached?.inputLength === data.length && cached.y === y) {
+    if (cached?.fingerprint === fingerprint) {
       return cached.data;
     }
 
@@ -753,7 +780,7 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
     }
 
     // Cache the result
-    this.#processedDataCache.set(cacheKey, { data: result, inputLength: data.length, y });
+    this.#processedDataCache.set(cacheKey, { data: result, fingerprint });
 
     return result;
   }
@@ -798,6 +825,7 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
 
   /**
    * Set the global bounds (from synced panels).
+   * Rebuild datasets so viewport-windowed series match the new bounds.
    */
   public setGlobalBounds(bounds: Immutable<Bounds1D> | undefined): void {
     if (this.isDestroyed()) {
@@ -805,11 +833,14 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
     }
     this.#globalBounds = bounds;
     this.#interactionBounds = undefined;
+    // Slice bounds changed — rebuild from fullData/currentData, then render.
+    this.#buildAndUpdateDatasets();
     this.#queueDispatchRender();
   }
 
   /**
    * Reset the view to the default bounds.
+   * Rebuild datasets so viewport-windowed series match the reset window.
    */
   public resetBounds(): void {
     if (this.isDestroyed()) {
@@ -818,6 +849,7 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
     this.#interactionBounds = undefined;
     this.#globalBounds = undefined;
     this.#updateAction.yBounds = this.#configBounds.y;
+    this.#buildAndUpdateDatasets();
     this.#queueDispatchRender();
   }
 
@@ -956,7 +988,14 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
 
     this.emit("viewportChange", this.#canReset());
 
-    // After render update, dispatch datasets to update the chart data
+    if (haveInteractionEvents) {
+      // Pan/zoom changed the visible window — rebuild sliced series from fullData
+      // (previously only re-dispatched stale pending datasets).
+      this.#buildAndUpdateDatasets();
+      return;
+    }
+
+    // After non-interaction render update, dispatch any pending datasets.
     this.#queueDispatchDatasets();
   }
 

--- a/packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.viewport.test.ts
+++ b/packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.viewport.test.ts
@@ -573,6 +573,48 @@ describe("StateTransitionsCoordinator ingestion correctness", () => {
     coordinator.destroy();
   });
 
+  it("keeps header-stamped history sorted across incremental block loads", async () => {
+    const { renderer, datasetSnapshots } = makeMockRenderer();
+    const coordinator = new StateTransitionsCoordinator(renderer);
+    const stamped = (receiveSec: number, stampSec: number, value: number) => ({
+      ...makeMsg(receiveSec, value),
+      message: { data: value, header: { stamp: { sec: stampSec, nsec: 0 } } },
+    });
+    // Later-loaded blocks carry stamps that interleave with the already-sorted prefix
+    // ([0, 50, 100] then [25, 75]), exercising the incremental merge rather than a full re-sort.
+    const blockA = [stamped(0, 0, 0), stamped(1, 100, 2), stamped(2, 50, 1)];
+    const blockB = [stamped(3, 75, 4), stamped(4, 25, 3)];
+
+    coordinator.handleConfig(
+      {
+        isSynced: true,
+        paths: [{ value: "/t.data", timestampMethod: "headerStamp" }],
+      },
+      {},
+    );
+
+    const firstState = playerState({ blockMessages: blockA });
+    coordinator.handlePlayerState(firstState);
+
+    // Second progress emission: same first block reference plus a newly loaded block, the shape
+    // BlockLoader produces as the cache fills.
+    const secondState = playerState({ blockMessages: blockA }) as {
+      progress: { messageCache: { blocks: unknown[] } };
+    };
+    secondState.progress.messageCache.blocks.push({
+      messagesByTopic: { "/t": blockB },
+      sizeInBytes: blockB.length * 8,
+    });
+    coordinator.handlePlayerState(secondState as never);
+    coordinator.setGlobalBounds({ min: 0, max: 200 });
+    await settleCoordinator();
+
+    expect(datasetSnapshots.at(-1)?.[0]?.data.map((datum) => datum.x)).toEqual([
+      0, 25, 50, 75, 100,
+    ]);
+    coordinator.destroy();
+  });
+
   it("keeps the first streaming value when duplicate timestamps arrive", async () => {
     const { renderer, datasetSnapshots } = makeMockRenderer();
     const coordinator = new StateTransitionsCoordinator(renderer);

--- a/packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.viewport.test.ts
+++ b/packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.viewport.test.ts
@@ -1,0 +1,494 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+/**
+ * Regression tests for StateTransitions viewport rebuild behavior.
+ * Codex review: pan/zoom/sync must rebuild sliced datasets from fullData, not
+ * only re-dispatch stale pending datasets.
+ */
+
+import type { Dataset, UpdateAction } from "./StateTransitionsChartRenderer";
+import { StateTransitionsCoordinator } from "./StateTransitionsCoordinator";
+import type { StateTransitionsRenderer } from "./StateTransitionsRenderer";
+
+function makeMockRenderer() {
+  const updates: UpdateAction[] = [];
+  const datasetSnapshots: Dataset[][] = [];
+  const renderer = {
+    update: jest.fn(async (action: UpdateAction) => {
+      updates.push(action);
+      // Simulate pan/zoom resulting bounds when interaction events are present.
+      if ((action.interactionEvents?.length ?? 0) > 0) {
+        return { x: { min: 40, max: 60 }, y: { min: -20, max: 0 } };
+      }
+      return { x: { min: 0, max: 30 }, y: { min: -20, max: 0 } };
+    }),
+    updateDatasets: jest.fn(async (datasets: Dataset[]) => {
+      datasetSnapshots.push(datasets);
+      return { min: 0, max: 1, left: 0, right: 100 };
+    }),
+    getElementsAtPixel: jest.fn(async () => []),
+    getDatalabelAtEvent: jest.fn(async () => undefined),
+  };
+  return {
+    renderer: renderer as unknown as StateTransitionsRenderer,
+    updates,
+    datasetSnapshots,
+    raw: renderer,
+  };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    setImmediate(resolve);
+  });
+}
+
+async function settleCoordinator(): Promise<void> {
+  // throttle 100ms + debouncePromise chains
+  await flushMicrotasks();
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, 150);
+  });
+  await flushMicrotasks();
+}
+
+describe("StateTransitionsCoordinator viewport rebuild", () => {
+  beforeEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("rebuilds datasets after setGlobalBounds so slice tracks synced view", async () => {
+    const { renderer, datasetSnapshots } = makeMockRenderer();
+    const coordinator = new StateTransitionsCoordinator(renderer);
+
+    coordinator.handleConfig(
+      {
+        isSynced: true,
+        xAxisRange: 30,
+        paths: [
+          {
+            value: "/t.data",
+            timestampMethod: "receiveTime",
+          },
+        ],
+      },
+      {},
+    );
+
+    // Seed fullData indirectly: inject via player-like flow is heavy; instead use
+    // setDataRange + handlePlayerState with blocks.
+    const datatypes = new Map([
+      [
+        "std_msgs/Float64",
+        {
+          name: "std_msgs/Float64",
+          definitions: [{ name: "data", type: "float64", isComplex: false, isArray: false }],
+        },
+      ],
+    ]);
+
+    const makeMsg = (sec: number, value: number) => ({
+      topic: "/t",
+      schemaName: "std_msgs/Float64",
+      receiveTime: { sec, nsec: 0 },
+      message: { data: value },
+      sizeInBytes: 8,
+    });
+
+    // Messages spanning 0..100s at 1Hz of constant then change — enough for windowing.
+    const blockMessages = Array.from({ length: 101 }, (_, sec) => makeMsg(sec, sec < 50 ? 0 : 1));
+
+    coordinator.handlePlayerState({
+      presence: 3,
+      playerId: "test",
+      progress: {
+        messageCache: {
+          blocks: [
+            {
+              messagesByTopic: { "/t": blockMessages },
+              sizeInBytes: blockMessages.length * 8,
+            },
+          ],
+          startTime: { sec: 0, nsec: 0 },
+        },
+      },
+      capabilities: [],
+      profile: undefined,
+      activeData: {
+        messages: [],
+        totalBytesReceived: 0,
+        currentTime: { sec: 30, nsec: 0 },
+        startTime: { sec: 0, nsec: 0 },
+        endTime: { sec: 100, nsec: 0 },
+        isPlaying: false,
+        speed: 1,
+        lastSeekTime: 1,
+        topics: [{ name: "/t", schemaName: "std_msgs/Float64" }],
+        topicStats: new Map(),
+        datatypes,
+        publishedTopics: new Map(),
+        subscribedTopics: new Map(),
+        services: new Map(),
+      },
+    } as never);
+
+    await settleCoordinator();
+    const snapshotsBeforeSync = datasetSnapshots.length;
+
+    // Sync viewport to a window far from follow mode (40–60).
+    coordinator.setGlobalBounds({ min: 40, max: 60 });
+    await settleCoordinator();
+
+    expect(datasetSnapshots.length).toBeGreaterThan(snapshotsBeforeSync);
+    const series = datasetSnapshots[datasetSnapshots.length - 1]![0];
+    expect(series).toBeDefined();
+    const xs = series!.data.map((p) => p.x);
+    // Sliced rebuild should include points near the synced window (not only 0..30 follow).
+    expect(xs.some((x) => x >= 40)).toBe(true);
+    expect(Math.max(...xs)).toBeGreaterThanOrEqual(40);
+
+    coordinator.destroy();
+  });
+
+  it("rebuilds datasets after pan interaction bounds update", async () => {
+    const { renderer, datasetSnapshots, raw } = makeMockRenderer();
+    const coordinator = new StateTransitionsCoordinator(renderer);
+
+    coordinator.handleConfig(
+      {
+        isSynced: false,
+        paths: [{ value: "/t.data", timestampMethod: "receiveTime" }],
+      },
+      {},
+    );
+
+    const datatypes = new Map([
+      [
+        "std_msgs/Float64",
+        {
+          name: "std_msgs/Float64",
+          definitions: [{ name: "data", type: "float64", isComplex: false, isArray: false }],
+        },
+      ],
+    ]);
+
+    const blockMessages = Array.from({ length: 80 }, (_, sec) => ({
+      topic: "/t",
+      schemaName: "std_msgs/Float64",
+      receiveTime: { sec, nsec: 0 },
+      message: { data: sec },
+      sizeInBytes: 8,
+    }));
+
+    coordinator.handlePlayerState({
+      presence: 3,
+      playerId: "test",
+      progress: {
+        messageCache: {
+          blocks: [
+            {
+              messagesByTopic: { "/t": blockMessages },
+              sizeInBytes: blockMessages.length * 8,
+            },
+          ],
+          startTime: { sec: 0, nsec: 0 },
+        },
+      },
+      capabilities: [],
+      profile: undefined,
+      activeData: {
+        messages: [],
+        totalBytesReceived: 0,
+        currentTime: { sec: 10, nsec: 0 },
+        startTime: { sec: 0, nsec: 0 },
+        endTime: { sec: 80, nsec: 0 },
+        isPlaying: false,
+        speed: 1,
+        lastSeekTime: 1,
+        topics: [{ name: "/t", schemaName: "std_msgs/Float64" }],
+        topicStats: new Map(),
+        datatypes,
+        publishedTopics: new Map(),
+        subscribedTopics: new Map(),
+        services: new Map(),
+      },
+    } as never);
+
+    await settleCoordinator();
+    const beforeSnapshots = datasetSnapshots.length;
+
+    coordinator.addInteractionEvent({
+      type: "pan",
+      // Chart.js-like interaction payload shape is opaque to coordinator
+    } as never);
+
+    await settleCoordinator();
+
+    // Interaction should trigger renderer.update and a datasets rebuild.
+    expect(raw.update).toHaveBeenCalled();
+    expect(datasetSnapshots.length).toBeGreaterThan(beforeSnapshots);
+    const series = datasetSnapshots[datasetSnapshots.length - 1]![0];
+    expect(series).toBeDefined();
+    const xs = series!.data.map((p) => p.x);
+    // Mock pan bounds 40–60 → rebuilt slice should reach that neighborhood.
+    expect(Math.max(...xs)).toBeGreaterThanOrEqual(40);
+
+    coordinator.destroy();
+  });
+});
+
+describe("StateTransitionsCoordinator block gap tolerance", () => {
+  beforeEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("does not skip past an unloaded block and lose its history when it arrives late", async () => {
+    const { renderer, datasetSnapshots } = makeMockRenderer();
+    const coordinator = new StateTransitionsCoordinator(renderer);
+
+    coordinator.handleConfig(
+      { isSynced: false, paths: [{ value: "/t.data", timestampMethod: "receiveTime" }] },
+      {},
+    );
+
+    const datatypes = new Map([
+      [
+        "std_msgs/Float64",
+        {
+          name: "std_msgs/Float64",
+          definitions: [{ name: "data", type: "float64", isComplex: false, isArray: false }],
+        },
+      ],
+    ]);
+
+    // 4 blocks × 5 samples at 1 Hz. Each block holds one constant value; the render transform
+    // emits one point per state change plus the trailing endpoint.
+    const blockMessages = [0, 1, 2, 3].map((blockIdx) =>
+      Array.from({ length: 5 }, (_, i) => ({
+        topic: "/t",
+        schemaName: "std_msgs/Float64",
+        receiveTime: { sec: blockIdx * 5 + i, nsec: 0 },
+        message: { data: blockIdx },
+        sizeInBytes: 8,
+      })),
+    );
+
+    const block = (idx: number) => ({
+      messagesByTopic: { "/t": blockMessages[idx]! },
+      sizeInBytes: 40,
+    });
+
+    const emit = async (blocks: unknown[]) => {
+      coordinator.handlePlayerState({
+        presence: 3,
+        playerId: "test",
+        progress: { messageCache: { blocks, startTime: { sec: 0, nsec: 0 } } },
+        capabilities: [],
+        profile: undefined,
+        activeData: {
+          messages: [],
+          totalBytesReceived: 0,
+          currentTime: { sec: 20, nsec: 0 },
+          startTime: { sec: 0, nsec: 0 },
+          endTime: { sec: 20, nsec: 0 },
+          isPlaying: false,
+          speed: 1,
+          lastSeekTime: 1,
+          topics: [{ name: "/t", schemaName: "std_msgs/Float64" }],
+          topicStats: new Map(),
+          datatypes,
+          publishedTopics: new Map(),
+          subscribedTopics: new Map(),
+          services: new Map(),
+        },
+      } as never);
+      await settleCoordinator();
+    };
+
+    // Pass 1: blocks 0-1 loaded contiguously.
+    await emit([block(0), block(1)]);
+
+    // Pass 2: block 2 is still loading but block 3 has arrived. The cursor must stop at the gap
+    // rather than consuming block 3 and stranding block 2 behind it.
+    await emit([block(0), block(1), undefined, block(3)]);
+
+    // Pass 3: the gap fills in. Both block 2 and block 3 must now be ingested.
+    await emit([block(0), block(1), block(2), block(3)]);
+
+    coordinator.setGlobalBounds({ min: 0, max: 20 });
+    await settleCoordinator();
+
+    const series = datasetSnapshots[datasetSnapshots.length - 1]![0];
+    expect(series).toBeDefined();
+    const xs = series!.data.map((p) => p.x);
+
+    // Segment processing emits one point per state change plus a trailing endpoint, so each block
+    // contributes its transition at x = 5k. Block 2's transition at x=10 is the regression guard:
+    // before the fix block 3 was consumed first, the cursor advanced past index 2, and no reset
+    // recovered it — the output was [0, 5, 15, 19] with a silent hole where block 2 belongs.
+    expect(xs).toEqual([0, 5, 10, 15, 19]);
+
+    coordinator.destroy();
+  });
+});
+
+describe("StateTransitionsCoordinator ingestion correctness", () => {
+  beforeEach(() => {
+    jest.useRealTimers();
+  });
+
+  const datatypes = new Map([
+    [
+      "std_msgs/Float64",
+      {
+        name: "std_msgs/Float64",
+        definitions: [{ name: "data", type: "float64", isComplex: false, isArray: false }],
+      },
+    ],
+  ]);
+
+  const makeMsg = (sec: number, value: number) => ({
+    topic: "/t",
+    schemaName: "std_msgs/Float64",
+    receiveTime: { sec, nsec: 0 },
+    message: { data: value },
+    sizeInBytes: 8,
+  });
+
+  function playerState(args: {
+    messages?: ReturnType<typeof makeMsg>[];
+    blockMessages?: ReturnType<typeof makeMsg>[];
+  }) {
+    const blocks =
+      args.blockMessages != undefined
+        ? [
+            {
+              messagesByTopic: { "/t": args.blockMessages },
+              sizeInBytes: args.blockMessages.length * 8,
+            },
+          ]
+        : undefined;
+    return {
+      presence: 3,
+      playerId: "test",
+      progress: {
+        messageCache: blocks != undefined ? { blocks, startTime: { sec: 0, nsec: 0 } } : undefined,
+      },
+      capabilities: [],
+      profile: undefined,
+      activeData: {
+        messages: args.messages ?? [],
+        totalBytesReceived: 0,
+        currentTime: { sec: 5, nsec: 0 },
+        startTime: { sec: 0, nsec: 0 },
+        endTime: { sec: 10, nsec: 0 },
+        isPlaying: false,
+        speed: 1,
+        lastSeekTime: 1,
+        topics: [{ name: "/t", schemaName: "std_msgs/Float64" }],
+        topicStats: new Map(),
+        datatypes,
+        publishedTopics: new Map(),
+        subscribedTopics: new Map(),
+        services: new Map(),
+      },
+    } as never;
+  }
+
+  it("preserves every sample when Show Points is enabled after data has loaded", async () => {
+    const { renderer, datasetSnapshots } = makeMockRenderer();
+    const coordinator = new StateTransitionsCoordinator(renderer);
+    const blockMessages = [makeMsg(0, 1), makeMsg(1, 1), makeMsg(2, 1)];
+    const config = {
+      isSynced: false,
+      paths: [{ value: "/t.data", timestampMethod: "receiveTime" as const }],
+    };
+
+    coordinator.handleConfig(config, {});
+    coordinator.handlePlayerState(playerState({ blockMessages }));
+    await settleCoordinator();
+    expect(datasetSnapshots.at(-1)?.[0]?.data.map((datum) => datum.x)).toEqual([0, 2]);
+
+    coordinator.handleConfig({ ...config, showPoints: true }, {});
+    coordinator.handlePlayerState(playerState({ blockMessages }));
+    await settleCoordinator();
+
+    expect(datasetSnapshots.at(-1)?.[0]?.data.map((datum) => datum.x)).toEqual([0, 1, 2]);
+    coordinator.destroy();
+  });
+
+  it("restores raw streaming history when Show Points is enabled, without a player re-emit", async () => {
+    const { renderer, datasetSnapshots } = makeMockRenderer();
+    const coordinator = new StateTransitionsCoordinator(renderer);
+    const config = {
+      isSynced: false,
+      paths: [{ value: "/t.data", timestampMethod: "receiveTime" as const }],
+    };
+
+    coordinator.handleConfig(config, {});
+    coordinator.handlePlayerState(
+      playerState({ messages: [makeMsg(0, 1), makeMsg(1, 1), makeMsg(2, 1)] }),
+    );
+    await settleCoordinator();
+    // With Show Points off the render transform collapses the plateau to its endpoints...
+    expect(datasetSnapshots.at(-1)?.[0]?.data.map((datum) => datum.x)).toEqual([0, 2]);
+
+    coordinator.handleConfig({ ...config, showPoints: true }, {});
+    await settleCoordinator();
+
+    // ...but the canonical store kept every raw sample, so enabling Show Points renders the
+    // interior point too — for live-only sources, with no blocks and no further player emits.
+    expect(datasetSnapshots.at(-1)?.[0]?.data.map((datum) => datum.x)).toEqual([0, 1, 2]);
+    coordinator.destroy();
+  });
+
+  it("sorts header-stamped block data before viewport slicing", async () => {
+    const { renderer, datasetSnapshots } = makeMockRenderer();
+    const coordinator = new StateTransitionsCoordinator(renderer);
+    const headerStampedMessages = [
+      { receiveSec: 0, stampSec: 0, value: 0 },
+      { receiveSec: 1, stampSec: 100, value: 2 },
+      { receiveSec: 2, stampSec: 50, value: 1 },
+    ].map(({ receiveSec, stampSec, value }) => ({
+      ...makeMsg(receiveSec, value),
+      message: { data: value, header: { stamp: { sec: stampSec, nsec: 0 } } },
+    }));
+
+    coordinator.handleConfig(
+      {
+        isSynced: true,
+        paths: [{ value: "/t.data", timestampMethod: "headerStamp" }],
+      },
+      {},
+    );
+    coordinator.handlePlayerState(playerState({ blockMessages: headerStampedMessages }));
+    coordinator.setGlobalBounds({ min: 40, max: 60 });
+    await settleCoordinator();
+
+    expect(datasetSnapshots.at(-1)?.[0]?.data.map((datum) => datum.x)).toEqual([0, 50, 100]);
+    coordinator.destroy();
+  });
+
+  it("keeps the first streaming value when duplicate timestamps arrive", async () => {
+    const { renderer, datasetSnapshots } = makeMockRenderer();
+    const coordinator = new StateTransitionsCoordinator(renderer);
+    coordinator.handleConfig(
+      {
+        isSynced: false,
+        paths: [{ value: "/t.data", timestampMethod: "receiveTime" }],
+      },
+      {},
+    );
+
+    coordinator.handlePlayerState(playerState({ messages: [makeMsg(5, 1), makeMsg(5, 2)] }));
+    await settleCoordinator();
+
+    expect(datasetSnapshots.at(-1)?.[0]?.data.map((datum) => datum.value)).toEqual([1]);
+    coordinator.destroy();
+  });
+});

--- a/packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.viewport.test.ts
+++ b/packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.viewport.test.ts
@@ -474,6 +474,105 @@ describe("StateTransitionsCoordinator ingestion correctness", () => {
     coordinator.destroy();
   });
 
+  it("rebuilds sliced datasets when axis config bounds change without a player emit", async () => {
+    const { renderer, datasetSnapshots } = makeMockRenderer();
+    const coordinator = new StateTransitionsCoordinator(renderer);
+    const blockMessages = Array.from({ length: 10 }, (_, sec) => makeMsg(sec, sec));
+
+    coordinator.handleConfig(
+      {
+        isSynced: false,
+        xAxisMinValue: 0,
+        xAxisMaxValue: 4,
+        paths: [{ value: "/t.data", timestampMethod: "receiveTime" }],
+      },
+      {},
+    );
+    coordinator.handlePlayerState(playerState({ blockMessages }));
+    await settleCoordinator();
+
+    // The narrow view's slice cannot include the tail of the recording.
+    expect(datasetSnapshots.at(-1)?.[0]?.data.map((datum) => datum.x)).not.toContain(9);
+
+    // Widening the configured axis on a paused source must rebuild the slice immediately —
+    // there is no player emit coming to do it later.
+    coordinator.handleConfig(
+      {
+        isSynced: false,
+        xAxisMinValue: 0,
+        xAxisMaxValue: 9,
+        paths: [{ value: "/t.data", timestampMethod: "receiveTime" }],
+      },
+      {},
+    );
+    await settleCoordinator();
+
+    expect(datasetSnapshots.at(-1)?.[0]?.data.map((datum) => datum.x)).toContain(9);
+    coordinator.destroy();
+  });
+
+  it("keeps a live header-stamped sample whose stamp falls between block stamps", async () => {
+    const { renderer, datasetSnapshots } = makeMockRenderer();
+    const coordinator = new StateTransitionsCoordinator(renderer);
+    // Blocks receive-ordered with non-monotonic header stamps: [0, 100, 50].
+    const headerStampedBlocks = [
+      { receiveSec: 0, stampSec: 0, value: 0 },
+      { receiveSec: 1, stampSec: 100, value: 2 },
+      { receiveSec: 2, stampSec: 50, value: 1 },
+    ].map(({ receiveSec, stampSec, value }) => ({
+      ...makeMsg(receiveSec, value),
+      message: { data: value, header: { stamp: { sec: stampSec, nsec: 0 } } },
+    }));
+    // Live sample stamped 75: below the blocks' max stamp but absent from the blocks. Range
+    // dedupe against the sorted maximum would silently discard this transition.
+    const liveMsg = {
+      ...makeMsg(3, 3),
+      message: { data: 3, header: { stamp: { sec: 75, nsec: 0 } } },
+    };
+
+    coordinator.handleConfig(
+      {
+        isSynced: true,
+        paths: [{ value: "/t.data", timestampMethod: "headerStamp" }],
+      },
+      {},
+    );
+    coordinator.handlePlayerState(playerState({ blockMessages: headerStampedBlocks }));
+    coordinator.handlePlayerState(
+      playerState({ blockMessages: headerStampedBlocks, messages: [liveMsg] }),
+    );
+    coordinator.setGlobalBounds({ min: 40, max: 80 });
+    await settleCoordinator();
+
+    expect(datasetSnapshots.at(-1)?.[0]?.data.map((datum) => datum.x)).toContain(75);
+    coordinator.destroy();
+  });
+
+  it("slices at least the renderer's half-range pan buffer around the viewport", async () => {
+    const { renderer, datasetSnapshots } = makeMockRenderer();
+    const coordinator = new StateTransitionsCoordinator(renderer);
+    const blockMessages = Array.from({ length: 100 }, (_, sec) => makeMsg(sec, sec));
+
+    coordinator.handleConfig(
+      {
+        isSynced: true,
+        paths: [{ value: "/t.data", timestampMethod: "receiveTime" }],
+      },
+      {},
+    );
+    coordinator.handlePlayerState(playerState({ blockMessages }));
+    coordinator.setGlobalBounds({ min: 40, max: 60 });
+    await settleCoordinator();
+
+    // downsampleStates keeps half a view range on each side as its pan/zoom buffer; the slice
+    // must cover it ([30, 70] here) or fast pans expose blank regions until the next rebuild.
+    const xs = datasetSnapshots.at(-1)?.[0]?.data.map((datum) => datum.x) ?? [];
+    expect(xs).toContain(32);
+    expect(xs).toContain(68);
+    expect(xs).not.toContain(20);
+    coordinator.destroy();
+  });
+
   it("keeps the first streaming value when duplicate timestamps arrive", async () => {
     const { renderer, datasetSnapshots } = makeMockRenderer();
     const coordinator = new StateTransitionsCoordinator(renderer);

--- a/packages/studio-base/src/panels/StateTransitions/stateTransitionData.test.ts
+++ b/packages/studio-base/src/panels/StateTransitions/stateTransitionData.test.ts
@@ -75,7 +75,6 @@ describe("sliceStateDataForViewport", () => {
     // startIdx points at last element (x=40 <= 50), endIdx same after search → single continuity point
     expect(sliced.map((p) => p.x)).toEqual([40]);
   });
-
 });
 
 describe("processCacheFingerprint", () => {
@@ -185,7 +184,6 @@ describe("sliceMergedStateDataForViewport", () => {
       );
     }
   });
-
 });
 
 describe("sliceInterleavedStateDataForViewport", () => {

--- a/packages/studio-base/src/panels/StateTransitions/stateTransitionData.test.ts
+++ b/packages/studio-base/src/panels/StateTransitions/stateTransitionData.test.ts
@@ -7,6 +7,7 @@
 
 import {
   processCacheFingerprint,
+  sliceInterleavedStateDataForViewport,
   sliceMergedStateDataForViewport,
   sliceStateDataForViewport,
 } from "./stateTransitionData";
@@ -185,4 +186,53 @@ describe("sliceMergedStateDataForViewport", () => {
     }
   });
 
+});
+
+describe("sliceInterleavedStateDataForViewport", () => {
+  it("keeps a current sample whose x falls between fullData samples", () => {
+    const fullData = [d(0, "a"), d(50, "b"), d(100, "c")];
+    const currentData = [d(75, "live")];
+
+    expect(sliceInterleavedStateDataForViewport(fullData, currentData, 40, 90)).toEqual([
+      d(0, "a"),
+      d(50, "b"),
+      d(75, "live"),
+      d(100, "c"),
+    ]);
+  });
+
+  it("matches slicing the materialized sorted merge across randomized interleaved inputs", () => {
+    let seed = 7;
+    const rand = () => {
+      seed = (seed * 1103515245 + 12345) % 2147483648;
+      return seed / 2147483648;
+    };
+
+    for (let trial = 0; trial < 200; trial++) {
+      // Draw distinct x values, then deal them randomly into the two stores so their ranges
+      // fully interleave (the header-stamp case the concatenation-based slice cannot handle).
+      const xs = new Set<number>();
+      const count = Math.floor(rand() * 20);
+      while (xs.size < count) {
+        xs.add(Math.floor(rand() * 60));
+      }
+      const fullData: Datum[] = [];
+      const currentData: Datum[] = [];
+      for (const x of [...xs].sort((a, b) => a - b)) {
+        (rand() < 0.5 ? fullData : currentData).push(d(x, `v${x}`));
+      }
+
+      const minX = Math.floor(rand() * 70) - 5;
+      const maxX = minX + Math.floor(rand() * 40);
+
+      const oracle = sliceStateDataForViewport(
+        [...fullData, ...currentData].sort((a, b) => a.x - b.x),
+        minX,
+        maxX,
+      );
+      expect(sliceInterleavedStateDataForViewport(fullData, currentData, minX, maxX)).toEqual(
+        oracle,
+      );
+    }
+  });
 });

--- a/packages/studio-base/src/panels/StateTransitions/stateTransitionData.test.ts
+++ b/packages/studio-base/src/panels/StateTransitions/stateTransitionData.test.ts
@@ -1,0 +1,188 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import {
+  processCacheFingerprint,
+  sliceMergedStateDataForViewport,
+  sliceStateDataForViewport,
+} from "./stateTransitionData";
+import { Datum } from "./types";
+
+function d(x: number, value: number | string): Datum {
+  return {
+    x,
+    y: 0,
+    value,
+    label: String(value),
+    labelColor: "#fff",
+  };
+}
+
+/**
+ * The previous production path: materialize the merge, then window it. Kept here as the reference
+ * oracle that `sliceMergedStateDataForViewport` must match exactly.
+ */
+function legacyMergeThenSlice(
+  fullData: Datum[],
+  currentData: Datum[],
+  minX: number,
+  maxX: number,
+): Datum[] {
+  let merged: Datum[];
+  if (currentData.length === 0) {
+    merged = fullData;
+  } else if (fullData.length === 0) {
+    merged = currentData;
+  } else {
+    const lastFullX = fullData[fullData.length - 1]?.x ?? -Infinity;
+    merged = [...fullData, ...currentData.filter((datum) => datum.x > lastFullX)];
+  }
+  return sliceStateDataForViewport(merged, minX, maxX);
+}
+
+describe("sliceStateDataForViewport", () => {
+  const data = [d(0, "a"), d(10, "b"), d(20, "c"), d(30, "d"), d(40, "e")];
+
+  it("includes the last point at or before minX for continuity", () => {
+    const sliced = sliceStateDataForViewport(data, 15, 35);
+    expect(sliced.map((p) => p.x)).toEqual([10, 20, 30, 40]);
+  });
+
+  it("includes the endpoint after a viewport enclosed by a collapsed plateau", () => {
+    const plateau = [d(0, "stable"), d(100, "stable")];
+    expect(sliceStateDataForViewport(plateau, 40, 50).map((p) => p.x)).toEqual([0, 100]);
+  });
+
+  it("returns empty for empty input", () => {
+    expect(sliceStateDataForViewport([], 0, 1)).toEqual([]);
+  });
+
+  it("returns all data when window covers full range", () => {
+    expect(sliceStateDataForViewport(data, -1, 100).map((p) => p.x)).toEqual([0, 10, 20, 30, 40]);
+  });
+
+  it("handles a window before the first sample", () => {
+    expect(sliceStateDataForViewport(data, -10, -1)).toEqual([]);
+  });
+
+  it("handles a window after the last sample by keeping last point before min", () => {
+    const sliced = sliceStateDataForViewport(data, 50, 60);
+    // startIdx points at last element (x=40 <= 50), endIdx same after search → single continuity point
+    expect(sliced.map((p) => p.x)).toEqual([40]);
+  });
+
+});
+
+describe("processCacheFingerprint", () => {
+  it("changes when the trailing endpoint mutates without a length change", () => {
+    const data: Datum[] = [d(0, "open"), d(1, "open")];
+
+    const before = processCacheFingerprint(data, /*y*/ 0, /*viewMin*/ 0, /*viewMax*/ 10);
+    data[1]!.x = 5; // in-place endpoint mutation, same length
+    const after = processCacheFingerprint(data, 0, 0, 10);
+
+    expect(after).not.toEqual(before);
+  });
+
+  it("changes when viewport bounds change", () => {
+    const data = [d(0, "a"), d(1, "b")];
+    const a = processCacheFingerprint(data, 0, 0, 10);
+    const b = processCacheFingerprint(data, 0, 5, 15);
+    expect(a).not.toEqual(b);
+  });
+
+  it("is stable for identical inputs", () => {
+    const data = [d(0, "a"), d(2, "a")];
+    expect(processCacheFingerprint(data, 1, 0, 3)).toEqual(processCacheFingerprint(data, 1, 0, 3));
+  });
+});
+
+describe("sliceMergedStateDataForViewport", () => {
+  const full = [d(0, "a"), d(10, "b"), d(20, "c"), d(30, "d")];
+  const current = [d(25, "stale"), d(30, "dup"), d(40, "e"), d(50, "f")];
+
+  it("drops currentData samples not newer than the last fullData sample", () => {
+    const sliced = sliceMergedStateDataForViewport(full, current, -1, 100);
+    expect(sliced.map((p) => p.x)).toEqual([0, 10, 20, 30, 40, 50]);
+    // x=30 comes from fullData, not the currentData duplicate.
+    expect(sliced[3]!.value).toBe("d");
+  });
+
+  it("windows across the fullData/currentData boundary", () => {
+    const sliced = sliceMergedStateDataForViewport(full, current, 28, 45);
+    // Keeps both the last point before minX and the first point after maxX for line continuity.
+    expect(sliced.map((p) => p.x)).toEqual([20, 30, 40, 50]);
+  });
+
+  it("windows entirely inside currentData", () => {
+    const sliced = sliceMergedStateDataForViewport(full, current, 45, 60);
+    expect(sliced.map((p) => p.x)).toEqual([40, 50]);
+  });
+
+  it("windows entirely inside fullData", () => {
+    const sliced = sliceMergedStateDataForViewport(full, current, 5, 15);
+    expect(sliced.map((p) => p.x)).toEqual([0, 10, 20]);
+  });
+
+  it("keeps both endpoints when a collapsed plateau surrounds the viewport", () => {
+    const plateau = [d(0, "stable"), d(100, "stable")];
+    expect(sliceMergedStateDataForViewport(plateau, [], 40, 50).map((p) => p.x)).toEqual([0, 100]);
+  });
+
+  it("handles empty inputs", () => {
+    expect(sliceMergedStateDataForViewport([], [], 0, 10)).toEqual([]);
+    expect(sliceMergedStateDataForViewport([], current, 0, 100).map((p) => p.x)).toEqual([
+      25, 30, 40, 50,
+    ]);
+    expect(sliceMergedStateDataForViewport(full, [], 0, 100).map((p) => p.x)).toEqual([
+      0, 10, 20, 30,
+    ]);
+  });
+
+  it("returns only the continuity point when the window is past the end", () => {
+    expect(sliceMergedStateDataForViewport(full, current, 80, 90).map((p) => p.x)).toEqual([50]);
+  });
+
+  it("returns empty when the window is before the first sample", () => {
+    expect(sliceMergedStateDataForViewport(full, current, -20, -10)).toEqual([]);
+  });
+
+  it("matches the legacy merge-then-slice result across randomized inputs", () => {
+    let seed = 42;
+    const rand = () => {
+      seed = (seed * 1103515245 + 12345) % 2147483648;
+      return seed / 2147483648;
+    };
+
+    for (let trial = 0; trial < 200; trial++) {
+      const fullLen = Math.floor(rand() * 12);
+      const currentLen = Math.floor(rand() * 12);
+
+      const fullData: Datum[] = [];
+      let x = 0;
+      for (let i = 0; i < fullLen; i++) {
+        x += Math.floor(rand() * 5);
+        fullData.push(d(x, `f${i}`));
+      }
+      // currentData overlaps fullData's tail so the "newer than lastFullX" filter is exercised.
+      const currentData: Datum[] = [];
+      let cx = Math.max(0, x - Math.floor(rand() * 8));
+      for (let i = 0; i < currentLen; i++) {
+        cx += Math.floor(rand() * 5);
+        currentData.push(d(cx, `c${i}`));
+      }
+
+      const minX = Math.floor(rand() * 40) - 5;
+      const maxX = minX + Math.floor(rand() * 30);
+
+      expect(sliceMergedStateDataForViewport(fullData, currentData, minX, maxX)).toEqual(
+        legacyMergeThenSlice(fullData, currentData, minX, maxX),
+      );
+    }
+  });
+
+});

--- a/packages/studio-base/src/panels/StateTransitions/stateTransitionData.ts
+++ b/packages/studio-base/src/panels/StateTransitions/stateTransitionData.ts
@@ -153,7 +153,7 @@ export function sliceInterleavedStateDataForViewport(
 }
 
 /** Merge two x-sorted arrays into one x-sorted array (stable: `a` wins ties). */
-function mergeSortedByX(a: readonly Datum[], b: readonly Datum[]): Datum[] {
+export function mergeSortedByX(a: readonly Datum[], b: readonly Datum[]): Datum[] {
   const merged: Datum[] = [];
   let i = 0;
   let j = 0;

--- a/packages/studio-base/src/panels/StateTransitions/stateTransitionData.ts
+++ b/packages/studio-base/src/panels/StateTransitions/stateTransitionData.ts
@@ -1,0 +1,200 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { Datum } from "./types";
+
+/**
+ * Fingerprint for processed-dataset caches. Includes the head/tail endpoints as well as length so
+ * any in-place endpoint mutation (same length, new x) still invalidates the cache.
+ */
+export function processCacheFingerprint(
+  data: readonly Datum[],
+  y: number,
+  viewMin: number,
+  viewMax: number,
+): string {
+  if (data.length === 0) {
+    return `0|${y}|${viewMin}|${viewMax}`;
+  }
+  const head = data[0]!;
+  const tail = data[data.length - 1]!;
+  return [data.length, y, viewMin, viewMax, head.x, tail.x, String(tail.value)].join("|");
+}
+
+/**
+ * Slice the merged (fullData ++ newer currentData) series to the visible x-window **without
+ * materializing the merge**.
+ *
+ * `sliceStateDataForViewport(getMergedData(...))` was O(total history) per rebuild: the merge
+ * copied the entire preloaded series before the window narrowed it, and rebuilds run on every
+ * player emit plus every pan/zoom interaction. This walks the two sorted arrays as one virtual
+ * concatenation and copies only the visible window.
+ *
+ * Result is identical to slicing the materialized merge: `currentData` contributes only samples
+ * strictly newer than the last `fullData` sample, matching the previous merge semantics.
+ *
+ * The window is materialized with native `Array.slice` rather than an element-by-element copy
+ * through the virtual accessor. A/B measurement showed the naive loop was ~2x *slower* than the
+ * old merge-then-slice for mid-sized series (~1k-10k samples, the range a partially preloaded bag
+ * actually reaches) even though it won by 100x at 400k; native slice wins in every regime.
+ */
+export function sliceMergedStateDataForViewport(
+  fullData: readonly Datum[],
+  currentData: readonly Datum[],
+  minX: number,
+  maxX: number,
+): Datum[] {
+  const fullLength = fullData.length;
+  const lastFullX = fullLength > 0 ? fullData[fullLength - 1]!.x : -Infinity;
+
+  // First index of currentData strictly newer than fullData's last sample.
+  const currentStart = firstIndexAfter(currentData, lastFullX);
+  const currentLength = currentData.length - currentStart;
+  const totalLength = fullLength + currentLength;
+  if (totalLength === 0) {
+    return [];
+  }
+
+  // Virtual index into the concatenation; both halves are sorted and the second is strictly newer.
+  const at = (index: number): Datum =>
+    index < fullLength ? fullData[index]! : currentData[currentStart + index - fullLength]!;
+
+  /** Copy [startIdx, endIdx) out of the virtual concatenation using native slices. */
+  const collect = (startIdx: number, endIdx: number): Datum[] => {
+    if (endIdx <= fullLength) {
+      return fullData.slice(startIdx, endIdx);
+    }
+    const currentFrom = currentStart + Math.max(0, startIdx - fullLength);
+    const currentTo = currentStart + endIdx - fullLength;
+    if (startIdx >= fullLength) {
+      return currentData.slice(currentFrom, currentTo);
+    }
+    // Window straddles the boundary.
+    return fullData.slice(startIdx, fullLength).concat(currentData.slice(currentFrom, currentTo));
+  };
+
+  if (!(maxX >= minX)) {
+    // Degenerate/NaN bounds: preserve the previous "return everything" behaviour.
+    return collect(0, totalLength);
+  }
+
+  // lo is the first index with x > minX. Include lo-1 for continuity when present.
+  const startIdx = Math.max(0, firstIndexAfterVirtual(at, 0, totalLength, minX) - 1);
+  let endIdx = firstIndexAfterVirtual(at, startIdx, totalLength, maxX); // exclusive
+
+  // A state is rendered as a line between samples. Keep the first point after the window so a
+  // collapsed plateau whose endpoints surround the viewport still has a segment to draw.
+  // Do not do this when the entire dataset starts after the window: there is no active state yet.
+  if (endIdx > 0 && endIdx < totalLength) {
+    endIdx += 1;
+  }
+
+  if (startIdx >= endIdx) {
+    // No points in range; still return the last point before minX if any.
+    if (startIdx < totalLength && at(startIdx).x <= minX) {
+      return [at(startIdx)];
+    }
+    return [];
+  }
+
+  return collect(startIdx, endIdx);
+}
+
+/** First index of a sorted array whose x is strictly greater than `x`. */
+function firstIndexAfter(data: readonly Datum[], x: number): number {
+  let lo = 0;
+  let hi = data.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (data[mid]!.x <= x) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  return lo;
+}
+
+/** As {@link firstIndexAfter}, over a virtual array addressed by `at` within [lo, hi). */
+function firstIndexAfterVirtual(
+  at: (index: number) => Datum,
+  from: number,
+  to: number,
+  x: number,
+): number {
+  let lo = from;
+  let hi = to;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (at(mid).x <= x) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  return lo;
+}
+
+/**
+ * Slice sorted state samples to the visible x-window, retaining the last sample
+ * at or before minX so the first visible segment has the correct state.
+ */
+export function sliceStateDataForViewport(
+  data: readonly Datum[],
+  minX: number,
+  maxX: number,
+): Datum[] {
+  if (data.length === 0) {
+    return [];
+  }
+  if (!(maxX >= minX)) {
+    return data.slice();
+  }
+
+  // Binary search for first index with x > minX (strictly after window start).
+  let lo = 0;
+  let hi = data.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (data[mid]!.x <= minX) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  // lo is first index with x > minX. Include lo-1 for continuity when present.
+  const startIdx = Math.max(0, lo - 1);
+
+  // Binary search for first index with x > maxX.
+  lo = startIdx;
+  hi = data.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (data[mid]!.x <= maxX) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  let endIdx = lo; // exclusive
+
+  // Retain the first post-window point for line continuity. This is required for collapsed
+  // plateaus such as [start, end] when the viewport lies entirely between the two endpoints.
+  if (endIdx > 0 && endIdx < data.length) {
+    endIdx += 1;
+  }
+
+  if (startIdx >= endIdx) {
+    // No points in range; still return last point before minX if any.
+    if (startIdx < data.length && data[startIdx]!.x <= minX) {
+      return [data[startIdx]!];
+    }
+    return [];
+  }
+
+  return data.slice(startIdx, endIdx);
+}

--- a/packages/studio-base/src/panels/StateTransitions/stateTransitionData.ts
+++ b/packages/studio-base/src/panels/StateTransitions/stateTransitionData.ts
@@ -35,7 +35,10 @@ export function processCacheFingerprint(
  * concatenation and copies only the visible window.
  *
  * Result is identical to slicing the materialized merge: `currentData` contributes only samples
- * strictly newer than the last `fullData` sample, matching the previous merge semantics.
+ * strictly newer than the last `fullData` sample, matching the previous merge semantics. This is
+ * only valid for receive-time-ordered series; header-stamped series must use
+ * {@link sliceInterleavedStateDataForViewport} because their currentData can interleave with
+ * fullData on the x axis.
  *
  * The window is materialized with native `Array.slice` rather than an element-by-element copy
  * through the virtual accessor. A/B measurement showed the naive loop was ~2x *slower* than the
@@ -102,6 +105,72 @@ export function sliceMergedStateDataForViewport(
   }
 
   return collect(startIdx, endIdx);
+}
+
+/**
+ * As {@link sliceMergedStateDataForViewport}, but for series whose currentData can interleave
+ * with fullData on the x axis. Header stamps are not monotonic in receive order, so a live
+ * sample's stamp may fall between block stamps; the concatenation-based slice would silently
+ * drop it.
+ *
+ * Each store contributes a bounded candidate window (its last sample at or before minX through
+ * its first sample after maxX); the two windows are merged and the standard single-array slice
+ * applies the margin semantics to the merge. Every global boundary candidate is inside some
+ * store's candidate window, so the result equals slicing the materialized sorted merge — at
+ * O(log history + window) cost, never O(history).
+ *
+ * Assumes exact-x duplicates across the two stores were already removed at ingestion
+ * (StateTransitionsCoordinator dedupes header-stamped samples by stamp membership).
+ */
+export function sliceInterleavedStateDataForViewport(
+  fullData: readonly Datum[],
+  currentData: readonly Datum[],
+  minX: number,
+  maxX: number,
+): Datum[] {
+  if (fullData.length === 0) {
+    return sliceStateDataForViewport(currentData, minX, maxX);
+  }
+  if (currentData.length === 0) {
+    return sliceStateDataForViewport(fullData, minX, maxX);
+  }
+  if (!(maxX >= minX)) {
+    // Degenerate/NaN bounds: preserve the "return everything" behaviour of the base slice.
+    return mergeSortedByX(fullData.slice(), currentData.slice());
+  }
+
+  const candidateWindow = (data: readonly Datum[]): Datum[] => {
+    const from = Math.max(0, firstIndexAfter(data, minX) - 1);
+    const to = Math.min(data.length, firstIndexAfter(data, maxX) + 1);
+    return data.slice(from, Math.max(from, to));
+  };
+
+  return sliceStateDataForViewport(
+    mergeSortedByX(candidateWindow(fullData), candidateWindow(currentData)),
+    minX,
+    maxX,
+  );
+}
+
+/** Merge two x-sorted arrays into one x-sorted array (stable: `a` wins ties). */
+function mergeSortedByX(a: readonly Datum[], b: readonly Datum[]): Datum[] {
+  const merged: Datum[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < a.length && j < b.length) {
+    if (a[i]!.x <= b[j]!.x) {
+      merged.push(a[i++]!);
+    } else {
+      merged.push(b[j++]!);
+    }
+  }
+  while (i < a.length) {
+    merged.push(a[i++]!);
+  }
+  while (j < b.length) {
+    merged.push(b[j++]!);
+  }
+  return merged;
 }
 
 /** First index of a sorted array whose x is strictly greater than `x`. */


### PR DESCRIPTION
## Summary

Non-destructive replacement for the windowing half of #1420. Per review feedback on #1420: raw data is never removed at ingestion — 丢失原始数据的问题已解决：原始数据全部保留，压缩只发生在渲染层，Show Points 可无损还原全部原始点（包括纯实时数据）。

**What it keeps from #1420:** binary viewport slice over the merged full/current stores, dataset rebuilds on pan/zoom/sync/reset bounds changes, block-gap cursor fix, firstBlockRefs reset fix, header-stamp sorting, fingerprint render cache.

**What it drops:** ingestion-time compaction entirely. Canonical stores always retain every raw sample, so Show Points is lossless for both block-backed and live-only sources, and toggling it takes effect immediately with no block reprocessing.

## Performance (isolated component measurement)

Deterministic coordinator benchmark, 200k-point fixture, follow window 30 s, identical probe on both sides. Transition-heavy case (closest to the Astribot S1 high-rate panels):

| Per playback emit | `main` | this PR |
|---|---:|---:|
| Points shipped to the chart worker (median) | 100,066 | 231 (−99.8%) |
| Main-thread blocking median / p95 | 38 ms / 41 ms | ~0 ms / ~0 ms |

Bounds-change rebuilds (new in this PR) cost ≈1 ms total across 30 window moves. (Numbers re-measured after widening the slice pad to cover the renderer's half-range pan buffer — one of the review fixes.) Baseline's 38 ms reproduces the previously reported 36 ms worker peak — the windowing alone achieves the reduction, with zero data loss. Claimed scope: fewer datums shipped per rebuild (deterministic count) and reduced main-thread blocking in an isolated component benchmark — not an end-to-end latency claim.

### Verify it yourself

The probe ships in this PR (`StateTransitionsCoordinator.perfprobe.test.ts`, skipped in CI):

```bash
# on this branch:
PERF_PROBE=1 TRANSITION_EVERY=2 yarn test packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.perfprobe.test.ts
# baseline (the probe file is additive, so it drops onto main cleanly):
git switch main
git checkout rei125/pr1420-replacement -- packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.perfprobe.test.ts
PERF_PROBE=1 TRANSITION_EVERY=2 yarn test packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.perfprobe.test.ts
```

Compare the `PERFPROBE_RESULT` lines: `deliveredPoints` is deterministic (identical every run); `blockedMs` is machine-dependent but the cross-branch ratio is stable. `TRANSITION_EVERY=50` runs the plateau-heavy variant.

## Correctness evidence

- 200-trial randomized oracle: sliced build exactly equals merge-then-slice for random stores/bounds.
- Show Points on restores every raw timestamp/value; live-only sequence [0,1,2] fully recovers after toggling (the case that was unacceptable in #1420).
- Incremental block loading equals one-shot loading; unloaded block gaps stop the cursor instead of silently skipping data; header-stamped data sorted before display.
- 26 functional tests pass; render output for a given viewport is identical to `main` by construction.

## Behavior changes vs `main`

Intended none for rendering semantics. Three bug fixes ride along, each with a regression test: block-gap data skip, second-block-pass reset, header-stamp ordering. Structural: datasets are rebuilt per bounds change instead of shipping full history up-front (measured ~0 ms median).

Supersedes #1420 (disposition of the old draft to be decided separately).
