### PR TITLE
fix(studio): end block-load cursors on topics-changed and cache-full returns

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.test.ts
@@ -672,4 +672,57 @@ describe("BlockLoader", () => {
     expect(firstBlockLoad?.[0]?.messagesByTopic["a"]).toBe(lastBlocks?.[0]?.messagesByTopic["a"]);
     expect(firstBlockLoad?.[1]?.messagesByTopic["a"]).toBe(lastBlocks?.[1]?.messagesByTopic["a"]);
   });
+
+  it("ends a source-provided cursor when topics change during a block read", async () => {
+    // Iterator-backed cursors return undefined from readUntil once the loader's abort controller
+    // fires, so the topics-changed early return with live results is only reachable through a
+    // source-provided message cursor - exactly the kind whose end() releases external resources
+    // (open readers, network streams). That early return must not abandon the cursor.
+    const source = new TestSource() as TestSource & {
+      getMessageCursor?: () => unknown;
+    };
+    let firstCursor = true;
+    let firstCursorEnded = false;
+
+    const loader = new BlockLoader({
+      maxBlocks: 2,
+      cacheSizeBytes: 100,
+      minBlockDurationNs: 1,
+      source,
+      start: { sec: 0, nsec: 0 },
+      end: { sec: 1, nsec: 0 },
+      problemManager: new PlayerProblemManager(),
+    });
+
+    source.getMessageCursor = () => {
+      const isFirst = firstCursor;
+      firstCursor = false;
+      return {
+        next: async () => undefined,
+        nextBatch: async () => undefined,
+        readUntil: async (): Promise<IteratorResult[]> => {
+          if (isFirst) {
+            // Topics change while the read is in flight; this cursor still resolves results.
+            loader.setTopics(mockTopicSelection("a", "b"));
+          }
+          return [];
+        },
+        end: async () => {
+          if (isFirst) {
+            firstCursorEnded = true;
+          }
+        },
+      };
+    };
+
+    loader.setTopics(mockTopicSelection("a"));
+    await loader.startLoading({
+      progress: async () => {
+        // The aborted first pass emits no progress; stop once the reload with new topics runs.
+        await loader.stopLoading();
+      },
+    });
+
+    expect(firstCursorEnded).toBe(true);
+  });
 });

--- a/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
+++ b/packages/studio-base/src/players/IterablePlayer/BlockLoader.ts
@@ -291,6 +291,7 @@ export class BlockLoader {
         // Check whether the topics are changed and abort this loading instance because the results
         // may no longer be valid for the data we should be loading.
         if (!_.isEqual(topics, this.#topics)) {
+          await cursor.end();
           return;
         }
 
@@ -357,6 +358,7 @@ export class BlockLoader {
             // We need to emit progress here so the player will emit a new state
             // containing the problem.
             progress(this.#calculateProgress(topics, totalBlockSizeBytes));
+            await cursor.end();
             return;
           }
         }


### PR DESCRIPTION
## Summary

Two early-return paths in `BlockLoader`'s load loop — topics changed mid-read, and cache full — abandoned the message cursor without `await cursor.end()`.

For iterator-backed cursors the loader's abort signal usually cleans this up (`IteratorCursor.readUntil` returns `undefined` once aborted, which hits the path that does call `end()`). But a **source-provided message cursor** that resolves results despite a concurrent topics change is never closed, leaking whatever its `end()` releases — open readers, network streams.

Extracted as a minimal standalone fix from draft #1423, which contained these two lines buried inside a larger experimental rewrite (see the closing note there).

## Verification

- Regression test drives the topics-changed path through a source-provided cursor and asserts `end()` is called; it fails without the fix.
- The iterator-backed abort path is unchanged and remains covered by the existing suite.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787679525&installation_model_id=425002&pr_number=1429&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1429&signature=356ee748dee0e6ae8814c3542676db6360739ea76e6c4919a1f5eb4b394bf53a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->