### PR TITLE
Stabilize spill cache recovery test

### DIFF
--- a/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/CachingIterableSource.test.ts
@@ -2914,7 +2914,17 @@ describe("CachingIterableSource", () => {
       });
       document.dispatchEvent(new Event("visibilitychange"));
 
-      await waitFor(async () => (await getPlaybackSpillSessions()).length === 1);
+      await waitFor(async () => {
+        const sessions = await getPlaybackSpillSessions();
+        const loadedRanges = bufferedSource.loadedRanges();
+        return (
+          sessions.length === 1 &&
+          sessions[0]?.sessionId !== originalSession.sessionId &&
+          loadedRanges.length === 1 &&
+          loadedRanges[0]?.start === 0.2 &&
+          loadedRanges[0].end === 0.3
+        );
+      });
       const recoveredSession = (await getPlaybackSpillSessions())[0];
       expect(recoveredSession?.sessionId).not.toBe(originalSession.sessionId);
       expect(bufferedSource.loadedRanges()).toEqual([{ start: 0.2, end: 0.3 }]);


### PR DESCRIPTION
## Summary
- wait for both replacement session creation and loaded-range refresh in the spill cache recovery test
- remove a timing race that could observe the new session before recovery finished

## Root cause
The test previously treated the new IndexedDB session record as proof that the entire asynchronous recovery had completed. Under different scheduling, the loaded-range cache could still contain the previous persisted range for a short time.

## Validation
- full `CachingIterableSource.test.ts` suite: 50 tests passed
- affected recovery test repeated 20 times successfully
- `yarn typecheck:ci`
- targeted ESLint and Prettier checks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788453942&installation_model_id=425002&pr_number=1446&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1446&signature=0232fb1b1050d5096876bf230e598d72475684c05a05463f2df9aa03a7c3baa9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->