### PR TITLE
Use default cursor for timeline

### DIFF
--- a/packages/studio-base/src/components/PlaybackControls/EventsOverlay.test.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/EventsOverlay.test.tsx
@@ -271,10 +271,12 @@ function renderOverlayWithSeek({
   consoleApi = makeConsoleApiMock({ updateEvent: jest.fn().mockResolvedValue({}) }),
   events,
   seekPlayback = jest.fn<void, [Time]>(),
+  setCursor = jest.fn(),
 }: {
   consoleApi?: React.ContextType<typeof CoSceneConsoleApiContext>;
   events: TimelinePositionedEvent[];
   seekPlayback?: jest.Mock<void, [Time]>;
+  setCursor?: jest.Mock<void, [string]>;
 }): { eventsStore: StoreApi<EventsStore>; seekPlayback: jest.Mock<void, [Time]> } {
   const eventsStore = makeEventsStore({
     events,
@@ -299,7 +301,7 @@ function renderOverlayWithSeek({
         onSeek={(playbackSeconds) => {
           seekPlayback(fromSec(playbackSeconds));
         }}
-        setCursor={jest.fn()}
+        setCursor={setCursor}
         viewport={viewport}
       />
     </Wrapper>,
@@ -326,6 +328,14 @@ async function dragRollingEditBoundary(targetClientX: number): Promise<void> {
 describe("<EventsOverlay />", () => {
   afterEach(() => {
     jest.useRealTimers();
+  });
+
+  it("keeps the default cursor away from event resize hotspots", () => {
+    const setCursor = jest.fn<void, [string]>();
+
+    renderOverlayWithSeek({ events: [], setCursor });
+
+    expect(setCursor).toHaveBeenLastCalledWith("default");
   });
 
   it("shows the shortcut hint when the timeline has no moments", async () => {

--- a/packages/studio-base/src/components/PlaybackControls/EventsOverlay.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/EventsOverlay.tsx
@@ -1461,7 +1461,7 @@ function UnmemoizedEventsOverlay(props: Props): React.JSX.Element | ReactNull {
     ) {
       setCursor("ew-resize");
     } else {
-      setCursor("pointer");
+      setCursor("default");
     }
   }, [
     canWriteEvents,

--- a/packages/studio-base/src/components/PlaybackControls/Scrubber.test.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Scrubber.test.tsx
@@ -50,6 +50,7 @@ function dispatchMockPipelineProps(store: MockPipelineStore, mockProps: MockPipe
 let mockSliderProps:
   | {
       disabled?: boolean;
+      cursor?: string;
       onChange?: (playbackSeconds: number) => void;
       onHoverOver?: (event: HoverOverEvent) => void;
       onHoverOut?: () => void;
@@ -98,6 +99,7 @@ jest.mock("./Slider", () => ({
   __esModule: true,
   default: function MockSlider(props: {
     disabled?: boolean;
+    cursor?: string;
     onChange?: (playbackSeconds: number) => void;
     onHoverOver?: (event: HoverOverEvent) => void;
     onHoverOut?: () => void;
@@ -286,6 +288,16 @@ describe("<Scrubber />", () => {
     );
 
     expect(screen.getByTestId("scrubber-slider").dataset.disabled).toBe("true");
+  });
+
+  it("uses the default cursor for the timeline slider", () => {
+    render(
+      <Wrapper>
+        <Scrubber onSeek={jest.fn()} />
+      </Wrapper>,
+    );
+
+    expect(mockSliderProps?.cursor).toBe("default");
   });
 
   it("ignores timeline seek changes while keyframe search is active", () => {

--- a/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
+++ b/packages/studio-base/src/components/PlaybackControls/Scrubber.tsx
@@ -433,7 +433,7 @@ export default function Scrubber(props: Props): React.JSX.Element {
 
   const [hoverComponentId] = useState<string>(() => uuidv4());
 
-  const [cursor, setCursor] = useState("pointer");
+  const [cursor, setCursor] = useState("default");
   const [eventContextMenuRequest, setEventContextMenuRequest] = useState<
     EventContextMenuRequest | undefined
   >(undefined);


### PR DESCRIPTION
## What changed

- Change the normal timeline hover cursor from the pointer hand to the system default cursor.
- Keep the horizontal resize cursor for event resize hotspots.
- Add regression coverage for the scrubber and events overlay cursor behavior.

## Why

The timeline previously used a pointer cursor across its normal hover area, which made it appear like a link or button. Using the default cursor better matches the intended interaction styling while preserving resize feedback where applicable.

## Validation

- `yarn test packages/studio-base/src/components/PlaybackControls/Scrubber.test.tsx packages/studio-base/src/components/PlaybackControls/EventsOverlay.test.tsx --runInBand`
- `yarn run tsc --noEmit`
- `yarn lint`
- `yarn format:check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coscene-io/codesmith/honeybee/pr/1453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789203743&installation_model_id=425002&pr_number=1453&repository=coscene-io%2Fhoneybee&return_to=https%3A%2F%2Fgithub.com%2Fcoscene-io%2Fhoneybee%2Fpull%2F1453&signature=fe255a8f32a713c6da6ba0bc0ff08a3e70dbc416a8bae1bc7ce97ec672d1f699"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->