### PR TITLE
Fix player switching and cache topic stats

### DIFF
--- a/packages/studio-base/src/components/PlayerManager.test.tsx
+++ b/packages/studio-base/src/components/PlayerManager.test.tsx
@@ -7,7 +7,7 @@
 
 import { IndexedDbMessageStore } from "@foxglove/studio-base/persistence/IndexedDbMessageStore";
 
-import { markRealtimeCacheForCleanup } from "./PlayerManager";
+import { closePlayerForSourceSwitch, markRealtimeCacheForCleanup } from "./PlayerManager";
 
 jest.mock("@foxglove/studio-base/persistence/IndexedDbMessageStore", () => ({
   IndexedDbMessageStore: jest.fn(),
@@ -19,6 +19,17 @@ const mockDiscardAndSeal = jest.fn();
 const mockClose = jest.fn();
 const mockClear = jest.fn();
 const mockCleanupOldSessions = jest.fn();
+
+describe("closePlayerForSourceSwitch", () => {
+  it("contains teardown failures so a replacement source can be initialized", async () => {
+    const close = jest.fn().mockRejectedValue(new Error("close failed"));
+
+    await expect(closePlayerForSourceSwitch({ close })).resolves.toBeUndefined();
+
+    expect(close).toHaveBeenCalledTimes(1);
+    jest.mocked(console.warn).mockClear();
+  });
+});
 
 describe("markRealtimeCacheForCleanup", () => {
   beforeEach(() => {

--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -95,6 +95,21 @@ const selectProject = (store: CoreDataStore) => store.project;
 const selectJobRun = (store: CoreDataStore) => store.jobRun;
 const selectDataSource = (store: CoreDataStore) => store.dataSource;
 
+/** Close the current player without letting teardown failures block a source replacement. */
+export async function closePlayerForSourceSwitch(
+  player: Pick<Player, "close"> | undefined,
+): Promise<void> {
+  if (player == undefined) {
+    return;
+  }
+
+  try {
+    await player.close();
+  } catch (error) {
+    log.warn("Failed to close current player while switching sources:", error);
+  }
+}
+
 function useBeforeConnectionSource(): (
   sourceId: string,
   params: Record<string, string | undefined>,
@@ -382,9 +397,7 @@ export default function PlayerManager(
         return;
       }
 
-      if (playerInstances) {
-        await playerInstances.player.close();
-      }
+      await closePlayerForSourceSwitch(playerInstances?.player);
 
       setCurrentSourceArgs(args);
 

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.test.tsx
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.test.tsx
@@ -14,12 +14,15 @@ type MockClient = {
   close: jest.Mock;
   clientSyncTime: jest.Mock;
   emit: (name: string, ...args: unknown[]) => void;
+  subscribe: jest.Mock<number, [number]>;
+  unsubscribe: jest.Mock;
 };
 
 type MockCache = {
   close: jest.Mock<Promise<void>, []>;
   rejectClose: (error: unknown) => void;
   resolveClose: () => void;
+  storeTopics: jest.Mock;
 };
 
 const mockClients: MockClient[] = [];
@@ -35,6 +38,8 @@ jest.mock("@foxglove/ws-protocol", () => {
     readonly #listeners = new Map<string, Set<MockListener>>();
     public close = jest.fn();
     public clientSyncTime = jest.fn();
+    public subscribe = jest.fn((_channelId: number) => 1);
+    public unsubscribe = jest.fn();
 
     public constructor() {
       if (mockClientConstructionError != undefined) {
@@ -73,7 +78,6 @@ jest.mock("@foxglove/studio-base/persistence/RealtimeVizHistoryCache", () => ({
       init: jest.Mock;
       append: jest.Mock;
       storeDatatypes: jest.Mock;
-      storeTopics: jest.Mock;
     } = {
       init: jest.fn().mockResolvedValue(undefined),
       append: jest.fn(),
@@ -294,5 +298,42 @@ describe("FoxgloveWebSocketPlayer lifecycle", () => {
 
     await rejection;
     await expect(player.close()).resolves.toBeUndefined();
+  });
+
+  it("stores final topic message counts before closing the persistent cache", async () => {
+    const player = makePlayer();
+    const client = mockClients[0]!;
+    const cache = mockCaches[0]!;
+    await flushPromises();
+
+    client.emit("advertise", [
+      {
+        id: 7,
+        topic: "/test",
+        encoding: "json",
+        schemaName: "test_msgs/Test",
+        schema: '{"type":"object","properties":{"value":{"type":"number"}}}',
+        schemaEncoding: "jsonschema",
+      },
+    ]);
+    player.setSubscriptions([{ topic: "/test" }]);
+    client.emit("message", {
+      subscriptionId: 1,
+      data: new TextEncoder().encode('{"value":1}'),
+      timestamp: 1n,
+    });
+
+    const closePromise = player.close();
+    const finalStoreCall = cache.storeTopics.mock.calls.at(-1)!;
+    const topicStats = finalStoreCall[1] as Map<string, { numMessages: number }>;
+
+    expect(topicStats.get("/test")).toEqual({ numMessages: 1 });
+    expect(cache.storeTopics.mock.invocationCallOrder.at(-1)).toBeLessThan(
+      cache.close.mock.invocationCallOrder[0]!,
+    );
+
+    client.emit("close", { type: "close", data: { code: 1000, reason: "" } });
+    cache.resolveClose();
+    await closePromise;
   });
 });

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.tsx
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/index.tsx
@@ -1414,6 +1414,10 @@ export default class FoxgloveWebSocketPlayer implements Player {
       ? race([waitForClose, new Promise<void>((resolve) => setTimeout(resolve, 5000))])
       : Promise.resolve();
 
+    // Message counts change independently of the channel list, so persist one final metadata
+    // snapshot before closing the active cache. The cache tracks this write and close() waits for it.
+    persistentCache?.storeTopics(this.#topics, this.#topicsStats);
+
     const caches = [persistentCache, initializingPersistentCache].filter(
       (cache): cache is RealtimeVizHistoryCache => cache != undefined,
     );


### PR DESCRIPTION
## Summary
- keep source replacement moving when the previous player reports a teardown failure
- persist the final realtime topic message counts before closing the IndexedDB cache
- add regression coverage for both behaviors

## Context
Applies the same fixes for the first two unresolved review findings from coscene-io/bombus#133 to Honeybee.

## Validation
- `yarn test --ci --runInBand` (263 suites, 2231 tests; 1 suite and 1 test skipped)
- `yarn typecheck:ci`
- `yarn lint:ci`
- `yarn format:check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788433501&installation_model_id=425002&pr_number=1445&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1445&signature=ca1eb91b7c8864fa5ec879db4122faa33087f3578919f9c0739d50c4820d4ee8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->