### PR TITLE
Fix saving remotely deleted personal layouts

### DIFF
--- a/packages/studio-base/src/components/CoSceneLayout/CurrentLayoutButton.test.tsx
+++ b/packages/studio-base/src/components/CoSceneLayout/CurrentLayoutButton.test.tsx
@@ -1,0 +1,103 @@
+/** @jest-environment jsdom */
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { LayoutID } from "@foxglove/studio-base/context/CurrentLayoutContext";
+import {
+  ISO8601Timestamp,
+  Layout,
+  LayoutPermission,
+} from "@foxglove/studio-base/services/CoSceneILayoutStorage";
+import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
+
+import { CurrentLayoutButton } from "./CurrentLayoutButton";
+
+jest.mock("@foxglove/studio-base/context/CoSceneConsoleApiContext", () => ({
+  useConsoleApi: () => ({
+    updateProjectLayout: {
+      permission: () => true,
+    },
+  }),
+}));
+
+function ts(value: string): ISO8601Timestamp {
+  return value as ISO8601Timestamp;
+}
+
+function makeRemotelyDeletedLayout(permission: LayoutPermission): Layout {
+  const id = `${permission === "PERSONAL_WRITE" ? "users/u" : "warehouses/w/projects/p"}/layouts/1`;
+  const data = {
+    layout: "Panel!1",
+    configById: {},
+    globalVariables: {},
+    userNodes: {},
+  };
+
+  return {
+    id: id as LayoutID,
+    parent: id.slice(0, id.lastIndexOf("/layouts/")),
+    folder: "",
+    name: "Layout",
+    permission,
+    baseline: {
+      data,
+      savedAt: ts("2024-01-01T00:00:00.000Z"),
+      modifier: undefined,
+      modifierNickname: undefined,
+    },
+    working: {
+      data,
+      savedAt: ts("2024-01-01T00:00:01.000Z"),
+    },
+    syncInfo: {
+      status: "remotely-deleted",
+      lastRemoteSavedAt: undefined,
+      lastRemoteUpdatedAt: undefined,
+    },
+  };
+}
+
+function renderButton(layout: Layout, onOverwriteLayout = jest.fn()): void {
+  render(
+    <ThemeProvider isDark>
+      <CurrentLayoutButton
+        currentLayoutId={layout.id}
+        layouts={{ allLayouts: [layout], personalFolders: [], projectFolders: [] }}
+        onClick={jest.fn()}
+        onOverwriteLayout={onOverwriteLayout}
+        onRevertLayout={jest.fn()}
+      />
+    </ThemeProvider>,
+  );
+  // The component currently renders action buttons inside a ButtonBase.
+  for (const [message] of jest.mocked(console.error).mock.calls) {
+    expect(message).toContain("validateDOMNesting");
+  }
+  jest.mocked(console.error).mockClear();
+}
+
+describe("<CurrentLayoutButton />", () => {
+  it("allows saving a remotely deleted personal layout with a draft", () => {
+    const layout = makeRemotelyDeletedLayout("PERSONAL_WRITE");
+    const onOverwriteLayout = jest.fn();
+    renderButton(layout, onOverwriteLayout);
+
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    expect(saveButton.hasAttribute("disabled")).toBe(false);
+
+    fireEvent.click(saveButton);
+    expect(onOverwriteLayout).toHaveBeenCalledWith(layout);
+  });
+
+  it("keeps saving disabled for a remotely deleted project layout", () => {
+    renderButton(makeRemotelyDeletedLayout("PROJECT_WRITE"));
+
+    expect(screen.getByRole("button", { name: "Save" }).hasAttribute("disabled")).toBe(true);
+  });
+});

--- a/packages/studio-base/src/components/CoSceneLayout/CurrentLayoutButton.tsx
+++ b/packages/studio-base/src/components/CoSceneLayout/CurrentLayoutButton.tsx
@@ -157,7 +157,7 @@ export function CurrentLayoutButton({
       key: "saveChanges",
       text: t("save"),
       onClick: handleOverwrite,
-      disabled: deletedOnServer || isRead || !canUpdate,
+      disabled: (deletedOnServer && isProject) || isRead || !canUpdate,
       visible: hasModifications,
     },
     {

--- a/packages/studio-base/src/components/CoSceneLayout/LayoutTableRowMenu.test.tsx
+++ b/packages/studio-base/src/components/CoSceneLayout/LayoutTableRowMenu.test.tsx
@@ -1,0 +1,107 @@
+/** @jest-environment jsdom */
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { LayoutID } from "@foxglove/studio-base/context/CurrentLayoutContext";
+import {
+  ISO8601Timestamp,
+  Layout,
+  LayoutPermission,
+} from "@foxglove/studio-base/services/CoSceneILayoutStorage";
+import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
+
+import { LayoutTableRowMenu } from "./LayoutTableRowMenu";
+
+jest.mock("@foxglove/studio-base/context/CoSceneConsoleApiContext", () => ({
+  useConsoleApi: () => ({
+    deleteProjectLayout: { permission: () => true },
+    updateProjectLayout: { permission: () => true },
+  }),
+}));
+
+jest.mock("@foxglove/studio-base/hooks/useConfirm", () => ({
+  useConfirm: () => jest.fn(),
+}));
+
+function ts(value: string): ISO8601Timestamp {
+  return value as ISO8601Timestamp;
+}
+
+function makeRemotelyDeletedLayout(permission: LayoutPermission): Layout {
+  const parent = permission === "PERSONAL_WRITE" ? "users/u" : "warehouses/w/projects/p";
+  const data = {
+    layout: "Panel!1",
+    configById: {},
+    globalVariables: {},
+    userNodes: {},
+  };
+
+  return {
+    id: `${parent}/layouts/1` as LayoutID,
+    parent,
+    folder: "",
+    name: "Layout",
+    permission,
+    baseline: {
+      data,
+      savedAt: ts("2024-01-01T00:00:00.000Z"),
+      modifier: undefined,
+      modifierNickname: undefined,
+    },
+    working: {
+      data,
+      savedAt: ts("2024-01-01T00:00:01.000Z"),
+    },
+    syncInfo: {
+      status: "remotely-deleted",
+      lastRemoteSavedAt: undefined,
+      lastRemoteUpdatedAt: undefined,
+    },
+  };
+}
+
+function renderMenu(layout: Layout, onOverwriteLayout = jest.fn()): void {
+  const anchorEl = document.createElement("button");
+  document.body.appendChild(anchorEl);
+
+  render(
+    <ThemeProvider isDark>
+      <LayoutTableRowMenu
+        anchorEl={anchorEl}
+        layout={layout}
+        handleMenuClose={jest.fn()}
+        handleOpenDialog={jest.fn()}
+        onDeleteLayout={jest.fn()}
+        onExportLayout={jest.fn()}
+        onOverwriteLayout={onOverwriteLayout}
+        onRevertLayout={jest.fn()}
+      />
+    </ThemeProvider>,
+  );
+}
+
+describe("<LayoutTableRowMenu />", () => {
+  it("allows saving a remotely deleted personal layout with a draft", () => {
+    const layout = makeRemotelyDeletedLayout("PERSONAL_WRITE");
+    const onOverwriteLayout = jest.fn();
+    renderMenu(layout, onOverwriteLayout);
+
+    const saveItem = screen.getByTestId("save-changes");
+    expect(saveItem.getAttribute("aria-disabled")).not.toBe("true");
+
+    fireEvent.click(saveItem);
+    expect(onOverwriteLayout).toHaveBeenCalledWith(layout);
+  });
+
+  it("keeps saving disabled for a remotely deleted project layout", () => {
+    renderMenu(makeRemotelyDeletedLayout("PROJECT_WRITE"));
+
+    expect(screen.getByTestId("save-changes").getAttribute("aria-disabled")).toBe("true");
+  });
+});

--- a/packages/studio-base/src/components/CoSceneLayout/LayoutTableRowMenu.tsx
+++ b/packages/studio-base/src/components/CoSceneLayout/LayoutTableRowMenu.tsx
@@ -131,7 +131,7 @@ export function LayoutTableRowMenu({
         text: t("save"),
         "data-testid": "save-changes",
         onClick: saveChanges,
-        disabled: deletedOnServer || disabled || !canUpdate,
+        disabled: (deletedOnServer && isProject) || disabled || !canUpdate,
       },
       {
         type: "item",

--- a/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.test.ts
+++ b/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.test.ts
@@ -847,6 +847,34 @@ describe("CoSceneLayoutManager", () => {
     });
   });
 
+  it("does not restore a remotely deleted layout from a remote layout without savedAt", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const manager = makeManager({ localStorage, remoteStorage });
+    const id = layoutId("users/u/layouts/1");
+    const localLayout = makeLocalLayout({
+      id,
+      data: layoutData("local-baseline"),
+      working: {
+        data: layoutData("local-draft"),
+        savedAt: ts("2024-01-01T00:00:01.000Z"),
+      },
+      syncStatus: "remotely-deleted",
+    });
+    await localStorage.put(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      localLayout,
+    );
+    remoteStorage.layouts.set(id, {
+      ...makeRemoteLayout({ id, data: layoutData("legacy-remote") }),
+      savedAt: undefined,
+    });
+
+    await manager.syncWithRemote(new AbortController().signal);
+
+    expect(await manager.getLayout({ id })).toEqual(localLayout);
+  });
+
   it("reuploads an updated personal layout when the remote copy is missing", async () => {
     const localStorage = new MemoryLayoutStorage();
     const remoteStorage = new MemoryRemoteLayoutStorage();

--- a/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.test.ts
+++ b/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.test.ts
@@ -807,6 +807,46 @@ describe("CoSceneLayoutManager", () => {
     expect(localLayout?.working).toBeUndefined();
   });
 
+  it("restores a remotely deleted personal layout when it reappears remotely", async () => {
+    const localStorage = new MemoryLayoutStorage();
+    const remoteStorage = new MemoryRemoteLayoutStorage();
+    const manager = makeManager({ localStorage, remoteStorage });
+    const id = layoutId("users/u/layouts/1");
+    const working = {
+      data: layoutData("local-draft"),
+      savedAt: ts("2024-01-01T00:00:01.000Z"),
+    };
+    await localStorage.put(
+      `${CoSceneLayoutManager.REMOTE_STORAGE_NAMESPACE_PREFIX}${remoteStorage.namespace}`,
+      makeLocalLayout({
+        id,
+        data: layoutData("stale-baseline"),
+        working,
+        syncStatus: "remotely-deleted",
+      }),
+    );
+    remoteStorage.layouts.set(
+      id,
+      makeRemoteLayout({
+        id,
+        data: layoutData("remote-baseline"),
+        savedAt: ts("2024-01-01T00:00:02.000Z"),
+        updatedAt: ts("2024-01-01T00:00:03.000Z"),
+      }),
+    );
+
+    await manager.syncWithRemote(new AbortController().signal);
+
+    const localLayout = await manager.getLayout({ id });
+    expect(localLayout?.baseline.data).toEqual(layoutData("remote-baseline"));
+    expect(localLayout?.working).toEqual(working);
+    expect(localLayout?.syncInfo).toEqual({
+      status: "tracked",
+      lastRemoteSavedAt: ts("2024-01-01T00:00:02.000Z"),
+      lastRemoteUpdatedAt: ts("2024-01-01T00:00:03.000Z"),
+    });
+  });
+
   it("reuploads an updated personal layout when the remote copy is missing", async () => {
     const localStorage = new MemoryLayoutStorage();
     const remoteStorage = new MemoryRemoteLayoutStorage();

--- a/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.test.ts
+++ b/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.test.ts
@@ -845,6 +845,14 @@ describe("CoSceneLayoutManager", () => {
       lastRemoteSavedAt: ts("2024-01-01T00:00:02.000Z"),
       lastRemoteUpdatedAt: ts("2024-01-01T00:00:03.000Z"),
     });
+    const backupLayout = await localStorage.get(CoSceneLayoutManager.LOCAL_STORAGE_NAMESPACE, id);
+    expect(backupLayout?.baseline.data).toEqual(layoutData("remote-baseline"));
+    expect(backupLayout?.working).toBeUndefined();
+    expect(backupLayout?.syncInfo).toEqual({
+      status: "tracked",
+      lastRemoteSavedAt: ts("2024-01-01T00:00:02.000Z"),
+      lastRemoteUpdatedAt: ts("2024-01-01T00:00:03.000Z"),
+    });
   });
 
   it("does not restore a remotely deleted layout from a remote layout without savedAt", async () => {

--- a/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.ts
+++ b/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.ts
@@ -72,6 +72,28 @@ function expectedRemoteTimestamps(layout: Layout): {
     : {};
 }
 
+function trackedLayoutFromRemote(remoteLayout: RemoteLayout): Layout {
+  return {
+    id: remoteLayout.id,
+    folder: remoteLayout.folder,
+    name: remoteLayout.name,
+    permission: remoteLayout.permission,
+    baseline: {
+      data: remoteLayout.data,
+      savedAt: remoteLayout.savedAt,
+      modifier: remoteLayout.modifier,
+      modifierNickname: remoteLayout.modifierNickname,
+    },
+    working: undefined,
+    syncInfo: {
+      status: "tracked",
+      lastRemoteSavedAt: remoteLayout.savedAt,
+      lastRemoteUpdatedAt: remoteLayout.updatedAt,
+    },
+    parent: remoteLayout.parent,
+  };
+}
+
 function localLayoutSyncSnapshotMatches(currentLayout: Layout, operationLayout: Layout): boolean {
   return (
     currentLayout.syncInfo?.status === operationLayout.syncInfo?.status &&
@@ -1009,25 +1031,7 @@ export default class CoSceneLayoutManager implements ILayoutManager {
               break;
             }
             log.debug(`Adding layout to cache: ${remoteLayout.id}`);
-            await local.put({
-              id: remoteLayout.id,
-              folder: remoteLayout.folder,
-              name: remoteLayout.name,
-              permission: remoteLayout.permission,
-              baseline: {
-                data: remoteLayout.data,
-                savedAt: remoteLayout.savedAt,
-                modifier: remoteLayout.modifier,
-                modifierNickname: remoteLayout.modifierNickname,
-              },
-              working: undefined,
-              syncInfo: {
-                status: "tracked",
-                lastRemoteSavedAt: remoteLayout.savedAt,
-                lastRemoteUpdatedAt: remoteLayout.updatedAt,
-              },
-              parent: remoteLayout.parent,
-            });
+            await local.put(trackedLayoutFromRemote(remoteLayout));
             break;
           }
 
@@ -1042,6 +1046,14 @@ export default class CoSceneLayoutManager implements ILayoutManager {
             }
             const localLayout = await local.get(operation.localLayout.id);
             if (!localLayout?.syncInfo) {
+              if (
+                localLayout == undefined &&
+                operation.type === "restore-from-remote" &&
+                options.backupPersonalOnly === true
+              ) {
+                log.debug(`Adding restored layout to backup cache: ${remoteLayout.id}`);
+                await local.put(trackedLayoutFromRemote(remoteLayout));
+              }
               break;
             }
             if (

--- a/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.ts
+++ b/packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.ts
@@ -1031,6 +1031,7 @@ export default class CoSceneLayoutManager implements ILayoutManager {
             break;
           }
 
+          case "restore-from-remote":
           case "update-baseline": {
             const { remoteLayout } = operation;
             if (
@@ -1064,7 +1065,10 @@ export default class CoSceneLayoutManager implements ILayoutManager {
               },
               working: localLayout.working,
               syncInfo: {
-                status: localLayout.syncInfo.status,
+                status:
+                  operation.type === "restore-from-remote"
+                    ? "tracked"
+                    : localLayout.syncInfo.status,
                 lastRemoteSavedAt: remoteLayout.savedAt,
                 lastRemoteUpdatedAt: remoteLayout.updatedAt,
               },

--- a/packages/studio-base/src/services/LayoutManager/coSceneComputeLayoutSyncOperations.ts
+++ b/packages/studio-base/src/services/LayoutManager/coSceneComputeLayoutSyncOperations.ts
@@ -83,6 +83,11 @@ export default function coSceneComputeLayoutSyncOperations(
           ops.push({ local: false, type: "delete-remote", localLayout });
           break;
         case "remotely-deleted":
+          // Match the tracked-layout behavior for legacy remote layouts.
+          if (!remoteLayout.savedAt) {
+            break;
+          }
+
           log.debug(`Restoring remotely deleted layout from remote: ${localLayout.id}`);
           ops.push({
             local: true,

--- a/packages/studio-base/src/services/LayoutManager/coSceneComputeLayoutSyncOperations.ts
+++ b/packages/studio-base/src/services/LayoutManager/coSceneComputeLayoutSyncOperations.ts
@@ -15,6 +15,12 @@ export type SyncOperation =
   | { local: true; type: "add-to-cache"; remoteLayout: RemoteLayout }
   | { local: true; type: "delete-local"; localLayout: Layout }
   | { local: true; type: "mark-deleted"; localLayout: Layout }
+  | {
+      local: true;
+      type: "restore-from-remote";
+      localLayout: Layout & { syncInfo: NonNullable<Layout["syncInfo"]> };
+      remoteLayout: RemoteLayout;
+    }
   | { local: false; type: "delete-remote"; localLayout: Layout }
   | { local: false; type: "upload-new"; localLayout: Layout }
   | { local: false; type: "upload-updated"; localLayout: Layout }
@@ -77,9 +83,13 @@ export default function coSceneComputeLayoutSyncOperations(
           ops.push({ local: false, type: "delete-remote", localLayout });
           break;
         case "remotely-deleted":
-          log.warn(
-            `Remote layout is present but cache is marked as remotely deleted: ${localLayout.id}`,
-          );
+          log.debug(`Restoring remotely deleted layout from remote: ${localLayout.id}`);
+          ops.push({
+            local: true,
+            type: "restore-from-remote",
+            localLayout: { ...localLayout, syncInfo: localLayout.syncInfo },
+            remoteLayout,
+          });
           break;
       }
     } else {


### PR DESCRIPTION
## Summary

- allow users to save personal layout drafts when the cached layout is marked as remotely deleted
- restore a remotely deleted cached layout to `tracked` when the same layout reappears remotely
- preserve the local working draft while refreshing its remote baseline and timestamps

## Root cause

The save button treated every `remotely-deleted` layout as unsavable, even though personal layouts can be recreated from their local draft. Separately, the sync operation only logged when a remote layout reappeared and left the stale cached status unchanged, so the disabled state could persist indefinitely.

## Compatibility

- remotely deleted project layouts remain unsavable
- user and project layout listing keeps its existing all-or-nothing failure behavior, avoiding partial responses being interpreted as remote deletions
- no public APIs or persisted data shapes changed

## Validation

- `yarn jest packages/studio-base/src/components/CoSceneLayout/CurrentLayoutButton.test.tsx packages/studio-base/src/services/LayoutManager/CoSceneLayoutManager.test.ts --runInBand` (38 tests passed)
- targeted Prettier check passed
- targeted ESLint check passed
- `yarn typecheck:ci` passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788507033&installation_model_id=425002&pr_number=1447&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1447&signature=ded33aebc5a31d16ef39e646b76201870e4abc5dc56e4b7fa5d714fd3ca7e916"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->