### PR TITLE
fix(studio): backport remote MP4 review fixes

### DIFF
--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts
@@ -11,6 +11,10 @@ import * as THREE from "three";
 
 import { PinholeCameraModel } from "@foxglove/den/image";
 import { IRenderer } from "@foxglove/studio-base/panels/ThreeDeeRender/IRenderer";
+import {
+  type RemoteVideoFrameReference,
+  registerRemoteVideoFrameProvider,
+} from "@foxglove/studio-base/players/IterablePlayer/Mp4/RemoteVideoFrameRegistry";
 
 import {
   type CompressedVideoFrameEvent,
@@ -176,6 +180,16 @@ class TestVideoBatchRenderable extends ImageRenderable {
   }
 }
 
+class TestRemoteFrameRenderable extends ImageRenderable {
+  public constructor() {
+    super(mockUserData.topic, mockRenderer, makeUserData());
+  }
+
+  public async decodeRemoteFrame(image: RemoteVideoFrameReference): Promise<TestDecodedImage> {
+    return await this.decodeImage(image);
+  }
+}
+
 async function flushPromises(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
@@ -247,6 +261,74 @@ describe("ImageRenderable", () => {
     // @ts-expect-error decodeImage is protected, but ok to use on tests
     await renderable.decodeImage(renderable.userData.image!, 100);
     expect(renderable.getDecodedImage()).toBeInstanceOf(ImageBitmap);
+  });
+
+  it("applies MP4 rotation metadata before rendering a remote frame", async () => {
+    const originalOffscreenCanvas = globalThis.OffscreenCanvas;
+    const frame = new MockVideoFrame(1920, 1080) as unknown as VideoFrame;
+    const bitmap = { width: 1080, height: 1920, close: jest.fn() } as unknown as ImageBitmap;
+    const context = {
+      drawImage: jest.fn(),
+      rotate: jest.fn(),
+      translate: jest.fn(),
+    };
+    const transferToImageBitmap = jest.fn(() => bitmap);
+    const canvases: Array<{ width: number; height: number }> = [];
+
+    class MockOffscreenCanvas {
+      public constructor(
+        public readonly width: number,
+        public readonly height: number,
+      ) {
+        canvases.push(this);
+      }
+
+      public getContext() {
+        return context;
+      }
+
+      public transferToImageBitmap() {
+        return transferToImageBitmap();
+      }
+    }
+
+    Object.defineProperty(globalThis, "OffscreenCanvas", {
+      configurable: true,
+      value: MockOffscreenCanvas,
+      writable: true,
+    });
+
+    const reference: RemoteVideoFrameReference = {
+      timestamp: { sec: 1, nsec: 0 },
+      duration: { sec: 0, nsec: 100_000_000 },
+      frame_id: "",
+      provider_id: "rotation-provider",
+      rotation: 90,
+    };
+    const provider = { getFrame: jest.fn(async () => frame) };
+    const unregister = registerRemoteVideoFrameProvider(reference.provider_id, provider);
+
+    try {
+      const renderable = new TestRemoteFrameRenderable();
+      await expect(renderable.decodeRemoteFrame(reference)).resolves.toBe(bitmap);
+      expect(provider.getFrame).toHaveBeenCalledWith(
+        reference.timestamp,
+        expect.stringMatching(/^image-renderable-/),
+      );
+      expect(canvases).toEqual([{ width: 1080, height: 1920 }]);
+      expect(context.translate).toHaveBeenCalledWith(540, 960);
+      expect(context.rotate).toHaveBeenCalledWith(Math.PI / 2);
+      expect(context.drawImage).toHaveBeenCalledWith(frame, -960, -540, 1920, 1080);
+      expect(transferToImageBitmap).toHaveBeenCalledTimes(1);
+      expect((frame as unknown as MockVideoFrame).close).toHaveBeenCalledTimes(1);
+    } finally {
+      unregister();
+      Object.defineProperty(globalThis, "OffscreenCanvas", {
+        configurable: true,
+        value: originalOffscreenCanvas,
+        writable: true,
+      });
+    }
   });
 
   it("should dispose resources", () => {

--- a/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
+++ b/packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.ts
@@ -167,6 +167,8 @@ export type ImageUserData = BaseUserData & {
 };
 
 export class ImageRenderable extends Renderable<ImageUserData> {
+  readonly #remoteVideoFrameConsumerId = `image-renderable-${globalThis.crypto.randomUUID()}`;
+
   // Make sure that everything is build the first time we render
   // set when camera info or image changes
   #geometryNeedsUpdate = true;
@@ -707,7 +709,8 @@ export class ImageRenderable extends Renderable<ImageUserData> {
     resizeWidth?: number,
   ): Promise<DecodedImageResult> {
     if (isRemoteVideoFrameReference(image)) {
-      return { image: await getRemoteVideoFrame(image), ok: true };
+      const frame = await getRemoteVideoFrame(image, this.#remoteVideoFrameConsumerId);
+      return { image: rotateVideoFrame(frame, image.rotation), ok: true };
     }
     if ("format" in image) {
       if (!VIDEO_FORMATS.has(image.format)) {
@@ -1375,6 +1378,46 @@ const videoFrameDimensionsEqual = (a?: VideoFrame, b?: VideoFrame) =>
 const isVideoFrame = (
   value: ImageBitmap | ImageData | VideoFrame | undefined,
 ): value is VideoFrame => typeof VideoFrame !== "undefined" && value instanceof VideoFrame;
+
+function rotateVideoFrame(frame: VideoFrame, rotationDegrees: number): VideoFrame | ImageBitmap {
+  if (!Number.isFinite(rotationDegrees)) {
+    return frame;
+  }
+  const rotation = ((rotationDegrees % 360) + 360) % 360;
+  if (rotation === 0) {
+    return frame;
+  }
+
+  const radians = THREE.MathUtils.degToRad(rotation);
+  const sourceWidth = frame.displayWidth;
+  const sourceHeight = frame.displayHeight;
+  const width = Math.max(
+    1,
+    Math.round(
+      Math.abs(sourceWidth * Math.cos(radians)) + Math.abs(sourceHeight * Math.sin(radians)),
+    ),
+  );
+  const height = Math.max(
+    1,
+    Math.round(
+      Math.abs(sourceWidth * Math.sin(radians)) + Math.abs(sourceHeight * Math.cos(radians)),
+    ),
+  );
+  const canvas = new OffscreenCanvas(width, height);
+
+  try {
+    const context = canvas.getContext("2d");
+    if (!context) {
+      throw new Error("Failed to create a canvas context for MP4 rotation");
+    }
+    context.translate(width / 2, height / 2);
+    context.rotate(radians);
+    context.drawImage(frame, -sourceWidth / 2, -sourceHeight / 2, sourceWidth, sourceHeight);
+    return canvas.transferToImageBitmap();
+  } finally {
+    frame.close();
+  }
+}
 
 function closeDecodedImageResource(resource: unknown): void {
   if (resource == undefined) {

--- a/packages/studio-base/src/players/IterablePlayer/Mp4/Mp4IterableSource.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mp4/Mp4IterableSource.test.ts
@@ -8,6 +8,10 @@
 import { fromNanoSec, toNanoSec } from "@foxglove/rostime";
 
 import { Mp4IterableSource } from "./Mp4IterableSource";
+import {
+  REMOTE_VIDEO_FRAME_REFERENCE_DATATYPE,
+  REMOTE_VIDEO_FRAME_REFERENCE_SCHEMA_NAME,
+} from "./RemoteVideoFrameRegistry";
 
 describe("Mp4IterableSource", () => {
   it("emits presentation-ordered VFR references and seeks with backfill", async () => {
@@ -39,6 +43,9 @@ describe("Mp4IterableSource", () => {
     const initialization = await source.initialize();
     expect(initialization.end).toEqual(fromNanoSec(1_000_000_000n));
     expect(initialization.problems).toEqual([]);
+    expect(initialization.datatypes).toEqual(
+      new Map([[REMOTE_VIDEO_FRAME_REFERENCE_SCHEMA_NAME, REMOTE_VIDEO_FRAME_REFERENCE_DATATYPE]]),
+    );
 
     const results = [];
     for await (const result of source.messageIterator({

--- a/packages/studio-base/src/players/IterablePlayer/Mp4/Mp4IterableSource.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mp4/Mp4IterableSource.ts
@@ -17,6 +17,7 @@ import {
 
 import type { Mp4FrameIndexEntry, Mp4MediabunnyInfo } from "./Mp4MediabunnyController";
 import {
+  REMOTE_VIDEO_FRAME_REFERENCE_DATATYPE,
   REMOTE_VIDEO_FRAME_REFERENCE_SCHEMA_NAME,
   RemoteVideoFrameProvider,
   RemoteVideoFrameReference,
@@ -81,7 +82,9 @@ export class Mp4IterableSource implements IDeserializedIterableSource {
       end: fromNanoSec(info.endTimeNs),
       topics: [{ name: this.#topic, schemaName: REMOTE_VIDEO_FRAME_REFERENCE_SCHEMA_NAME }],
       topicStats: new Map([[this.#topic, { numMessages: info.frames.length }]]),
-      datatypes: new Map(),
+      datatypes: new Map([
+        [REMOTE_VIDEO_FRAME_REFERENCE_SCHEMA_NAME, REMOTE_VIDEO_FRAME_REFERENCE_DATATYPE],
+      ]),
       profile: "mp4",
       publishersByTopic: new Map(),
       problems: [],

--- a/packages/studio-base/src/players/IterablePlayer/Mp4/Mp4MediabunnyController.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mp4/Mp4MediabunnyController.test.ts
@@ -103,12 +103,12 @@ describe("Mp4MediabunnyController", () => {
     }));
 
     const controller = new Mp4MediabunnyController("https://example.com/video.mp4");
-    const frameAtOne = controller.getFrame(fromNanoSec(1_000_000_000n));
+    const frameAtOne = controller.getFrame(fromNanoSec(1_000_000_000n), "renderable-one");
     await firstSampleRequested.promise;
 
-    const firstFrameAtFour = controller.getFrame(fromNanoSec(4_000_000_000n));
-    const frameAtEight = controller.getFrame(fromNanoSec(8_000_000_000n));
-    const secondFrameAtFour = controller.getFrame(fromNanoSec(4_000_000_000n));
+    const firstFrameAtFour = controller.getFrame(fromNanoSec(4_000_000_000n), "renderable-four-a");
+    const frameAtEight = controller.getFrame(fromNanoSec(8_000_000_000n), "renderable-eight");
+    const secondFrameAtFour = controller.getFrame(fromNanoSec(4_000_000_000n), "renderable-four-b");
     firstSample.resolve(videoSampleAt(1));
 
     const frames = await Promise.all([
@@ -119,6 +119,55 @@ describe("Mp4MediabunnyController", () => {
     ]);
     expect(frames.map(frameTimestamp)).toEqual([1, 4, 8, 4]);
     expect(getSample.mock.calls.map(([timestampSeconds]) => timestampSeconds)).toEqual([1, 4, 8]);
+
+    await controller.dispose();
+  });
+
+  it("coalesces superseded queued requests from the same renderable", async () => {
+    const firstSample = deferred<VideoSample>();
+    const firstSampleRequested = deferred<void>();
+    const getSample = jest
+      .fn<Promise<VideoSample>, [number]>()
+      .mockImplementation(async (timestampSeconds) => {
+        if (timestampSeconds === 1) {
+          firstSampleRequested.resolve();
+          return await firstSample.promise;
+        }
+        return videoSampleAt(timestampSeconds);
+      });
+    const track = {
+      canDecode: jest.fn(async () => true),
+      getCodec: jest.fn(async () => "avc"),
+      getDecoderConfig: jest.fn(async () => ({ codec: "avc1.640028" })),
+      getDisplayHeight: jest.fn(async () => 1080),
+      getDisplayWidth: jest.fn(async () => 1920),
+      getDurationFromMetadata: jest.fn(async () => 10),
+      getFirstTimestamp: jest.fn(async () => 0),
+      getRotation: jest.fn(async () => 0),
+    };
+
+    (Input as jest.Mock).mockImplementation(() => ({
+      dispose: jest.fn(),
+      getPrimaryVideoTrack: jest.fn(async () => track),
+    }));
+    (EncodedPacketSink as jest.Mock).mockImplementation(() => ({ packets }));
+    (VideoSampleSink as jest.Mock).mockImplementation(() => ({
+      getSample,
+      samples: jest.fn(() => noSamples([])),
+    }));
+
+    const controller = new Mp4MediabunnyController("https://example.com/video.mp4");
+    const initialFrame = controller.getFrame(fromNanoSec(1_000_000_000n), "renderable-a");
+    await firstSampleRequested.promise;
+
+    const staleFrame = controller.getFrame(fromNanoSec(4_000_000_000n), "renderable-a");
+    const latestFrame = controller.getFrame(fromNanoSec(8_000_000_000n), "renderable-a");
+    const otherFrame = controller.getFrame(fromNanoSec(6_000_000_000n), "renderable-b");
+    firstSample.resolve(videoSampleAt(1));
+
+    const frames = await Promise.all([initialFrame, staleFrame, latestFrame, otherFrame]);
+    expect(frames.map(frameTimestamp)).toEqual([1, 8, 8, 6]);
+    expect(getSample.mock.calls.map(([timestampSeconds]) => timestampSeconds)).toEqual([1, 8, 6]);
 
     await controller.dispose();
   });
@@ -159,7 +208,7 @@ describe("Mp4MediabunnyController", () => {
     }));
 
     const controller = new Mp4MediabunnyController("https://example.com/video.mp4");
-    const blockedFrame = controller.getFrame(fromNanoSec(1_000_000_000n));
+    const blockedFrame = controller.getFrame(fromNanoSec(1_000_000_000n), "renderable");
     await sampleRequested.promise;
 
     // Without disposing the input first, this would wait for the blocked range read to settle.

--- a/packages/studio-base/src/players/IterablePlayer/Mp4/Mp4MediabunnyController.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mp4/Mp4MediabunnyController.ts
@@ -44,6 +44,7 @@ type DecodedFrame = {
 
 type PendingFrameRequest = {
   timestampNs: bigint;
+  consumerId: string;
   resolve: (frame: VideoFrame) => void;
   reject: (error: unknown) => void;
 };
@@ -191,13 +192,13 @@ export class Mp4MediabunnyController implements RemoteVideoFrameProvider {
     }
   }
 
-  public async getFrame(timestamp: Time): Promise<VideoFrame> {
+  public async getFrame(timestamp: Time, consumerId: string): Promise<VideoFrame> {
     if (this.#disposed) {
       throw new Error("The remote MP4 decoder has been disposed");
     }
     const timestampNs = toNanoSec(timestamp);
     return await new Promise<VideoFrame>((resolve, reject) => {
-      this.#pendingFrameRequests.push({ timestampNs, resolve, reject });
+      this.#pendingFrameRequests.push({ timestampNs, consumerId, resolve, reject });
       this.#startProcessingFrameRequests();
     });
   }
@@ -304,15 +305,24 @@ export class Mp4MediabunnyController implements RemoteVideoFrameProvider {
 
   async #processFrameRequests(): Promise<void> {
     while (!this.#disposed && this.#pendingFrameRequests.length > 0) {
-      // Requests from different renderables can be pending at the same time, and each can still be
-      // current for its own consumer. Only coalesce requests for the exact same presentation time.
+      const pendingRequests = this.#pendingFrameRequests.splice(0);
+      const latestTimestampByConsumer = new Map<string, bigint>();
+      for (const request of pendingRequests) {
+        latestTimestampByConsumer.set(request.consumerId, request.timestampNs);
+      }
+
+      // A renderable only needs its newest queued timestamp. Resolve its superseded promises with
+      // that same frame so ImageRenderable can discard them through its existing sequence check.
+      // Requests from different renderables remain independent, while matching timestamps still
+      // share one decode.
       const requestsByTimestamp = new Map<bigint, PendingFrameRequest[]>();
-      for (const request of this.#pendingFrameRequests.splice(0)) {
-        const requests = requestsByTimestamp.get(request.timestampNs);
+      for (const request of pendingRequests) {
+        const timestampNs = latestTimestampByConsumer.get(request.consumerId)!;
+        const requests = requestsByTimestamp.get(timestampNs);
         if (requests) {
           requests.push(request);
         } else {
-          requestsByTimestamp.set(request.timestampNs, [request]);
+          requestsByTimestamp.set(timestampNs, [request]);
         }
       }
 

--- a/packages/studio-base/src/players/IterablePlayer/Mp4/Mp4MediabunnyController.worker.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mp4/Mp4MediabunnyController.worker.ts
@@ -22,8 +22,8 @@ export class Mp4MediabunnyControllerWorker {
     return await this.#controller.initialize();
   }
 
-  public async getFrame(timestamp: Time): Promise<VideoFrame> {
-    const frame = await this.#controller.getFrame(timestamp);
+  public async getFrame(timestamp: Time, consumerId: string): Promise<VideoFrame> {
+    const frame = await this.#controller.getFrame(timestamp, consumerId);
     return Comlink.transfer(frame, [frame]);
   }
 

--- a/packages/studio-base/src/players/IterablePlayer/Mp4/README.md
+++ b/packages/studio-base/src/players/IterablePlayer/Mp4/README.md
@@ -20,9 +20,8 @@ presentation order.
 
 The HTTP server must provide `Content-Length` and `Accept-Ranges: bytes`. Browser deployments also
 need CORS access and must expose `Accept-Ranges`. The source accepts H.264 and H.265 MP4 tracks only,
-and playback requires browser WebCodecs support for the track's exact codec/profile. MP4 rotation
-metadata is reported in frame references; applying non-zero track rotation in the renderer is not
-yet implemented.
+and playback requires browser WebCodecs support for the track's exact codec/profile. MP4 track
+rotation metadata is applied at the renderer boundary before display.
 
 ## Browser benchmark
 

--- a/packages/studio-base/src/players/IterablePlayer/Mp4/RemoteVideoFrameRegistry.test.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mp4/RemoteVideoFrameRegistry.test.ts
@@ -27,11 +27,11 @@ describe("RemoteVideoFrameRegistry", () => {
     const provider = { getFrame: jest.fn(async () => frame) };
     const unregister = registerRemoteVideoFrameProvider(REFERENCE.provider_id, provider);
 
-    await expect(getRemoteVideoFrame(REFERENCE)).resolves.toBe(frame);
-    expect(provider.getFrame).toHaveBeenCalledWith(REFERENCE.timestamp);
+    await expect(getRemoteVideoFrame(REFERENCE, "test-consumer")).resolves.toBe(frame);
+    expect(provider.getFrame).toHaveBeenCalledWith(REFERENCE.timestamp, "test-consumer");
 
     unregister();
-    await expect(getRemoteVideoFrame(REFERENCE)).rejects.toThrow(
+    await expect(getRemoteVideoFrame(REFERENCE, "test-consumer")).rejects.toThrow(
       "The remote MP4 decoder is no longer available",
     );
   });

--- a/packages/studio-base/src/players/IterablePlayer/Mp4/RemoteVideoFrameRegistry.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mp4/RemoteVideoFrameRegistry.ts
@@ -5,12 +5,23 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import type { MessageDefinition } from "@foxglove/message-definition";
 import { Time } from "@foxglove/rostime";
 
 export const REMOTE_VIDEO_FRAME_REFERENCE_SCHEMA_NAME = "coscene.RemoteVideoFrameReference";
 export const REMOTE_VIDEO_FRAME_REFERENCE_DATATYPES = new Set([
   REMOTE_VIDEO_FRAME_REFERENCE_SCHEMA_NAME,
 ]);
+export const REMOTE_VIDEO_FRAME_REFERENCE_DATATYPE = {
+  name: REMOTE_VIDEO_FRAME_REFERENCE_SCHEMA_NAME,
+  definitions: [
+    { name: "timestamp", type: "time" },
+    { name: "duration", type: "duration" },
+    { name: "frame_id", type: "string" },
+    { name: "provider_id", type: "string" },
+    { name: "rotation", type: "float64" },
+  ],
+} satisfies MessageDefinition;
 
 /** A serializable timeline marker. The decoded frame stays outside player message caches. */
 export type RemoteVideoFrameReference = {
@@ -22,7 +33,7 @@ export type RemoteVideoFrameReference = {
 };
 
 export interface RemoteVideoFrameProvider {
-  getFrame(timestamp: Time): Promise<VideoFrame>;
+  getFrame(timestamp: Time, consumerId: string): Promise<VideoFrame>;
 }
 
 const providers = new Map<string, RemoteVideoFrameProvider>();
@@ -44,12 +55,13 @@ export function registerRemoteVideoFrameProvider(
 
 export async function getRemoteVideoFrame(
   reference: RemoteVideoFrameReference,
+  consumerId: string,
 ): Promise<VideoFrame> {
   const provider = providers.get(reference.provider_id);
   if (!provider) {
     throw new Error("The remote MP4 decoder is no longer available");
   }
-  return await provider.getFrame(reference.timestamp);
+  return await provider.getFrame(reference.timestamp, consumerId);
 }
 
 export function isRemoteVideoFrameReference(value: unknown): value is RemoteVideoFrameReference {

--- a/packages/studio-base/src/players/IterablePlayer/Mp4/WorkerMp4MediabunnyController.ts
+++ b/packages/studio-base/src/players/IterablePlayer/Mp4/WorkerMp4MediabunnyController.ts
@@ -42,8 +42,8 @@ export class WorkerMp4MediabunnyController implements RemoteVideoFrameProvider {
     return await (await this.#getRemote()).initialize();
   }
 
-  public async getFrame(timestamp: Time): Promise<VideoFrame> {
-    return await (await this.#getRemote()).getFrame(timestamp);
+  public async getFrame(timestamp: Time, consumerId: string): Promise<VideoFrame> {
+    return await (await this.#getRemote()).getFrame(timestamp, consumerId);
   }
 
   public async dispose(): Promise<void> {


### PR DESCRIPTION
## Summary

- Publish the `coscene.RemoteVideoFrameReference` message definition so the remote video topic exposes its schema to consumers.
- Apply MP4 track rotation in the shared Honeybee image renderable with `OffscreenCanvas`, closing the original `VideoFrame`; this covers both Image Mode and 3D Images, and updates the design note.
- Thread UUID-based renderable consumer IDs through the remote-frame registry and Comlink worker bridge, then coalesce queued scrubs to the newest timestamp per consumer while keeping consumers independent and sharing identical-timestamp decodes.

## Source

Ported and adapted from [coscene-io/bombus#152](https://github.com/coscene-io/bombus/pull/152), commit [`8247b2c5`](https://github.com/coscene-io/bombus/commit/8247b2c5).

## Verification

- `yarn jest packages/studio-base/src/players/IterablePlayer/Mp4 packages/studio-base/src/panels/ThreeDeeRender/renderables/Images/ImageRenderable.test.ts packages/studio-base/src/panels/ThreeDeeRender/renderables/Images.test.ts packages/studio-base/src/panels/ThreeDeeRender/renderables/ImageMode/ImageMode.test.ts --runInBand` (8 suites, 70 tests passed)
- `yarn run tsc --noEmit`
- `yarn lint`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788930853&installation_model_id=425002&pr_number=1448&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1448&signature=8bc131cf685809949eb60d163c5ca4a80e3bad04353e782dac00d03ed80fd863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->