### PR TITLE
Fix production web build type errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,12 @@ jobs:
       - run: set -x
 
       - run: yarn run tsc --noEmit
+      - name: Verify production web build
+        run: yarn run web:build:prod
+        env:
+          # Production builds upload source maps when this token is present. CI only needs to
+          # compile and type-check the application.
+          SENTRY_AUTH_TOKEN: ""
       - run: yarn run lint:ci
 
   unit-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,6 @@ jobs:
       - run: set -x
 
       - run: yarn run tsc --noEmit
-      - name: Verify production web build
-        run: yarn run web:build:prod
-        env:
-          # Production builds upload source maps when this token is present. CI only needs to
-          # compile and type-check the application.
-          SENTRY_AUTH_TOKEN: ""
       - run: yarn run lint:ci
 
   unit-test:

--- a/packages/studio-base/src/panels/Log/index.tsx
+++ b/packages/studio-base/src/panels/Log/index.tsx
@@ -64,6 +64,12 @@ type Props = {
   saveConfig: SaveConfig<Config>;
 };
 
+const DEFAULT_CONFIG: Config = {
+  searchTerms: [],
+  minLogLevel: 1,
+  reverseOrder: false,
+};
+
 const SUPPORTED_DATATYPES = [
   "foxglove_msgs/Log",
   "foxglove_msgs/msg/Log",
@@ -223,7 +229,7 @@ LogPanel.displayName = "Log";
 
 export default Panel(
   Object.assign(LogPanel, {
-    defaultConfig: { searchTerms: [], minLogLevel: 1, reverseOrder: false },
+    defaultConfig: DEFAULT_CONFIG,
     panelType: "RosOut", // The legacy RosOut name is used for backwards compatibility
   }),
 );

--- a/packages/studio-base/src/panels/RawMessages/getDiff.ts
+++ b/packages/studio-base/src/panels/RawMessages/getDiff.ts
@@ -100,7 +100,7 @@ export default function getDiff({
 
     if (idToCompareWith != undefined) {
       const unmatchedAfterById = _.keyBy(after, idToCompareWith);
-      const diff = [];
+      const diff: DiffObject[] = [];
       for (const beforeItem of before) {
         if (beforeItem == undefined || typeof beforeItem !== "object") {
           throw new Error("beforeItem is invalid; should have checked this earlier");
@@ -135,7 +135,9 @@ export default function getDiff({
           showFullMessageForDiff,
         });
         if (!_.isEmpty(innerDiff)) {
-          diff.push(innerDiff);
+          // This branch compares keyed object entries, so the recursive result is a DiffObject.
+          // The production tsconfig cannot infer that from getDiff's general return type.
+          diff.push(innerDiff as DiffObject);
         }
       }
       return diff;

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/FoxgloveGrid.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/FoxgloveGrid.ts
@@ -500,7 +500,8 @@ export class FoxgloveGrid extends SceneExtension<FoxgloveGridRenderable> {
     const topic = messageEvent.topic;
 
     // Set the initial settings from default values merged with any user settings
-    const userSettings = this.renderer.config.topics[topic];
+    const userSettings: Partial<LayerSettingsFoxgloveGrid> | undefined =
+      this.renderer.config.topics[topic];
     const settings = { ...DEFAULT_SETTINGS, ...userSettings };
 
     const foxgloveGrid = normalizeFoxgloveGrid(messageEvent.message, settings.modifyHeight);

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/LaserScans.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/LaserScans.ts
@@ -353,7 +353,8 @@ export class LaserScans extends SceneExtension<LaserScanHistoryRenderable> {
     const finalQueue: MessageEvent<T>[] = [];
     for (const topic in msgsByTopic) {
       const topicMsgs = msgsByTopic[topic]!;
-      const userSettings = this.renderer.config.topics[topic];
+      const userSettings: Partial<LayerSettingsLaserScan> | undefined =
+        this.renderer.config.topics[topic];
       // if the topic has a decaytime add all messages to queue for topic
       if ((userSettings?.decayTime ?? DEFAULT_SETTINGS.decayTime) > 0) {
         finalQueue.push(...topicMsgs);
@@ -447,7 +448,8 @@ export class LaserScans extends SceneExtension<LaserScanHistoryRenderable> {
     let renderable = this.renderables.get(topic);
     if (!renderable) {
       // Set the initial settings from default values merged with any user settings
-      const userSettings = this.renderer.config.topics[topic];
+      const userSettings: Partial<LayerSettingsLaserScan> | undefined =
+        this.renderer.config.topics[topic];
       const settings = { ...DEFAULT_SETTINGS, ...userSettings };
       if (settings.colorField == undefined) {
         settings.colorField = "intensity";

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Markers.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Markers.ts
@@ -171,7 +171,8 @@ export class Markers extends SceneExtension<TopicMarkers> {
     // Update the MarkersNamespace settings
     const renderable = this.renderables.get(topicName);
     if (renderable) {
-      const settings = this.renderer.config.topics[topicName];
+      const settings: Partial<LayerSettingsMarker> | undefined =
+        this.renderer.config.topics[topicName];
       const ns = renderable.namespaces.get(namespace);
       if (ns) {
         const nsSettings = settings?.namespaces?.[namespace] as

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointClouds.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/PointClouds.ts
@@ -756,7 +756,8 @@ export class PointClouds extends SceneExtension<PointCloudHistoryRenderable> {
     const finalQueue: MessageEvent<T>[] = [];
     for (const topic in msgsByTopic) {
       const topicMsgs = msgsByTopic[topic]!;
-      const userSettings = this.renderer.config.topics[topic];
+      const userSettings: Partial<LayerSettingsPointClouds> | undefined =
+        this.renderer.config.topics[topic];
       // if the topic has a decaytime add all messages to queue for topic
       if ((userSettings?.decayTime ?? DEFAULT_SETTINGS.decayTime) > 0) {
         finalQueue.push(...topicMsgs);
@@ -907,7 +908,8 @@ export class PointClouds extends SceneExtension<PointCloudHistoryRenderable> {
     let renderable = this.renderables.get(topic);
     if (!renderable) {
       // Set the initial settings from default values merged with any user settings
-      const userSettings = this.renderer.config.topics[topic];
+      const userSettings: Partial<LayerSettingsPointClouds> | undefined =
+        this.renderer.config.topics[topic];
       const settings = { ...DEFAULT_SETTINGS, ...userSettings };
 
       // want to avoid setting this if fields didn't update

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicMarkers.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/TopicMarkers.ts
@@ -40,6 +40,8 @@ export type MarkerTopicUserData = BaseUserData & {
   settings: LayerSettingsMarker;
 };
 
+type PartialMarkerSettings = Partial<LayerSettingsMarker> | undefined;
+
 export class MarkersNamespace {
   public namespace: string;
   public markersById = new Map<number, RenderableMarker>();
@@ -49,7 +51,7 @@ export class MarkersNamespace {
     this.namespace = namespace;
 
     // Set the initial settings from default values merged with any user settings
-    const topicSettings = renderer.config.topics[topic];
+    const topicSettings: PartialMarkerSettings = renderer.config.topics[topic];
     const userSettings = topicSettings?.namespaces?.[namespace];
     this.settings = { ...DEFAULT_NAMESPACE_SETTINGS, ...userSettings };
   }

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/VelodyneScans.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/VelodyneScans.ts
@@ -161,7 +161,8 @@ export class VelodyneScans extends SceneExtension<PointCloudHistoryRenderable> {
     const finalQueue: MessageEvent<T>[] = [];
     for (const topic in msgsByTopic) {
       const topicMsgs = msgsByTopic[topic]!;
-      const userSettings = this.renderer.config.topics[topic];
+      const userSettings: Partial<LayerSettingsVelodyneScans> | undefined =
+        this.renderer.config.topics[topic];
       // if the topic has a decaytime add all messages to queue for topic
       if ((userSettings?.decayTime ?? DEFAULT_SETTINGS.decayTime) > 0) {
         finalQueue.push(...topicMsgs);
@@ -262,7 +263,8 @@ export class VelodyneScans extends SceneExtension<PointCloudHistoryRenderable> {
     let renderable = this.renderables.get(topic);
     if (!renderable) {
       // Set the initial settings from default values merged with any user settings
-      const userSettings = this.renderer.config.topics[topic];
+      const userSettings: Partial<LayerSettingsVelodyneScans> | undefined =
+        this.renderer.config.topics[topic];
       const settings = { ...DEFAULT_SETTINGS, ...userSettings };
       if (settings.colorField == undefined && fieldsUpdated) {
         autoSelectColorSettings(settings, fields, { supportsPackedRgbModes: false });

--- a/packages/studio-base/src/services/api/CoSceneConsoleApi.test.ts
+++ b/packages/studio-base/src/services/api/CoSceneConsoleApi.test.ts
@@ -183,4 +183,36 @@ describe("CoSceneConsoleApi", () => {
       }),
     );
   });
+
+  it("converts metadata schemas from base64 without retaining raw schema strings", async () => {
+    const api = await createApi(completeBaseInfo);
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        startTime: 0,
+        endTime: 1,
+        topics: [
+          {
+            topic: "/without-schema",
+            encoding: "json",
+            schemaName: "example.Empty",
+            schemaEncoding: "jsonschema",
+            version: "1",
+          },
+          {
+            topic: "/with-schema",
+            encoding: "protobuf",
+            schemaName: "example.Message",
+            schemaEncoding: "protobuf",
+            schema: "AQI=",
+            version: "1",
+          },
+        ],
+      }),
+    );
+
+    const result = await api.topics("file-key");
+
+    expect(result.metaData[0]).not.toHaveProperty("schema");
+    expect(Array.from(result.metaData[1]?.schema ?? [])).toEqual([1, 2]);
+  });
 });

--- a/packages/studio-base/src/services/api/CoSceneConsoleApi.ts
+++ b/packages/studio-base/src/services/api/CoSceneConsoleApi.ts
@@ -912,12 +912,12 @@ class CoSceneConsoleApi {
       },
     );
 
-    const metaData = topics.topics.map((topic) => {
-      if (topic.schema == undefined) {
+    const metaData = topics.topics.map(({ schema, ...topic }): TopicResponse => {
+      if (schema == undefined) {
         return topic;
       }
-      const decodedSchema = new Uint8Array(base64.length(topic.schema));
-      base64.decode(topic.schema, decodedSchema, 0);
+      const decodedSchema = new Uint8Array(base64.length(schema));
+      base64.decode(schema, decodedSchema, 0);
       return { ...topic, schema: decodedSchema };
     });
 

--- a/packages/ws-protocol/src/parse.test.ts
+++ b/packages/ws-protocol/src/parse.test.ts
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { parseClientMessage, parseServerMessage } from "./parse";
+
+function messageWithOpcode(opcode: number): ArrayBuffer {
+  const buffer = new ArrayBuffer(1);
+  new DataView(buffer).setUint8(0, opcode);
+  return buffer;
+}
+
+describe("binary message parsing", () => {
+  it("rejects unknown server message opcodes", () => {
+    expect(() => parseServerMessage(messageWithOpcode(255), 0)).toThrow(
+      "Unrecognized server message opcode: 255",
+    );
+  });
+
+  it("rejects unknown client message opcodes", () => {
+    expect(() => parseClientMessage(messageWithOpcode(255))).toThrow(
+      "Unrecognized client message opcode: 255",
+    );
+  });
+});

--- a/packages/ws-protocol/src/parse.ts
+++ b/packages/ws-protocol/src/parse.ts
@@ -92,6 +92,8 @@ export function parseServerMessage(buffer: ArrayBuffer, receiveTime: number): Se
           throw new Error(`Unrecognized pre-fetch asset status: ${status}`);
       }
     }
+    default:
+      throw new Error(`Unrecognized server message opcode: ${op}`);
   }
 }
 
@@ -122,5 +124,7 @@ export function parseClientMessage(buffer: ArrayBuffer): ClientMessage {
       const data = new DataView(buffer, offset, buffer.byteLength - offset);
       return { op, serviceId, callId, encoding, data };
     }
+    default:
+      throw new Error(`Unrecognized client message opcode: ${op}`);
   }
 }


### PR DESCRIPTION
## Summary

- restore the topic-specific and panel config types required by the production Rspack type checker
- keep metadata schema conversion type-safe and reject unknown WebSocket opcodes explicitly
- add regression coverage for metadata schema conversion and invalid protocol opcodes

## Root cause

PR #1417 removed type assertions that looked unnecessary under the root ESLint/TypeScript configuration. The production web build uses a different TypeScript context through `TsCheckerRspackPlugin`, where the generic renderer topic settings need to be widened to each renderable's settings type. The existing CI `yarn run tsc --noEmit` command only checks the root tsconfig and did not include the application packages, so the change merged before the 66 production-build errors were detected.

This fixes the failure seen in https://github.com/coscene-io/honeybee/actions/runs/30004032316/job/89195680122.

## Impact

The web image can be built and published again. Existing renderer behavior is preserved; malformed WebSocket opcodes now fail with an explicit error instead of returning `undefined`.

## Validation

- `SENTRY_AUTH_TOKEN= yarn run web:build:prod` (local verification only)
- `yarn run tsc --noEmit`
- `yarn workspace @foxglove/ws-protocol build`
- ESLint on all changed TypeScript files
- targeted Jest suites: 3 suites, 15 tests
- `git diff --check`
