### PR TITLE
test(studio): await spill recovery range update

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.test.ts
@@ -2912,9 +2912,12 @@ describe("CachingIterableSource", () => {
         configurable: true,
         value: "visible",
       });
+      const recoveryComplete = new Promise<void>((resolve) => {
+        bufferedSource.once("loadedRangesChange", resolve);
+      });
       document.dispatchEvent(new Event("visibilitychange"));
 
-      await waitFor(async () => (await getPlaybackSpillSessions()).length === 1);
+      await recoveryComplete;
       const recoveredSession = (await getPlaybackSpillSessions())[0];
       expect(recoveredSession?.sessionId).not.toBe(originalSession.sessionId);
       expect(bufferedSource.loadedRanges()).toEqual([{ start: 0.2, end: 0.3 }]);


### PR DESCRIPTION
## What changed

- Wait for the spill recovery `loadedRangesChange` completion signal before asserting the recovered session and in-memory ranges.
- Replace polling for replacement session metadata, which becomes visible before recovery is complete.

## Root cause

The test treated creation of the replacement IndexedDB session row as completion of spill-cache recovery. Recovery creates that row before restoring the topic fingerprint, clearing stale spill ranges, and recomputing the public loaded ranges. On slower CI runners, the assertion could run in that window and observe the old spill coverage merged with the memory cache as `[{ start: 0, end: 0.3 }]`.

This is a test synchronization race, not a product race. A controlled delay in the replacement store's `setTopicFingerprint()` reproduced the failing range deterministically; recovery subsequently published the correct `[{ start: 0.2, end: 0.3 }]` range.

## Impact

The test now waits for the event emitted by recovery's final range recomputation, eliminating the timing window without changing product behavior or adding sleeps.

## Validation

- `yarn test packages/studio-base/src/players/IterablePlayer/CachingIterableSource.test.ts` — 10 consecutive full-suite runs passed (50/50 tests each).
- `yarn eslint --config eslint.config.ci.cjs --max-warnings 0 packages/studio-base/src/players/IterablePlayer/CachingIterableSource.test.ts` — exit code 0.
- `git diff --check` — passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1431"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787795162&installation_model_id=425002&pr_number=1431&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1431&signature=f3c5b3ff44317366ea9e978994c94a3190ac7e0c15fa8167ca2a5bbc728e9451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->