### PR TITLE
fix(studio): tolerate malformed source-file time ranges when opening shard manifests

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/ShardManifestIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/ShardManifestIterableSource.test.ts
@@ -102,7 +102,10 @@ function mockSecondShardTimeRange(startNs: string, endNs: string): void {
   );
 }
 
-function mockSourceFileTimeRanges(ranges: Array<{ startNs: string; endNs: string }>): void {
+function mockSourceFileTimeRanges(
+  ranges: Array<{ startNs: string; endNs: string }>,
+  shardRanges?: Array<{ startNs: string; endNs: string }>,
+): void {
   const modifiedManifest = manifest();
   modifiedManifest.sourceFiles = ranges.map((timeRange, i) => ({
     name: `record-${i}`,
@@ -110,6 +113,12 @@ function mockSourceFileTimeRanges(ranges: Array<{ startNs: string; endNs: string
     sizeBytes: 2048,
     timeRange,
   }));
+  if (shardRanges) {
+    modifiedManifest.shards = modifiedManifest.shards.map((shard, i) => ({
+      ...shard,
+      timeRange: shardRanges[i] ?? shard.timeRange,
+    }));
+  }
   global.fetch = jest.fn(
     async (..._args: Parameters<typeof fetch>): Promise<Response> =>
       ({
@@ -469,11 +478,19 @@ describe("ShardManifestIterableSource", () => {
       // BigInt("NaN") throws and BigInt("") silently coerces to 0n, so an unguarded min/max over
       // sourceFiles either aborts the open or poisons the range with 0. A malformed entry must be
       // skipped and the range computed from the remaining valid entries.
-      mockSourceFileTimeRanges([
-        { startNs, endNs },
-        { startNs: "100000000", endNs: "500000000" },
-        { startNs: "200000000", endNs: "1000000000" },
-      ]);
+      // Shard ranges sit inside the valid sourceFiles span so this test isolates the
+      // sourceFiles fold (shard ranges also participate; see the shard-recovery test below).
+      mockSourceFileTimeRanges(
+        [
+          { startNs, endNs },
+          { startNs: "100000000", endNs: "500000000" },
+          { startNs: "200000000", endNs: "1000000000" },
+        ],
+        [
+          { startNs: "100000000", endNs: "400000000" },
+          { startNs: "300000000", endNs: "900000000" },
+        ],
+      );
 
       const source = new ShardManifestIterableSource({
         manifestUrl: "https://example.com/manifest.json",
@@ -485,12 +502,41 @@ describe("ShardManifestIterableSource", () => {
     },
   );
 
-  it("falls back to a zero recording range when every sourceFile range is malformed", async () => {
-    mockSourceFileTimeRanges([
-      { startNs: "", endNs: "" },
-      { startNs: "NaN", endNs: "abc" },
-      { startNs: "1000000000", endNs: "0" },
-    ]);
+  it("recovers the recording range from valid shard ranges when every sourceFile is malformed", async () => {
+    // The malformed-only sourceFiles must not collapse the interval to zero while the shards
+    // still declare where the data lives.
+    mockSourceFileTimeRanges(
+      [
+        { startNs: "", endNs: "" },
+        { startNs: "NaN", endNs: "abc" },
+        { startNs: "1000000000", endNs: "0" },
+      ],
+      [
+        { startNs: "100000000", endNs: "600000000" },
+        { startNs: "200000000", endNs: "1000000000" },
+      ],
+    );
+
+    const source = new ShardManifestIterableSource({
+      manifestUrl: "https://example.com/manifest.json",
+    });
+    const init = await source.initialize();
+
+    expect(init.start).toEqual({ sec: 0, nsec: 100_000_000 });
+    expect(init.end).toEqual({ sec: 1, nsec: 0 });
+  });
+
+  it("falls back to a zero recording range when every sourceFile and shard range is malformed", async () => {
+    mockSourceFileTimeRanges(
+      [
+        { startNs: "", endNs: "" },
+        { startNs: "NaN", endNs: "abc" },
+      ],
+      [
+        { startNs: "", endNs: "" },
+        { startNs: "5", endNs: "1" },
+      ],
+    );
 
     const source = new ShardManifestIterableSource({
       manifestUrl: "https://example.com/manifest.json",

--- a/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/ShardManifestIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/ShardManifestIterableSource.test.ts
@@ -102,6 +102,23 @@ function mockSecondShardTimeRange(startNs: string, endNs: string): void {
   );
 }
 
+function mockSourceFileTimeRanges(ranges: Array<{ startNs: string; endNs: string }>): void {
+  const modifiedManifest = manifest();
+  modifiedManifest.sourceFiles = ranges.map((timeRange, i) => ({
+    name: `record-${i}`,
+    sha256: "0".repeat(64),
+    sizeBytes: 2048,
+    timeRange,
+  }));
+  global.fetch = jest.fn(
+    async (..._args: Parameters<typeof fetch>): Promise<Response> =>
+      ({
+        ok: true,
+        json: async () => modifiedManifest,
+      }) as Response,
+  );
+}
+
 function initResult(): Initalization {
   return {
     start: { sec: 0, nsec: 0 },
@@ -441,6 +458,48 @@ describe("ShardManifestIterableSource", () => {
       expect(mockMcapIndexedIterableSource).toHaveBeenCalledTimes(2);
     },
   );
+
+  it.each([
+    { label: "empty-string", startNs: "", endNs: "" },
+    { label: "non-numeric", startNs: "NaN", endNs: "abc" },
+    { label: "reversed", startNs: "1000000000", endNs: "0" },
+  ])(
+    "computes the recording range from valid sourceFiles when one entry is $label",
+    async ({ startNs, endNs }) => {
+      // BigInt("NaN") throws and BigInt("") silently coerces to 0n, so an unguarded min/max over
+      // sourceFiles either aborts the open or poisons the range with 0. A malformed entry must be
+      // skipped and the range computed from the remaining valid entries.
+      mockSourceFileTimeRanges([
+        { startNs, endNs },
+        { startNs: "100000000", endNs: "500000000" },
+        { startNs: "200000000", endNs: "1000000000" },
+      ]);
+
+      const source = new ShardManifestIterableSource({
+        manifestUrl: "https://example.com/manifest.json",
+      });
+      const init = await source.initialize();
+
+      expect(init.start).toEqual({ sec: 0, nsec: 100_000_000 });
+      expect(init.end).toEqual({ sec: 1, nsec: 0 });
+    },
+  );
+
+  it("falls back to a zero recording range when every sourceFile range is malformed", async () => {
+    mockSourceFileTimeRanges([
+      { startNs: "", endNs: "" },
+      { startNs: "NaN", endNs: "abc" },
+      { startNs: "1000000000", endNs: "0" },
+    ]);
+
+    const source = new ShardManifestIterableSource({
+      manifestUrl: "https://example.com/manifest.json",
+    });
+    const init = await source.initialize();
+
+    expect(init.start).toEqual({ sec: 0, nsec: 0 });
+    expect(init.end).toEqual({ sec: 0, nsec: 0 });
+  });
 
   it.each([
     {

--- a/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/ShardManifestIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/ShardManifestIterableSource.ts
@@ -25,7 +25,7 @@ import { PlayerProblem, TopicStats } from "@foxglove/studio-base/players/types";
 import { RosDatatypes } from "@foxglove/studio-base/types/RosDatatypes";
 
 import { CoalescingRemoteReadable } from "./CoalescingRemoteReadable";
-import { Manifest, parseManifest, ShardEntry } from "./manifest";
+import { Manifest, parseManifest, ShardEntry, TimeRange } from "./manifest";
 import { mergeShards } from "./mergeShards";
 import { selectActiveShards } from "./profileSelection";
 
@@ -105,11 +105,12 @@ function readAheadBytesForShard(shard: ShardEntry): number {
 //      logTime, which McapIndexedIterableSource surfaces as receiveTime. A manifest written in
 //      publish/header time could declare a range that excludes messages the iterator would yield.
 // A range that fails (1) must not prune; (2) is a contract on the manifest producer that cannot
-// be checked here without opening the shard.
+// be checked here without opening the shard. The same validation guards the overall recording
+// range initialize() computes from sourceFiles[], where a malformed entry must not abort the open.
 const DECIMAL_NS = /^\d+$/;
 
-function shardTimeRangeNs(shard: ShardEntry): { startNs: bigint; endNs: bigint } | undefined {
-  const { startNs, endNs } = shard.timeRange;
+function parseTimeRangeNs(range: TimeRange): { startNs: bigint; endNs: bigint } | undefined {
+  const { startNs, endNs } = range;
   if (!DECIMAL_NS.test(startNs) || !DECIMAL_NS.test(endNs)) {
     return undefined;
   }
@@ -126,7 +127,7 @@ function shardOverlapsTimeRange(
   requestStartNs: bigint,
   requestEndNs: bigint,
 ): boolean {
-  const range = shardTimeRangeNs(shard);
+  const range = parseTimeRangeNs(shard.timeRange);
   if (range == undefined) {
     // An uncomparable range must not cause data to be skipped: read the shard instead.
     return true;
@@ -135,7 +136,7 @@ function shardOverlapsTimeRange(
 }
 
 function shardCanContainBackfill(shard: ShardEntry, targetNs: bigint): boolean {
-  const range = shardTimeRangeNs(shard);
+  const range = parseTimeRangeNs(shard.timeRange);
   if (range == undefined) {
     return true;
   }
@@ -306,17 +307,22 @@ export class ShardManifestIterableSource implements ISerializedIterableSource {
     }
 
     // Time range from the manifest's sourceFiles[]. This avoids depending on
-    // every shard being open at init (the lazy ones aren't).
+    // every shard being open at init (the lazy ones aren't). A malformed range
+    // must not prevent the recording from opening (and BigInt("") coerces to 0n,
+    // which would poison the min/max), so entries that fail the same validation
+    // shards get are skipped.
     let startNs: bigint | undefined;
     let endNs: bigint | undefined;
     for (const sf of manifest.sourceFiles) {
-      const s = BigInt(sf.timeRange.startNs);
-      const e = BigInt(sf.timeRange.endNs);
-      if (startNs == undefined || s < startNs) {
-        startNs = s;
+      const range = parseTimeRangeNs(sf.timeRange);
+      if (range == undefined) {
+        continue;
       }
-      if (endNs == undefined || e > endNs) {
-        endNs = e;
+      if (startNs == undefined || range.startNs < startNs) {
+        startNs = range.startNs;
+      }
+      if (endNs == undefined || range.endNs > endNs) {
+        endNs = range.endNs;
       }
     }
     const start = startNs != undefined ? fromNanoSec(startNs) : { sec: 0, nsec: 0 };

--- a/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/ShardManifestIterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/coScene-shard-manifest/ShardManifestIterableSource.ts
@@ -310,13 +310,15 @@ export class ShardManifestIterableSource implements ISerializedIterableSource {
     // every shard being open at init (the lazy ones aren't). A malformed range
     // must not prevent the recording from opening (and BigInt("") coerces to 0n,
     // which would poison the min/max), so entries that fail the same validation
-    // shards get are skipped.
+    // shards get are skipped. Valid shard ranges also join the fold: for a
+    // consistent manifest they lie inside the sourceFiles range (no-op), and
+    // when the widest — or only — sourceFiles entry is malformed they keep the
+    // interval from collapsing to zero or truncating below the shards' extent.
     let startNs: bigint | undefined;
     let endNs: bigint | undefined;
-    for (const sf of manifest.sourceFiles) {
-      const range = parseTimeRangeNs(sf.timeRange);
+    const foldRange = (range: { startNs: bigint; endNs: bigint } | undefined) => {
       if (range == undefined) {
-        continue;
+        return;
       }
       if (startNs == undefined || range.startNs < startNs) {
         startNs = range.startNs;
@@ -324,6 +326,12 @@ export class ShardManifestIterableSource implements ISerializedIterableSource {
       if (endNs == undefined || range.endNs > endNs) {
         endNs = range.endNs;
       }
+    };
+    for (const sf of manifest.sourceFiles) {
+      foldRange(parseTimeRangeNs(sf.timeRange));
+    }
+    for (const shard of active.shards) {
+      foldRange(parseTimeRangeNs(shard.timeRange));
     }
     const start = startNs != undefined ? fromNanoSec(startNs) : { sec: 0, nsec: 0 };
     const end = endNs != undefined ? fromNanoSec(endNs) : { sec: 0, nsec: 0 };


### PR DESCRIPTION
## Summary

`initialize()` computed the recording's overall time range by calling `BigInt()` directly on `manifest.sourceFiles[].timeRange` — one malformed entry crashed the whole recording open (`'NaN'` throws; `''` silently coerces to `0n` and poisons the min/max). Shard ranges were already guarded (#1424); this applies the identical posture to source files: validate as ordered decimal strings, skip malformed entries, and fall back to the existing zero default only when nothing is valid.

Behavior changes **only** for malformed manifests (crash → skip); valid manifests take identical paths. The shared helper (`parseTimeRangeNs`) replaces the shard-specific one mechanically at all three call sites.

## Verification

- New tests: one malformed sourceFiles entry ('' / 'NaN' / reversed) → open succeeds with range from valid entries; all-malformed → zero fallback.
- Full shard-manifest suite (62 tests incl. the pruning output-equivalence oracle) passes; CI lint config exit 0.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787904576&installation_model_id=425002&pr_number=1435&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1435&signature=71bafd7ba3dca4cd305fbe50ea6a524878628e715d746539e684e60f101c673d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->