### PR TITLE
Always use a fixed Image layout for remote MP4

### DIFF
--- a/packages/studio-base/src/components/CoSceneLayout/CurrentLayoutButton.test.tsx
+++ b/packages/studio-base/src/components/CoSceneLayout/CurrentLayoutButton.test.tsx
@@ -129,4 +129,28 @@ describe("<CurrentLayoutButton />", () => {
     expect(onSaveRecommendedLayout).toHaveBeenCalledTimes(1);
     expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
   });
+
+  it("shows the name of a transient layout that is not in storage", () => {
+    render(
+      <ThemeProvider isDark>
+        <CurrentLayoutButton
+          currentLayoutId={"remote-mp4-default" as LayoutID}
+          selectedLayout={{
+            id: "remote-mp4-default" as LayoutID,
+            data: { configById: {}, globalVariables: {}, userNodes: {} },
+            name: "MP4",
+            transient: true,
+          }}
+          layouts={{ allLayouts: [], personalFolders: [], projectFolders: [] }}
+          onClick={jest.fn()}
+          onOverwriteLayout={jest.fn()}
+          onSaveRecommendedLayout={jest.fn()}
+          onRevertLayout={jest.fn()}
+        />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByText("MP4")).toBeDefined();
+    expect(screen.queryByText("No layout")).toBeNull();
+  });
 });

--- a/packages/studio-base/src/components/CoSceneLayout/CurrentLayoutButton.tsx
+++ b/packages/studio-base/src/components/CoSceneLayout/CurrentLayoutButton.tsx
@@ -115,6 +115,10 @@ export function CurrentLayoutButton({
       return selectedLayout.name ?? t("recommendedLayout");
     }
 
+    if (selectedLayout?.transient === true && selectedLayout.name) {
+      return selectedLayout.name;
+    }
+
     if (!currentLayout) {
       return t("noLayouts");
     }

--- a/packages/studio-base/src/components/PlayerManager.tsx
+++ b/packages/studio-base/src/components/PlayerManager.tsx
@@ -168,6 +168,15 @@ function useBeforeConnectionSource(): (
           }
           consoleApi.setType("realtime");
           break;
+        case "remote-mp4":
+          if (params.key) {
+            await syncBaseInfo(params.key, isCurrent);
+          }
+          if (!isCurrent()) {
+            return false;
+          }
+          consoleApi.setType(undefined);
+          break;
         default:
           consoleApi.setType(undefined);
           break;

--- a/packages/studio-base/src/hooks/useSyncLayoutFromUrl.test.ts
+++ b/packages/studio-base/src/hooks/useSyncLayoutFromUrl.test.ts
@@ -25,6 +25,11 @@ import { useRecommendedLayouts } from "@foxglove/studio-base/context/Recommended
 import { useWorkspaceActions } from "@foxglove/studio-base/context/Workspace/useWorkspaceActions";
 import type { WorkspaceActions } from "@foxglove/studio-base/context/Workspace/useWorkspaceActions";
 import { useSyncLayoutFromUrl } from "@foxglove/studio-base/hooks/useSyncLayoutFromUrl";
+import {
+  defaultRemoteMp4Layout,
+  REMOTE_MP4_DEFAULT_LAYOUT_ID,
+  REMOTE_MP4_DEFAULT_LAYOUT_NAME,
+} from "@foxglove/studio-base/providers/CurrentLayoutProvider/defaultRemoteMp4Layout";
 import type { ILayoutManager } from "@foxglove/studio-base/services/CoSceneILayoutManager";
 import type { Layout } from "@foxglove/studio-base/services/CoSceneILayoutStorage";
 import type { RecommendedLayoutDescriptor } from "@foxglove/studio-base/services/RecommendedLayouts";
@@ -329,6 +334,33 @@ describe("useSyncLayoutFromUrl", () => {
       expect.stringContaining("layout unavailable"),
       { variant: "error" },
     );
+  });
+
+  it("always applies the built-in MP4 layout for remote-mp4", async () => {
+    const historyLayout = layout("users/u/layouts/history");
+    const urlLayout = layout("users/u/layouts/url");
+    jest.mocked(layoutManager.getHistory).mockResolvedValue(historyLayout);
+    jest.mocked(layoutManager.getLayout).mockResolvedValue(urlLayout);
+
+    renderHook(() => {
+      useSyncLayoutFromUrl({
+        ds: "remote-mp4",
+        layoutId: urlLayout.id,
+      });
+    });
+
+    await waitFor(() => {
+      expect(currentLayoutActions.setCurrentLayout).toHaveBeenCalledWith({
+        id: REMOTE_MP4_DEFAULT_LAYOUT_ID,
+        name: REMOTE_MP4_DEFAULT_LAYOUT_NAME,
+        data: defaultRemoteMp4Layout,
+        transient: true,
+      });
+    });
+    expect(layoutManager.getHistory).not.toHaveBeenCalled();
+    expect(layoutManager.getLayout).not.toHaveBeenCalled();
+    expect(setSelectedLayoutId).not.toHaveBeenCalled();
+    expect(openLayoutDrawer).not.toHaveBeenCalled();
   });
 
   it("opens the layout drawer when the URL layout and history are missing", async () => {

--- a/packages/studio-base/src/hooks/useSyncLayoutFromUrl.ts
+++ b/packages/studio-base/src/hooks/useSyncLayoutFromUrl.ts
@@ -19,6 +19,11 @@ import {
 } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import { useRecommendedLayouts } from "@foxglove/studio-base/context/RecommendedLayoutContext";
 import { useWorkspaceActions } from "@foxglove/studio-base/context/Workspace/useWorkspaceActions";
+import {
+  defaultRemoteMp4Layout,
+  REMOTE_MP4_DEFAULT_LAYOUT_ID,
+  REMOTE_MP4_DEFAULT_LAYOUT_NAME,
+} from "@foxglove/studio-base/providers/CurrentLayoutProvider/defaultRemoteMp4Layout";
 import { AppURLState } from "@foxglove/studio-base/util/appURLState";
 
 const selectedLayoutIdSelector = (state: LayoutState) => state.selectedLayout?.id;
@@ -48,6 +53,23 @@ export function useSyncLayoutFromUrl(targetUrlState: AppURLState | undefined): v
   useAsync(async () => {
     // 只有在 isReadyForSyncLayout 为 true 时才处理 layout
     if (isReadyForSyncLayout !== true) {
+      return;
+    }
+
+    // remote-mp4 always uses the single Image panel on the fixed topic.
+    // Do not restore history, recommended layouts, or URL layoutId.
+    if (targetUrlState?.ds === "remote-mp4") {
+      if (currentLayoutId === REMOTE_MP4_DEFAULT_LAYOUT_ID || isLayoutIdProcessed.current) {
+        return;
+      }
+      setCurrentLayout({
+        id: REMOTE_MP4_DEFAULT_LAYOUT_ID,
+        name: REMOTE_MP4_DEFAULT_LAYOUT_NAME,
+        data: defaultRemoteMp4Layout,
+        transient: true,
+      });
+      setUnappliedLayoutArgs({ layoutId: undefined });
+      isLayoutIdProcessed.current = true;
       return;
     }
 
@@ -206,5 +228,6 @@ export function useSyncLayoutFromUrl(targetUrlState: AppURLState | undefined): v
     recommendedLayouts,
     enqueueSnackbar,
     t,
+    targetUrlState?.ds,
   ]);
 }

--- a/packages/studio-base/src/providers/CurrentLayoutProvider/defaultRemoteMp4Layout.ts
+++ b/packages/studio-base/src/providers/CurrentLayoutProvider/defaultRemoteMp4Layout.ts
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024 Shanghai coScene Information Technology Co., Ltd.<hi@coscene.io>
+// SPDX-License-Identifier: MPL-2.0
+
+import type { LayoutID } from "@foxglove/studio-base/context/CurrentLayoutContext";
+import type { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
+import { DEFAULT_MP4_VIDEO_TOPIC } from "@foxglove/studio-base/players/IterablePlayer/Mp4/Mp4IterableSource";
+
+export const REMOTE_MP4_DEFAULT_LAYOUT_ID = "remote-mp4-default" as LayoutID;
+export const REMOTE_MP4_DEFAULT_LAYOUT_NAME = "MP4";
+export const REMOTE_MP4_IMAGE_PANEL_ID = "Image!remoteMp4";
+
+/**
+ * The only layout for `ds=remote-mp4`. The source always publishes this
+ * single topic, so there is nothing to pick or restore.
+ */
+export const defaultRemoteMp4Layout: LayoutData = {
+  configById: {
+    [REMOTE_MP4_IMAGE_PANEL_ID]: {
+      imageMode: {
+        imageTopic: DEFAULT_MP4_VIDEO_TOPIC,
+      },
+    },
+  },
+  globalVariables: {},
+  userNodes: {},
+  layout: REMOTE_MP4_IMAGE_PANEL_ID,
+};


### PR DESCRIPTION
## Summary
- Remote MP4 only publishes `/camera/h264`, so viz now always applies a single Image panel layout instead of restoring last-used layouts or opening the empty layout drawer.
- `ds.key` still syncs project context when the Data Platform play entry provides it.
- The layout button shows **MP4** for this transient layout.

Companion Data Platform PR: https://github.com/coscene-io/mono/pull/3257

## Test plan
- [x] `yarn jest packages/studio-base/src/hooks/useSyncLayoutFromUrl.test.ts packages/studio-base/src/components/CoSceneLayout/CurrentLayoutButton.test.tsx` (13 passed)
- [ ] Open `/viz?ds=remote-mp4&ds.url=…` and confirm an Image panel on `/camera/h264` appears with no layout drawer
- [ ] Confirm a bag/MCAP `ds=coscene-data-platform` session still restores last layout or recommended layouts as before