### PR TITLE
Fix Event trigger time precision

### DIFF
--- a/packages/studio-base/src/components/Events/CreateEventContainer/component/EventForm.tsx
+++ b/packages/studio-base/src/components/Events/CreateEventContainer/component/EventForm.tsx
@@ -24,7 +24,7 @@ import { UseFormReturn, Controller, useFieldArray } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { makeStyles } from "tss-react/mui";
 
-import { add, fromSec, fromDate } from "@foxglove/rostime";
+import { add, fromSec } from "@foxglove/rostime";
 import {
   CustomFieldValuesForm,
   FormWithCustomFieldValues,
@@ -211,10 +211,10 @@ export function EventForm({ form, onMetaDataKeyDown }: EventFormProps): React.Re
   );
 
   const formattedEventStartTime = watchedValues.startTime
-    ? formatTime(fromDate(watchedValues.startTime))
+    ? formatTime(watchedValues.startTime)
     : "-";
   const formattedEventEndTime = watchedValues.startTime
-    ? formatTime(add(fromDate(watchedValues.startTime), fromSec(watchedValues.duration ?? 0)))
+    ? formatTime(add(watchedValues.startTime, fromSec(watchedValues.duration ?? 0)))
     : "-";
 
   const invokeTabKey = () => {

--- a/packages/studio-base/src/components/Events/CreateEventContainer/hooks.ts
+++ b/packages/studio-base/src/components/Events/CreateEventContainer/hooks.ts
@@ -7,7 +7,7 @@
 
 import { useEffect, useState } from "react";
 
-import { toDate, subtract, isLessThan, isGreaterThan, toSec } from "@foxglove/rostime";
+import { subtract, isLessThan, isGreaterThan, toSec, Time } from "@foxglove/rostime";
 import { convertCustomFieldValuesToMap } from "@foxglove/studio-base/components/CustomFieldProperty/utils/convertCustomFieldForm";
 import {
   BagFileInfo,
@@ -74,7 +74,7 @@ export const useDefaultEventForm = (): CreateEventForm => {
 
   return {
     eventName: "",
-    startTime: markStartTime ? toDate(markStartTime) : undefined,
+    startTime: markStartTime,
     duration: 1,
     durationUnit: "sec",
     description: "",
@@ -87,8 +87,8 @@ export const useDefaultEventForm = (): CreateEventForm => {
   };
 };
 
-export const useTimeRange = (): { startTime: Date | undefined; duration: number } => {
-  const [startTime, setStartTime] = useState<Date | undefined>(undefined);
+export const useTimeRange = (): { startTime: Time | undefined; duration: number } => {
+  const [startTime, setStartTime] = useState<Time | undefined>(undefined);
   const [duration, setDuration] = useState<number>(0);
 
   const eventMarks = useEvents(selectEventMarks);
@@ -97,7 +97,7 @@ export const useTimeRange = (): { startTime: Date | undefined; duration: number 
   const markEndTime = eventMarks[1]?.time;
 
   useEffect(() => {
-    setStartTime(markStartTime ? toDate(markStartTime) : undefined);
+    setStartTime(markStartTime);
 
     setDuration(markEndTime && markStartTime ? toSec(subtract(markEndTime, markStartTime)) : 0);
   }, [markStartTime, markEndTime]);

--- a/packages/studio-base/src/components/Events/CreateEventContainer/index.test.tsx
+++ b/packages/studio-base/src/components/Events/CreateEventContainer/index.test.tsx
@@ -5,7 +5,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { getEventDurationSeconds } from ".";
+import { getEventDurationSeconds, getEventUpdateMaskPaths, timestampFromTime } from ".";
 
 describe("getEventDurationSeconds", () => {
   it("clamps negative second durations to zero", () => {
@@ -18,5 +18,31 @@ describe("getEventDurationSeconds", () => {
 
   it("converts positive nanosecond durations to seconds", () => {
     expect(getEventDurationSeconds(1_250_000_000, "nsec")).toBe(1.25);
+  });
+});
+
+describe("event trigger time precision", () => {
+  it("preserves sub-millisecond precision when creating an event timestamp", () => {
+    const timestamp = timestampFromTime({ sec: 1_723_456_789, nsec: 123_456_789 });
+
+    expect(timestamp.seconds).toBe(1_723_456_789n);
+    expect(timestamp.nanos).toBe(123_456_789);
+  });
+
+  it("does not update trigger time when only non-time fields change", () => {
+    const startTime = { sec: 1_723_456_789, nsec: 123_456_789 };
+
+    expect(getEventUpdateMaskPaths(startTime, { ...startTime })).not.toContain("triggerTime");
+  });
+
+  it("updates trigger time with exact precision when the time changes", () => {
+    const originalStartTime = { sec: 1_723_456_789, nsec: 123_456_789 };
+    const changedStartTime = { sec: 1_723_456_789, nsec: 987_654_321 };
+
+    expect(getEventUpdateMaskPaths(changedStartTime, originalStartTime)).toContain("triggerTime");
+    expect(timestampFromTime(changedStartTime)).toMatchObject({
+      seconds: 1_723_456_789n,
+      nanos: 987_654_321,
+    });
   });
 });

--- a/packages/studio-base/src/components/Events/CreateEventContainer/index.tsx
+++ b/packages/studio-base/src/components/Events/CreateEventContainer/index.tsx
@@ -6,7 +6,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { create } from "@bufbuild/protobuf";
-import { FieldMaskSchema, timestampFromDate } from "@bufbuild/protobuf/wkt";
+import { FieldMaskSchema, TimestampSchema, type Timestamp } from "@bufbuild/protobuf/wkt";
 import {
   EventSchema,
   Event,
@@ -26,6 +26,7 @@ import { toast } from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { v4 as uuidv4 } from "uuid";
 
+import { areEqual, Time } from "@foxglove/rostime";
 import { convertCustomFieldValuesMapToArray } from "@foxglove/studio-base/components/CustomFieldProperty/utils/convertCustomFieldForm";
 import { EventForm } from "@foxglove/studio-base/components/Events/CreateEventContainer/component/EventForm";
 import { TaskForm } from "@foxglove/studio-base/components/Events/CreateEventContainer/component/TaskForm";
@@ -47,6 +48,31 @@ const selectOrganization = (store: CoreDataStore) => store.organization;
 
 export function getEventDurationSeconds(duration: number, durationUnit: "sec" | "nsec"): number {
   return Math.max(0, durationUnit === "sec" ? duration : duration / 1e9);
+}
+
+export function timestampFromTime(time: Time): Timestamp {
+  return create(TimestampSchema, {
+    seconds: BigInt(time.sec),
+    nanos: time.nsec,
+  });
+}
+
+export function getEventUpdateMaskPaths(startTime: Time, originalStartTime?: Time): string[] {
+  const paths = [
+    "displayName",
+    "duration_nanos",
+    "description",
+    "duration",
+    "customizedFields",
+    "customFieldValues",
+    "files",
+  ];
+
+  if (originalStartTime == undefined || !areEqual(startTime, originalStartTime)) {
+    paths.unshift("triggerTime");
+  }
+
+  return paths;
 }
 
 function CreateTaskSuccessToast({ targetUrl }: { targetUrl: string }): React.ReactNode {
@@ -224,7 +250,7 @@ export function CreateEventContainer({ onClose }: { onClose: () => void }): Reac
       const newEvent = create(EventSchema, {
         name: toModifyEvent?.name ?? "",
         displayName: event.eventName,
-        triggerTime: timestampFromDate(event.startTime),
+        triggerTime: timestampFromTime(event.startTime),
         duration: secondsToDuration(durationSeconds),
         description: event.description,
         files: imageFiles,
@@ -233,16 +259,7 @@ export function CreateEventContainer({ onClose }: { onClose: () => void }): Reac
       });
 
       if (isEditing) {
-        const maskArray = [
-          "triggerTime",
-          "displayName",
-          "duration_nanos",
-          "description",
-          "duration",
-          "customizedFields",
-          "customFieldValues",
-          "files",
-        ];
+        const maskArray = getEventUpdateMaskPaths(event.startTime, toModifyEvent.startTime);
 
         await consoleApi.updateEvent({
           event: newEvent,

--- a/packages/studio-base/src/components/Events/CreateEventContainer/types.ts
+++ b/packages/studio-base/src/components/Events/CreateEventContainer/types.ts
@@ -6,11 +6,12 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 import { CustomFieldValue } from "@coscene-io/cosceneapis-es-v2/coscene/dataplatform/v1alpha3/common/custom_field_pb";
 
+import { Time } from "@foxglove/rostime";
 import { KeyValue } from "@foxglove/studio-base/context/EventsContext";
 
 export type CreateEventForm = {
   eventName: string;
-  startTime: undefined | Date;
+  startTime: undefined | Time;
   duration: undefined | number;
   durationUnit: "sec" | "nsec";
   description: undefined | string;

--- a/packages/studio-base/src/components/Events/EventsList/EventView.tsx
+++ b/packages/studio-base/src/components/Events/EventsList/EventView.tsx
@@ -248,9 +248,7 @@ function EventViewComponent(params: {
     onEdit({
       name: event.event.name,
       eventName: event.event.displayName,
-      startTime: timestampDate(
-        event.event.triggerTime ?? create(TimestampSchema, { seconds: BigInt(0), nanos: 0 }),
-      ),
+      startTime: event.startTime,
       duration: durationToSeconds(event.event.duration),
       durationUnit: "sec",
       description: event.event.description,

--- a/packages/studio-base/src/components/Events/EventsList/index.test.tsx
+++ b/packages/studio-base/src/components/Events/EventsList/index.test.tsx
@@ -71,22 +71,24 @@ function TestDialogs(): React.JSX.Element {
 function makeEvent({
   file,
   name,
+  startNsec = 0,
   startSec,
 }: {
   file?: string;
   name: string;
+  startNsec?: number;
   startSec: number;
 }): TimelinePositionedEvent {
   return {
     event: create(EventSchema, {
       name,
       displayName: name,
-      triggerTime: create(TimestampSchema, { seconds: BigInt(startSec), nanos: 0 }),
+      triggerTime: create(TimestampSchema, { seconds: BigInt(startSec), nanos: startNsec }),
       duration: create(DurationSchema, { seconds: BigInt(1), nanos: 0 }),
       files: file == undefined ? [] : [file],
     }),
-    startTime: { sec: startSec, nsec: 0 },
-    endTime: { sec: startSec + 1, nsec: 0 },
+    startTime: { sec: startSec, nsec: startNsec },
+    endTime: { sec: startSec + 1, nsec: startNsec },
     color: "#00ADEF",
     startPosition: startSec / 10,
     endPosition: (startSec + 1) / 10,
@@ -129,6 +131,11 @@ function EventFetchCountProbe(): React.JSX.Element {
   return <div data-testid="event-fetch-count">{eventFetchCount}</div>;
 }
 
+function EventToModifyProbe(): React.JSX.Element {
+  const startTime = useEvents((store: EventsStore) => store.toModifyEvent?.startTime);
+  return <div data-testid="event-to-modify-start">{`${startTime?.sec}:${startTime?.nsec}`}</div>;
+}
+
 function Wrapper({
   consoleApi,
   events,
@@ -159,6 +166,7 @@ function Wrapper({
                     />
                     <SeedEvents events={events} />
                     <EventFetchCountProbe />
+                    <EventToModifyProbe />
                     <EventsList />
                     <TestDialogs />
                   </MockMessagePipelineProvider>
@@ -318,5 +326,21 @@ describe("<EventsList />", () => {
       expect(screen.getAllByTestId("sidebar-event")).toHaveLength(1);
     });
     expect(screen.queryByRole("button", { name: "Delete All" })).toBeNull();
+  });
+
+  it("keeps a fetched sub-millisecond trigger time exact when entering edit", async () => {
+    const event = makeEvent({
+      name: "events/precise",
+      startSec: 1,
+      startNsec: 123_456_789,
+    });
+
+    render(<Wrapper consoleApi={makeConsoleApi()} events={[event]} />);
+
+    fireEvent.click(await screen.findByTitle("Edit Moment"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("event-to-modify-start").textContent).toBe("1:123456789");
+    });
   });
 });

--- a/packages/studio-base/src/components/Events/EventsList/index.tsx
+++ b/packages/studio-base/src/components/Events/EventsList/index.tsx
@@ -30,7 +30,7 @@ import { useAsyncFn } from "react-use";
 import { makeStyles } from "tss-react/mui";
 
 import Logger from "@foxglove/log";
-import { fromDate, add, fromSec } from "@foxglove/rostime";
+import { add, fromSec } from "@foxglove/rostime";
 import { positionEventMark } from "@foxglove/studio-base/components/Events/EventsSyncAdapter";
 import { deleteEventWithFile } from "@foxglove/studio-base/components/Events/deleteEventWithFile";
 import {
@@ -478,13 +478,13 @@ export function EventsList(): React.JSX.Element {
                           ) {
                             setEventMarks([
                               positionEventMark({
-                                currentTime: fromDate(currentEvent.startTime),
+                                currentTime: currentEvent.startTime,
                                 startTime,
                                 endTime,
                               }),
                               positionEventMark({
                                 currentTime: add(
-                                  fromDate(currentEvent.startTime),
+                                  currentEvent.startTime,
                                   fromSec(currentEvent.duration),
                                 ),
                                 startTime,

--- a/packages/studio-base/src/components/PlaybackControls/EventsOverlay.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/EventsOverlay.tsx
@@ -17,7 +17,7 @@ import { useTranslation } from "react-i18next";
 import { useResizeDetector } from "react-resize-detector";
 import { makeStyles } from "tss-react/mui";
 
-import { add, areEqual, fromSec, subtract, toDate, toSec } from "@foxglove/rostime";
+import { add, areEqual, fromSec, subtract, toSec } from "@foxglove/rostime";
 import { CreateEventContainer } from "@foxglove/studio-base/components/Events/CreateEventContainer/index";
 import {
   MessagePipelineContext,
@@ -1653,7 +1653,7 @@ function UnmemoizedEventsOverlay(props: Props): React.JSX.Element | ReactNull {
       setToModifyEvent({
         name: targetEvent.event.name,
         eventName: targetEvent.event.displayName,
-        startTime: toDate(targetEvent.startTime),
+        startTime: targetEvent.startTime,
         duration: eventDurationSec,
         durationUnit: "sec",
         description: targetEvent.event.description,

--- a/packages/studio-base/src/context/EventsContext.ts
+++ b/packages/studio-base/src/context/EventsContext.ts
@@ -22,7 +22,7 @@ export type KeyValue = { key: string; value: string };
 export type ToModifyEvent = {
   name: string;
   eventName: string;
-  startTime: undefined | Date;
+  startTime: undefined | Time;
   duration: undefined | number;
   durationUnit: "sec" | "nsec";
   description: undefined | string;


### PR DESCRIPTION
## Summary

- keep Event/Moment trigger times as precise `Time { sec, nsec }` values through create and ordinary edit flows
- construct protobuf `Timestamp` values directly from seconds and nanoseconds instead of round-tripping through JavaScript `Date`
- omit `trigger_time` from ordinary edit update masks when the time did not change, while preserving exact seconds/nanos when it did
- add regression coverage for sub-millisecond creation, text-only edits, fetched precise values entering edit, and precise changed times

## Root cause

The create dialog converted the playback `Time { sec, nsec }` to `Date` and then used `timestampFromDate()`. JavaScript `Date` only retains milliseconds, so microsecond/nanosecond precision was truncated before the gRPC-Web request was built.

The ordinary edit path similarly converted the fetched protobuf `Timestamp` to `Date`, then always included `triggerTime` in the update mask. Editing only a name or description therefore rewrote `trigger_time` with a millisecond-truncated value.

## Fix

The create form, list edit path, and timeline edit entry now retain the existing exact `Time` representation. Requests build `Timestamp { seconds, nanos }` directly. Ordinary edits compare the precise original and current times and only include the trigger-time mask when they differ.

The direct timeline time-edit request path already used precise seconds/nanos and remains unchanged.

## Starbase contract

No Starbase code is changed. Honeybee now preserves the precise protobuf value through transport so Starbase can apply its existing microsecond persistence contract. In particular, Honeybee no longer introduces an earlier millisecond truncation that discards precision before Starbase receives the value.

## Validation

- `yarn test packages/studio-base/src/components/Events/CreateEventContainer/index.test.tsx packages/studio-base/src/components/Events/EventsList/index.test.tsx --runInBand` (12 tests)
- `yarn test packages/studio-base/src/components/PlaybackControls/EventsOverlay.test.tsx --runInBand` (17 tests)
- `yarn typecheck:ci`
- `yarn lint:ci`
- targeted ESLint and Prettier checks for all changed files
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788941195&installation_model_id=425002&pr_number=1451&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1451&signature=f539031a821938384082ed6445425c08804ce3d9bc0282e2834791ea781cf6d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->