### PR TITLE
Fix viz login redirect loop

### DIFF
--- a/packages/studio-base/src/components/DeepLinksSyncAdapter.test.tsx
+++ b/packages/studio-base/src/components/DeepLinksSyncAdapter.test.tsx
@@ -7,8 +7,12 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import { act, render, screen, waitFor } from "@testing-library/react";
+import toast from "react-hot-toast";
 
-import { DeepLinksSyncAdapter } from "@foxglove/studio-base/components/DeepLinksSyncAdapter";
+import {
+  DeepLinksSyncAdapter,
+  getWebLoginRedirectUrl,
+} from "@foxglove/studio-base/components/DeepLinksSyncAdapter";
 import { SHARE_MANIFEST_DATA_SOURCE_ID } from "@foxglove/studio-base/util/shareManifest";
 
 const mockSelectSource = jest.fn();
@@ -19,12 +23,18 @@ const mockDataSourceClose = jest.fn();
 const mockSetExternalInitConfig = jest.fn();
 const mockBeginExternalInitConfigUpdate = jest.fn();
 const mockGetProject = jest.fn();
+const mockToastError = toast.error as jest.Mock;
 let mockCurrentUser: { userId: string } | undefined;
 let mockLoginStatus = "notLogin";
 let mockLastExternalInitConfig: string | undefined;
 
 jest.mock("@foxglove/studio-base/context/PlayerSelectionContext", () => ({
   usePlayerSelection: () => ({ selectSource: mockSelectSource }),
+}));
+
+jest.mock("react-hot-toast", () => ({
+  __esModule: true,
+  default: { error: jest.fn() },
 }));
 
 jest.mock("@foxglove/studio-base/context/CoSceneCurrentUserContext", () => ({
@@ -133,12 +143,75 @@ describe("<DeepLinksSyncAdapter /> share manifest handling", () => {
     mockSetExternalInitConfig.mockReset();
     mockBeginExternalInitConfigUpdate.mockReset();
     mockGetProject.mockReset();
+    mockToastError.mockClear();
 
     let updateGeneration = 0;
     mockBeginExternalInitConfigUpdate.mockImplementation(() => {
       const generation = ++updateGeneration;
       return { isCurrent: () => generation === updateGeneration };
     });
+  });
+
+  it.each([
+    ["before the login toast debounce", 500, 0],
+    ["after the login toast debounce", 1000, 1],
+  ])(
+    "initializes the original data source once when login completes %s",
+    async (_description, elapsedBeforeLogin, expectedToastCount) => {
+      const url = `${window.location.origin}/viz?ds=coscene-data-platform&ds.key=record-key&layoutId=${encodeURIComponent(
+        "warehouses/warehouse-a/projects/project-a/layouts/layout-a",
+      )}`;
+      window.history.replaceState(undefined, "", url);
+      const deepLinks = [url];
+      const { rerender } = render(<DeepLinksSyncAdapter deepLinks={deepLinks} />);
+
+      act(() => {
+        jest.advanceTimersByTime(elapsedBeforeLogin);
+      });
+      expect(mockToastError).toHaveBeenCalledTimes(expectedToastCount);
+
+      mockCurrentUser = { userId: "users/current-user" };
+      mockLoginStatus = "alreadyLogin";
+      rerender(<DeepLinksSyncAdapter deepLinks={deepLinks} />);
+
+      await waitFor(() => {
+        expect(mockSelectSource).toHaveBeenCalledWith("coscene-data-platform", {
+          type: "connection",
+          params: {
+            key: "record-key",
+            userId: "users/current-user",
+          },
+        });
+      });
+      expect(mockSelectSource).toHaveBeenCalledTimes(1);
+      expect(jest.getTimerCount()).toBe(0);
+
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+      expect(mockSelectSource).toHaveBeenCalledTimes(1);
+      expect(mockToastError).toHaveBeenCalledTimes(expectedToastCount);
+    },
+  );
+
+  it("keeps the complete viz URL while a logged-out user is redirected", async () => {
+    const url = `${window.location.origin}/viz?ds=coscene-data-platform&ds.key=record-key&layoutId=${encodeURIComponent(
+      "warehouses/warehouse-a/projects/project-a/layouts/layout-a",
+    )}`;
+    window.history.replaceState(undefined, "", url);
+
+    render(<DeepLinksSyncAdapter deepLinks={[url]} />);
+    await act(async () => {
+      await Promise.resolve();
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
+    });
+
+    expect(mockToastError).toHaveBeenCalledTimes(1);
+    expect(jest.getTimerCount()).toBe(1);
+    expect(getWebLoginRedirectUrl(window.location)).toBe(
+      `/login?redirectToPath=${encodeURIComponent(new URL(url).pathname + new URL(url).search)}`,
+    );
   });
 
   afterEach(() => {

--- a/packages/studio-base/src/components/DeepLinksSyncAdapter.tsx
+++ b/packages/studio-base/src/components/DeepLinksSyncAdapter.tsx
@@ -60,6 +60,10 @@ const selectBeginExternalInitConfigUpdate = (state: CoreDataStore) =>
 
 const DEFAULT_DEEPLINKS = Object.freeze([]);
 
+export function getWebLoginRedirectUrl(location: Pick<Location, "pathname" | "search">): string {
+  return `/login?redirectToPath=${encodeURIComponent(location.pathname + location.search)}`;
+}
+
 function ExpiredShareManifestDialog(): React.JSX.Element {
   return (
     <Dialog open disableEscapeKeyDown>
@@ -162,19 +166,19 @@ export function DeepLinksSyncAdapter({
   // 处理状态标记
   const isSourceProcessed = useRef(false);
   const hasShownInvalidDomainToast = useRef(false);
+  const loginRedirectTimeout = useRef<ReturnType<typeof setTimeout>>();
 
   // ========== 工具函数 ==========
   // 防抖的登录提示
   const debouncedPleaseLoginFirstToast = useMemo(() => {
     return _.debounce(() => {
       toast.error(t("pleaseLoginFirst", { ns: "openDialog" }));
-      setTimeout(() => {
+      loginRedirectTimeout.current = setTimeout(() => {
+        loginRedirectTimeout.current = undefined;
         if (isDesktopApp()) {
           window.open(`https://${domainConfig.webDomain}/studio/login`);
         } else {
-          window.location.href = `/login?redirectToPath=${encodeURIComponent(
-            window.location.pathname + window.location.search,
-          )}`;
+          window.location.href = getWebLoginRedirectUrl(window.location);
         }
       }, 500);
     }, 1000);
@@ -295,6 +299,26 @@ export function DeepLinksSyncAdapter({
     }
   }, [deepLinks, targetUrlState, domainConfig.webDomain, dialogActions.dataSource, t]);
 
+  useEffect(() => {
+    const authless = targetShareManifest?.status === "valid" || isAuthlessDataSource();
+    if (loginStatus === "notLogin" && unappliedSourceArgs?.ds && !authless) {
+      debouncedPleaseLoginFirstToast();
+    }
+
+    return () => {
+      debouncedPleaseLoginFirstToast.cancel();
+      if (loginRedirectTimeout.current != undefined) {
+        clearTimeout(loginRedirectTimeout.current);
+        loginRedirectTimeout.current = undefined;
+      }
+    };
+  }, [
+    debouncedPleaseLoginFirstToast,
+    loginStatus,
+    targetShareManifest?.status,
+    unappliedSourceArgs,
+  ]);
+
   // ========== 处理数据源初始化的主逻辑 ==========
   /**
    * 数据源初始化主逻辑
@@ -336,9 +360,6 @@ export function DeepLinksSyncAdapter({
 
     // 特殊情况：用户未登录但试图访问需要登录的数据源
     if (loginStatus === "notLogin" && unappliedSourceArgs?.ds && !authless) {
-      isSourceProcessed.current = true;
-      debouncedPleaseLoginFirstToast();
-      setUnappliedSourceArgs(undefined);
       return;
     }
 
@@ -397,7 +418,6 @@ export function DeepLinksSyncAdapter({
     loginStatus,
     dataSourceDialog.open,
     dialogActions.dataSource,
-    debouncedPleaseLoginFirstToast,
     loadLastExternalInitConfig,
     setIsReadyForSyncLayout,
     shareManifestExpired,

--- a/packages/studio-base/src/providers/CoSceneCurrentUserProvider.test.tsx
+++ b/packages/studio-base/src/providers/CoSceneCurrentUserProvider.test.tsx
@@ -1,0 +1,135 @@
+/** @jest-environment jsdom */
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { render, waitFor } from "@testing-library/react";
+import { useEffect } from "react";
+
+import {
+  LoginStatus,
+  User,
+  UserStore,
+  useCurrentUser,
+} from "@foxglove/studio-base/context/CoSceneCurrentUserContext";
+import CoSceneCurrentUserProvider from "@foxglove/studio-base/providers/CoSceneCurrentUserProvider";
+
+type ObservedUserState = Pick<UserStore, "loginStatus" | "role" | "user">;
+
+const cachedUser: User = {
+  userId: "users/cached-user",
+  nickName: "Cached user",
+  avatarUrl: "https://example.com/avatar.png",
+  phoneNumber: "",
+  agreedAgreement: "true",
+  role: "user",
+  email: "cached@example.com",
+  targetSite: "",
+};
+
+const cachedRole = {
+  organizationRole: 3,
+  projectRole: 4,
+};
+
+function CurrentUserObserver({
+  onChange,
+}: {
+  onChange: (state: ObservedUserState) => void;
+}): ReactNull {
+  const loginStatus = useCurrentUser((state) => state.loginStatus);
+  const user = useCurrentUser((state) => state.user);
+  const role = useCurrentUser((state) => state.role);
+
+  useEffect(() => {
+    onChange({ loginStatus, role, user });
+  }, [loginStatus, onChange, role, user]);
+
+  return ReactNull;
+}
+
+function seedPersistedUserStore(loginStatus: LoginStatus): void {
+  localStorage.setItem(
+    "user-storage",
+    JSON.stringify({
+      state: {
+        user: cachedUser,
+        role: cachedRole,
+        loginStatus,
+      },
+      version: 0,
+    }),
+  );
+}
+
+describe("<CoSceneCurrentUserProvider />", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("uses the token when legacy persisted state says the user is logged out", () => {
+    localStorage.setItem("coScene_org_jwt", "token");
+    seedPersistedUserStore("notLogin");
+    const observedStates: ObservedUserState[] = [];
+
+    render(
+      <CoSceneCurrentUserProvider>
+        <CurrentUserObserver onChange={(state) => observedStates.push(state)} />
+      </CoSceneCurrentUserProvider>,
+    );
+
+    expect(observedStates[0]?.loginStatus).toBe("alreadyLogin");
+  });
+
+  it("uses the missing token when legacy persisted state says the user is logged in", () => {
+    seedPersistedUserStore("alreadyLogin");
+    const observedStates: ObservedUserState[] = [];
+
+    render(
+      <CoSceneCurrentUserProvider>
+        <CurrentUserObserver onChange={(state) => observedStates.push(state)} />
+      </CoSceneCurrentUserProvider>,
+    );
+
+    expect(observedStates[0]?.loginStatus).toBe("notLogin");
+  });
+
+  it("restores cached user data and removes loginStatus on the next persisted write", async () => {
+    localStorage.setItem("coScene_org_jwt", "token");
+    seedPersistedUserStore("notLogin");
+    const observedStates: ObservedUserState[] = [];
+
+    render(
+      <CoSceneCurrentUserProvider>
+        <CurrentUserObserver onChange={(state) => observedStates.push(state)} />
+      </CoSceneCurrentUserProvider>,
+    );
+
+    expect(observedStates[0]).toEqual({
+      loginStatus: "alreadyLogin",
+      role: cachedRole,
+      user: cachedUser,
+    });
+    await waitFor(() => {
+      const persisted = JSON.parse(localStorage.getItem("user-storage") ?? "null") as {
+        state?: Record<string, unknown>;
+      };
+      expect(persisted.state).toEqual({
+        role: cachedRole,
+        user: {
+          agreedAgreement: cachedUser.agreedAgreement,
+          email: cachedUser.email,
+          nickName: cachedUser.nickName,
+          phoneNumber: cachedUser.phoneNumber,
+          role: cachedUser.role,
+          targetSite: cachedUser.targetSite,
+          userId: cachedUser.userId,
+        },
+      });
+      expect(persisted.state).not.toHaveProperty("loginStatus");
+    });
+  });
+});

--- a/packages/studio-base/src/providers/CoSceneCurrentUserProvider.test.tsx
+++ b/packages/studio-base/src/providers/CoSceneCurrentUserProvider.test.tsx
@@ -52,17 +52,18 @@ function CurrentUserObserver({
 }
 
 function seedPersistedUserStore(loginStatus: LoginStatus): void {
-  localStorage.setItem(
-    "user-storage",
-    JSON.stringify({
-      state: {
-        user: cachedUser,
-        role: cachedRole,
-        loginStatus,
-      },
-      version: 0,
-    }),
-  );
+  const persistedState = JSON.stringify({
+    state: {
+      user: cachedUser,
+      role: cachedRole,
+      loginStatus,
+    },
+    version: 0,
+  });
+  if (persistedState == undefined) {
+    throw new Error("Unable to serialize persisted user state");
+  }
+  localStorage.setItem("user-storage", persistedState);
 }
 
 describe("<CoSceneCurrentUserProvider />", () => {

--- a/packages/studio-base/src/providers/CoSceneCurrentUserProvider.tsx
+++ b/packages/studio-base/src/providers/CoSceneCurrentUserProvider.tsx
@@ -15,14 +15,39 @@ import {
   OrganizationRoleWeight,
   ProjectRoleEnum,
   ProjectRoleWeight,
+  User,
   UserStore,
 } from "@foxglove/studio-base/context/CoSceneCurrentUserContext";
+
+type PersistedUserStore = Pick<UserStore, "role"> & {
+  user: (Omit<User, "avatarUrl"> & { avatarUrl?: string }) | undefined;
+};
+
+function mergePersistedUserStore(persistedState: unknown, currentState: UserStore): UserStore {
+  if (persistedState == undefined || typeof persistedState !== "object") {
+    return currentState;
+  }
+
+  const persistedUserStore = persistedState as Partial<PersistedUserStore>;
+  return {
+    ...currentState,
+    ...(persistedUserStore.user != undefined
+      ? {
+          user: {
+            ...persistedUserStore.user,
+            avatarUrl: persistedUserStore.user.avatarUrl ?? "",
+          },
+        }
+      : {}),
+    ...(persistedUserStore.role != undefined ? { role: persistedUserStore.role } : {}),
+  };
+}
 
 function createCurrentUserStore() {
   const authToken = localStorage.getItem("coScene_org_jwt");
 
   return createStore<UserStore>()(
-    persist(
+    persist<UserStore, [], [], PersistedUserStore>(
       (set) => ({
         user: undefined,
         role: {
@@ -53,10 +78,12 @@ function createCurrentUserStore() {
         storage: createJSONStorage(() => localStorage), // 使用 localStorage
         // 可选：只持久化特定字段
         partialize: (state) => ({
-          user: { ...state.user, avatarUrl: undefined },
+          user: state.user == undefined ? undefined : { ...state.user, avatarUrl: undefined },
           role: state.role,
-          loginStatus: state.loginStatus,
         }),
+        // loginStatus is derived from coScene_org_jwt. Ignore the legacy persisted value so a
+        // stale user-storage entry cannot override the token state during hydration.
+        merge: mergePersistedUserStore,
       },
     ),
   );


### PR DESCRIPTION
## Summary

- derive `loginStatus` exclusively from `coScene_org_jwt` while continuing to hydrate cached user and role data
- retain pending viz deep-link arguments while login is in progress and cancel stale login redirect timers once authentication completes
- add regression coverage for legacy persisted login state, login timing around the debounce, single data-source initialization, and complete return URLs

## Root cause

Zustand hydration restored the legacy persisted `user-storage.loginStatus` after the provider had derived the correct state from `coScene_org_jwt`. `DeepLinksSyncAdapter` could then observe `notLogin`, mark the deep link as processed, discard its arguments, and schedule another login redirect before the provider corrected the state.

## Compatibility and user impact

Legacy `user-storage` entries are still read for cached user and role data, but their derived `loginStatus` field is ignored and naturally removed on the next persisted write. No mono, OAuth, cookie format, or public API changes are required. An incognito user can now log in once and return directly to the original `/viz` link.

## Validation

- `yarn install --immutable`
- targeted Jest tests: 2 suites, 12 tests passed
- `git diff --check`
- `yarn run tsc --noEmit`
- CI ESLint config on all changed TS/TSX files
- `yarn web:build:prod` (passed with existing asset-size and module-type warnings)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1452"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789199736&installation_model_id=425002&pr_number=1452&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1452&signature=52dbaabd91fa4f1fe0fc7899a467e77276b48394abf0b352df3633f62e232a4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->