### PR TITLE
Show Option shortcut on macOS

### DIFF
--- a/packages/studio-base/src/components/PlaybackControls/EventsOverlay.test.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/EventsOverlay.test.tsx
@@ -356,7 +356,7 @@ describe("<EventsOverlay />", () => {
       );
 
       expect(screen.getByTestId("timeline-empty-event-hint").textContent).toBe(
-        "使用快捷键 Alt+1 创建一刻，为数据打标注",
+        "使用快捷键 Alt + 1 创建一刻，为数据打标注",
       );
       expect(screen.getByTestId("timeline-empty-event-create-icon")).toBeTruthy();
     } finally {

--- a/packages/studio-base/src/components/PlaybackControls/EventsOverlay.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/EventsOverlay.tsx
@@ -66,6 +66,7 @@ import {
   type EventResizeEdge,
   type EventTimeRange,
 } from "./eventTimeEdit";
+import { SHORTCUTS } from "./keyboardShortcuts";
 import {
   clientXToFraction,
   clientXToTime,
@@ -1713,7 +1714,9 @@ function UnmemoizedEventsOverlay(props: Props): React.JSX.Element | ReactNull {
             >
               <EventCreateInactiveIcon focusable="false" />
             </span>
-            <span className={classes.emptyEventHintText}>{t("emptyTimelineHint")}</span>
+            <span className={classes.emptyEventHintText}>
+              {t("emptyTimelineHint", { shortcut: SHORTCUTS.createMoment[0] })}
+            </span>
           </div>
         )}
         {renderLaneLayout.items.map((item) => {

--- a/packages/studio-base/src/components/PlaybackControls/keyboardShortcuts.test.ts
+++ b/packages/studio-base/src/components/PlaybackControls/keyboardShortcuts.test.ts
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import { getCreateMomentShortcut, isMacUserAgent } from "./keyboardShortcuts";
+
+describe("keyboardShortcuts", () => {
+  it("uses Option for the create moment shortcut on macOS", () => {
+    const userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)";
+
+    expect(isMacUserAgent(userAgent)).toBe(true);
+    expect(getCreateMomentShortcut(userAgent)).toBe("Option + 1");
+  });
+
+  it("uses Alt for the create moment shortcut on other platforms", () => {
+    const userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64)";
+
+    expect(isMacUserAgent(userAgent)).toBe(false);
+    expect(getCreateMomentShortcut(userAgent)).toBe("Alt + 1");
+  });
+});

--- a/packages/studio-base/src/components/PlaybackControls/keyboardShortcuts.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/keyboardShortcuts.tsx
@@ -9,11 +9,20 @@ import { alpha } from "@mui/material";
 import { Fragment } from "react";
 import { makeStyles } from "tss-react/mui";
 
-export const isMac =
-  typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.userAgent);
+export function isMacUserAgent(userAgent: string): boolean {
+  return /Mac|iPhone|iPad/.test(userAgent);
+}
+
+const userAgent = typeof navigator !== "undefined" ? navigator.userAgent : "";
+
+export const isMac = isMacUserAgent(userAgent);
 
 /** Platform-specific modifier symbol: ⌘ on macOS, Ctrl elsewhere. */
 export const MOD = isMac ? "⌘" : "Ctrl";
+
+export function getCreateMomentShortcut(currentUserAgent: string): "Option + 1" | "Alt + 1" {
+  return isMacUserAgent(currentUserAgent) ? "Option + 1" : "Alt + 1";
+}
 
 /**
  * Keyboard shortcut definitions, keyed by action. Each value is a list of interchangeable
@@ -35,7 +44,7 @@ export const SHORTCUTS = {
   playbackSpeed: ["−", "+"],
   selectMoment: ["↑", "↓"],
   seekToMoment: ["Enter"],
-  createMoment: ["Alt + 1"],
+  createMoment: [getCreateMomentShortcut(userAgent)],
   setInOut: ["I", "O"],
   deleteMoment: ["Delete", "Backspace"],
   zoom: [`${MOD} + =`, `${MOD} + −`],

--- a/packages/studio-base/src/i18n/en/event.ts
+++ b/packages/studio-base/src/i18n/en/event.ts
@@ -34,7 +34,7 @@ export const event = {
   editMomentFailed: "Save failed",
   editMomentSuccess: "Save success",
   elapsed: "Elapsed",
-  emptyTimelineHint: "Use Alt+1 to create a moment and annotate data",
+  emptyTimelineHint: "Use {{shortcut}} to create a moment and annotate data",
   enableLinkedEventAdjustment: "Enable linked event adjustment",
   disableLinkedEventAdjustment: "Disable linked event adjustment",
   end: "End",

--- a/packages/studio-base/src/i18n/zh/event.ts
+++ b/packages/studio-base/src/i18n/zh/event.ts
@@ -34,7 +34,7 @@ export const event: Partial<TypeOptions["resources"]["event"]> = {
   editMomentFailed: "保存失败",
   editMomentSuccess: "保存成功",
   elapsed: "经过时间",
-  emptyTimelineHint: "使用快捷键 Alt+1 创建一刻，为数据打标注",
+  emptyTimelineHint: "使用快捷键 {{shortcut}} 创建一刻，为数据打标注",
   enableLinkedEventAdjustment: "开启联动调整",
   disableLinkedEventAdjustment: "关闭联动调整",
   end: "结束",


### PR DESCRIPTION
## Summary

- derive the create-moment shortcut label from the current device's user agent
- show `Option + 1` on macOS and `Alt + 1` on other platforms
- reuse the platform-specific label in the empty-timeline hint, shortcut help, and tooltips
- add coverage for macOS and Windows shortcut labels

## Root cause

The create-moment shortcut label was hardcoded as `Alt`, even though the same modifier key is presented as `Option` on macOS.

## User impact

macOS users now see the familiar `Option + 1` wording wherever the create-moment shortcut is surfaced. The keyboard behavior itself is unchanged.

## Validation

- `git diff --check`
- `yarn run tsc --noEmit`
- targeted ESLint for all changed TypeScript files
- `yarn jest packages/studio-base/src/components/PlaybackControls/keyboardShortcuts.test.ts packages/studio-base/src/components/PlaybackControls/EventsOverlay.test.tsx --runInBand`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1440"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788001679&installation_model_id=425002&pr_number=1440&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1440&signature=81a248376c43e915a109f289d8c50c617bd3ec0a46fcc54e9cc5d85836067518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->