### PR TITLE
refactor(studio): harden state-transitions render fingerprint and share the pan-buffer constant

### DIFF
--- a/packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.ts
+++ b/packages/studio-base/src/panels/StateTransitions/StateTransitionsCoordinator.ts
@@ -38,7 +38,7 @@ import {
   UpdateAction,
 } from "./StateTransitionsChartRenderer";
 import { StateTransitionsRenderer } from "./StateTransitionsRenderer";
-import { Viewport } from "./downsampleStates";
+import { VIEWPORT_PAN_BUFFER_FRACTION, Viewport } from "./downsampleStates";
 import positiveModulo from "./positiveModulo";
 import { PathState } from "./settings";
 import {
@@ -707,12 +707,11 @@ export class StateTransitionsCoordinator extends EventEmitter<EventTypes> {
       this.#globalBounds?.max ??
       this.#configBounds.x.max ??
       viewMin + 1;
-    // Pad the window so pan/edge segments stay connected without processing the full bag. The
-    // pad must cover at least the renderer's own pan/zoom buffer (downsampleStates keeps half a
-    // view range on each side): #dispatchRender applies an interaction to the already-loaded
-    // dataset before the throttled rebuild lands, so a smaller upstream slice would expose
-    // blank regions during fast pans.
-    const viewPad = Math.max(0, (viewMax - viewMin) * 0.5);
+    // Pad the window by the renderer's shared pan buffer (VIEWPORT_PAN_BUFFER_FRACTION) so
+    // pan/edge segments stay connected without processing the full bag: #dispatchRender applies
+    // an interaction to the already-loaded dataset before the throttled rebuild lands, so a
+    // smaller upstream slice would expose blank regions during fast pans.
+    const viewPad = Math.max(0, (viewMax - viewMin) * VIEWPORT_PAN_BUFFER_FRACTION);
     const sliceMin = viewMin - viewPad;
     const sliceMax = viewMax + viewPad;
 

--- a/packages/studio-base/src/panels/StateTransitions/downsampleStates.ts
+++ b/packages/studio-base/src/panels/StateTransitions/downsampleStates.ts
@@ -16,6 +16,14 @@ const MINIMUM_PIXEL_DISTANCE = 3;
 // Beyond this threshold, ChartJS can no longer render at 60FPS.
 export const MAX_POINTS = 5_000;
 
+/**
+ * Fraction of the visible x-range kept as extra buffer on each side of the viewport so points
+ * near the bounds stay connected to their peers during pan/zoom. The coordinator's upstream
+ * viewport slice (StateTransitionsCoordinator) pads by this same fraction: it must cover at
+ * least the renderer's buffer window or fast pans would expose blank regions.
+ */
+export const VIEWPORT_PAN_BUFFER_FRACTION = 0.5;
+
 export type Viewport = {
   width: number;
   height: number;
@@ -123,12 +131,10 @@ export function downsampleStates(data: Datum[], view: Viewport, maxPoints?: numb
   const indices: StatePoint[] = [];
   let interval: Interval | undefined;
 
-  // We keep points within a buffer window around the bounds so points near the bounds are
-  // connected to their peers and available for pan/zoom.
-  // Points outside this buffer window are dropped.
+  // Points outside the shared pan buffer window (see VIEWPORT_PAN_BUFFER_FRACTION) are dropped.
   const xRange = bounds.x.max - bounds.x.min;
-  const minX = bounds.x.min - xRange * 0.5;
-  const maxX = bounds.x.max + xRange * 0.5;
+  const minX = bounds.x.min - xRange * VIEWPORT_PAN_BUFFER_FRACTION;
+  const maxX = bounds.x.max + xRange * VIEWPORT_PAN_BUFFER_FRACTION;
 
   let firstPastBounds: number | undefined = undefined;
 

--- a/packages/studio-base/src/panels/StateTransitions/stateTransitionData.test.ts
+++ b/packages/studio-base/src/panels/StateTransitions/stateTransitionData.test.ts
@@ -99,6 +99,24 @@ describe("processCacheFingerprint", () => {
     const data = [d(0, "a"), d(2, "a")];
     expect(processCacheFingerprint(data, 1, 0, 3)).toEqual(processCacheFingerprint(data, 1, 0, 3));
   });
+
+  it("distinguishes a numeric tail value from its string form", () => {
+    const numeric = [d(0, "a"), d(1, 1)];
+    const stringy = [d(0, "a"), d(1, "1")];
+    expect(processCacheFingerprint(numeric, 0, 0, 10)).not.toEqual(
+      processCacheFingerprint(stringy, 0, 0, 10),
+    );
+  });
+
+  it("changes when a mid-window value mutates with unchanged endpoints and length", () => {
+    const data: Datum[] = [d(0, "a"), d(1, "b"), d(2, "c"), d(3, "d"), d(4, "e")];
+
+    const before = processCacheFingerprint(data, 0, 0, 10);
+    data[2]!.value = "z"; // in-place mutation at the sampled middle index (length >> 1)
+    const after = processCacheFingerprint(data, 0, 0, 10);
+
+    expect(after).not.toEqual(before);
+  });
 });
 
 describe("sliceMergedStateDataForViewport", () => {

--- a/packages/studio-base/src/panels/StateTransitions/stateTransitionData.test.ts
+++ b/packages/studio-base/src/panels/StateTransitions/stateTransitionData.test.ts
@@ -95,6 +95,15 @@ describe("processCacheFingerprint", () => {
     expect(a).not.toEqual(b);
   });
 
+  it("does not collide when string values contain the join delimiter", () => {
+    // Unescaped concatenation would let a crafted value forge adjacent fields: a middle value
+    // of 'y|2|string:z' could produce the same joined string as different mid/tail data.
+    const a = [d(0, "a"), d(1, "y|2|string:z"), d(2, "x")];
+    const b = [d(0, "a"), d(1, "y"), d(2, "z")];
+
+    expect(processCacheFingerprint(a, 0, 0, 10)).not.toEqual(processCacheFingerprint(b, 0, 0, 10));
+  });
+
   it("is stable for identical inputs", () => {
     const data = [d(0, "a"), d(2, "a")];
     expect(processCacheFingerprint(data, 1, 0, 3)).toEqual(processCacheFingerprint(data, 1, 0, 3));

--- a/packages/studio-base/src/panels/StateTransitions/stateTransitionData.ts
+++ b/packages/studio-base/src/panels/StateTransitions/stateTransitionData.ts
@@ -40,9 +40,13 @@ export function processCacheFingerprint(
   ].join("|");
 }
 
-/** Stringify a datum value prefixed with its type so e.g. 1 and "1" fingerprint differently. */
+/**
+ * Encode a datum value with its type so e.g. 1 and "1" fingerprint differently. JSON-encoding
+ * makes the field boundary unambiguous: a string value containing the join delimiter ("|")
+ * stays inside its quotes, so it cannot forge adjacent fingerprint fields.
+ */
 function taggedValue(value: Datum["value"]): string {
-  return `${typeof value}:${String(value)}`;
+  return `${typeof value}:${JSON.stringify(value) ?? String(value)}`;
 }
 
 /**

--- a/packages/studio-base/src/panels/StateTransitions/stateTransitionData.ts
+++ b/packages/studio-base/src/panels/StateTransitions/stateTransitionData.ts
@@ -8,8 +8,12 @@
 import { Datum } from "./types";
 
 /**
- * Fingerprint for processed-dataset caches. Includes the head/tail endpoints as well as length so
- * any in-place endpoint mutation (same length, new x) still invalidates the cache.
+ * Fingerprint for processed-dataset caches. O(1) by design: it samples rather than hashes the
+ * series, combining the length, the head/tail endpoints, the middle datum (index length >> 1),
+ * and type-tagged values (so 1 and "1" differ). This catches in-place endpoint mutations, tail
+ * value edits including type-only changes, and any mutation that lands on the sampled middle
+ * datum. It can still theoretically miss mutations that leave the length, both endpoints, and
+ * the middle sample unchanged — e.g. offsetting edits confined to other interior indices.
  */
 export function processCacheFingerprint(
   data: readonly Datum[],
@@ -21,8 +25,24 @@ export function processCacheFingerprint(
     return `0|${y}|${viewMin}|${viewMax}`;
   }
   const head = data[0]!;
+  const mid = data[data.length >> 1]!;
   const tail = data[data.length - 1]!;
-  return [data.length, y, viewMin, viewMax, head.x, tail.x, String(tail.value)].join("|");
+  return [
+    data.length,
+    y,
+    viewMin,
+    viewMax,
+    head.x,
+    tail.x,
+    taggedValue(tail.value),
+    mid.x,
+    taggedValue(mid.value),
+  ].join("|");
+}
+
+/** Stringify a datum value prefixed with its type so e.g. 1 and "1" fingerprint differently. */
+function taggedValue(value: Datum["value"]): string {
+  return `${typeof value}:${String(value)}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

Two small hardenings of the recently landed viewport-slicing work:

1. **Render-cache fingerprint**: values are now type-tagged (`1` vs `'1'` fingerprint differently) and a middle sample (index `length >> 1`) joins the endpoints, so mid-window mutations with unchanged endpoints invalidate the cache. Still O(1); the doc comment states honestly what residual cases sampling can miss. Failure direction is safe: a stronger fingerprint can only cause extra cache misses, never stale renders.
2. **Shared pan-buffer constant**: the coordinator's slice pad and `downsampleStates`' buffer window were the same deliberate 0.5 coupled only by comments; both now use exported `VIEWPORT_PAN_BUFFER_FRACTION`. Provably behavior-identical.

## Verification

New fingerprint tests (type-only tail change, mid-window mutation); full StateTransitions suite passes; CI lint config exit 0.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1436"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787904581&installation_model_id=425002&pr_number=1436&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1436&signature=a74fd79fa147020b49ff5fe0ca5d5389fd728fbea43341f5671a1dfaa1b124a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->